### PR TITLE
Port: scheduler auto_once stall retry (from pre-cutover branch)

### DIFF
--- a/packages/plugins/brain-orchestrator/src/handlers/resolver-status.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/resolver-status.ts
@@ -37,6 +37,21 @@ export type ResolverDeps = {
 
 // ── Goal-status derivation ────────────────────────────────────────────────
 
+// A goal in one of these states accepts no further task transitions; callers
+// must not revive or re-dispatch its tasks. Single source of truth so the
+// watchdog and cancelGoal agree on what "terminal" means.
+const TERMINAL_GOAL_STATUSES: ReadonlySet<GoalStatus> = new Set<GoalStatus>([
+  "completed",
+  "cancelled",
+  "failed",
+  "retired",
+]);
+
+/** True when a goal is in a terminal state (no further task work allowed). */
+export function isTerminalGoalStatus(status: GoalStatus): boolean {
+  return TERMINAL_GOAL_STATUSES.has(status);
+}
+
 /**
  * Compute what a goal's status SHOULD be, based on its tasks. Pure: does
  * not mutate the store. Evergreen goals are passed through unchanged
@@ -431,13 +446,7 @@ export function cancelGoal(
 ): TransitionResult & { readonly cancelledTaskCount?: number } {
   const goal = deps.goals.get(goalId);
   if (!goal) return { ok: false, error: `Goal "${goalId}" not found.` };
-  const terminalGoalStatuses: ReadonlySet<GoalStatus> = new Set<GoalStatus>([
-    "completed",
-    "cancelled",
-    "failed",
-    "retired",
-  ] as GoalStatus[]);
-  if (terminalGoalStatuses.has(goal.status)) {
+  if (isTerminalGoalStatus(goal.status)) {
     return {
       ok: false,
       error: `Goal "${goal.name}" is already ${goal.status}.`,

--- a/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
@@ -762,6 +762,81 @@ describe("reconcileStaleRuns", () => {
     expect(reconcileStaleRuns(deps, 1000)).toBe(1);
     expect(deps.tasks.get("t1")!.status).toBe("stalled");
   });
+
+  it("re-dispatches a stalled auto_once task instead of stalling it", () => {
+    const { deps, logs } = makeDeps({ now: 100_000 });
+    seedGoal(deps, { id: "g-1", status: "running" });
+    seedTask(deps, {
+      id: "t1",
+      status: "running",
+      startedAt: 0,
+      attemptCount: 1,
+      retryPolicy: "auto_once",
+      activeRunId: "run-1",
+      activeSessionKey: "sess-1",
+      latestCheckpoint: { checkpointAt: 0, phase: "p", summary: "s" },
+    });
+    expect(reconcileStaleRuns(deps, 1000)).toBe(1);
+    const t = deps.tasks.get("t1")!;
+    expect(t.status).toBe("ready");
+    // Cleared so dispatchOrphanedReadyTasks re-runs it with a fresh clock.
+    expect(t.activeRunId).toBeUndefined();
+    expect(t.activeSessionKey).toBeUndefined();
+    expect(t.startedAt).toBeUndefined();
+    expect(t.latestCheckpoint).toBeUndefined();
+    expect(t.readyAt).toBe(100_000);
+    expect(t.failureReason).toBeUndefined();
+    // reconcile must not burn the retry budget — the dispatcher bumps attemptCount.
+    expect(t.attemptCount).toBe(1);
+    expect(
+      logs.some((l) => l.message.includes("re-dispatching stalled auto_once")),
+    ).toBe(true);
+  });
+
+  it("stalls an auto_once task terminally once its single retry is used", () => {
+    const { deps } = makeDeps({ now: 100_000 });
+    seedGoal(deps, { id: "g-1", status: "running" });
+    seedTask(deps, {
+      id: "t1",
+      status: "running",
+      startedAt: 0,
+      attemptCount: 2, // first run + one retry already dispatched
+      retryPolicy: "auto_once",
+    });
+    expect(reconcileStaleRuns(deps, 1000)).toBe(1);
+    expect(deps.tasks.get("t1")!.status).toBe("stalled");
+  });
+
+  it("re-dispatches a stalled auto_once task in the dispatched state too", () => {
+    const { deps } = makeDeps({ now: 100_000 });
+    seedGoal(deps, { id: "g-1", status: "running" });
+    seedTask(deps, {
+      id: "t1",
+      status: "dispatched",
+      startedAt: 0,
+      attemptCount: 1,
+      retryPolicy: "auto_once",
+    });
+    expect(reconcileStaleRuns(deps, 1000)).toBe(1);
+    expect(deps.tasks.get("t1")!.status).toBe("ready");
+  });
+
+  it("re-runs a stalled auto_once task within the same tick", async () => {
+    const { dispatcher, spawnCalls } = makeDispatcher();
+    const { deps } = makeDeps({ now: 100_000, dispatcher });
+    seedGoal(deps, { id: "g-1", status: "running" });
+    seedTask(deps, {
+      id: "t1",
+      status: "running",
+      startedAt: 0,
+      attemptCount: 1,
+      retryPolicy: "auto_once",
+      activeRunId: "run-1",
+    });
+    await tick(deps, 1000);
+    // reconcileStaleRuns resets it to ready; dispatchOrphanedReadyTasks re-runs it.
+    expect(spawnCalls.map((t) => t.id)).toContain("t1");
+  });
 });
 
 // ── dispatchOrphanedReadyTasks ────────────────────────────────────────────

--- a/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
@@ -763,7 +763,7 @@ describe("reconcileStaleRuns", () => {
     expect(deps.tasks.get("t1")!.status).toBe("stalled");
   });
 
-  it("re-dispatches a stalled auto_once task instead of stalling it", () => {
+  it("re-dispatches a stalled auto_once task and closes the abandoned attempt", () => {
     const { deps, logs } = makeDeps({ now: 100_000 });
     seedGoal(deps, { id: "g-1", status: "running" });
     seedTask(deps, {
@@ -775,6 +775,15 @@ describe("reconcileStaleRuns", () => {
       activeRunId: "run-1",
       activeSessionKey: "sess-1",
       latestCheckpoint: { checkpointAt: 0, phase: "p", summary: "s" },
+    });
+    deps.tasks.createAttempt({
+      attemptId: "a1",
+      taskId: "t1",
+      attemptNumber: 1,
+      runId: "run-1",
+      sessionKey: "sess-1",
+      status: "running",
+      startedAt: 0,
     });
     expect(reconcileStaleRuns(deps, 1000)).toBe(1);
     const t = deps.tasks.get("t1")!;
@@ -788,9 +797,47 @@ describe("reconcileStaleRuns", () => {
     expect(t.failureReason).toBeUndefined();
     // reconcile must not burn the retry budget — the dispatcher bumps attemptCount.
     expect(t.attemptCount).toBe(1);
+    // Abandoned attempt closed so a late completion targets the retry attempt.
+    expect(t.attempts.find((a) => a.attemptId === "a1")!.status).toBe("stalled");
     expect(
       logs.some((l) => l.message.includes("re-dispatching stalled auto_once")),
     ).toBe(true);
+  });
+
+  it("stalls an auto_once task instead of retrying when its goal is terminal", () => {
+    const { deps } = makeDeps({ now: 100_000 });
+    seedGoal(deps, { id: "g-1", status: "failed" });
+    seedTask(deps, {
+      id: "t1",
+      status: "running",
+      startedAt: 0,
+      attemptCount: 1,
+      retryPolicy: "auto_once",
+    });
+    // Goal already failed → no fresh dispatch for a terminal workflow.
+    expect(reconcileStaleRuns(deps, 1000)).toBe(1);
+    expect(deps.tasks.get("t1")!.status).toBe("stalled");
+  });
+
+  it("stalls an auto_once task whose goal no longer exists", () => {
+    const { deps } = makeDeps({ now: 100_000 });
+    deps.tasks.create({
+      id: "t1",
+      goalId: "ghost",
+      name: "x",
+      task: "x",
+      blockedBy: [],
+      dispatch: { mode: "spawn", agentId: "a" },
+      status: "running",
+      startedAt: 0,
+      attemptCount: 1,
+      attempts: [],
+      priority: "normal",
+      onUpstreamFailure: "wait",
+      retryPolicy: "auto_once",
+    });
+    expect(reconcileStaleRuns(deps, 1000)).toBe(1);
+    expect(deps.tasks.get("t1")!.status).toBe("stalled");
   });
 
   it("stalls an auto_once task terminally once its single retry is used", () => {

--- a/packages/plugins/brain-orchestrator/src/handlers/scheduler.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/scheduler.ts
@@ -31,7 +31,7 @@ import type {
 } from "../store/tasks.js";
 import type { TracesStore } from "../store/traces.js";
 import type { WorkflowsStore } from "../store/workflows.js";
-import { refreshGoalStatus } from "./resolver-status.js";
+import { isTerminalGoalStatus, refreshGoalStatus } from "./resolver-status.js";
 
 // After N consecutive dispatch failures for the same task, the
 // orphan-dispatch path terminal-fails the task instead of retrying every tick.
@@ -426,16 +426,34 @@ export function reconcileStaleRuns(
       const silentMin = Math.round((nowMs - lastActivity) / 60_000);
 
       // auto_once: hand a silent run one fresh re-dispatch before declaring it
-      // stalled. Reset to "ready" with a cleared activity clock (startedAt +
-      // latestCheckpoint) and no activeRunId so this tick's
-      // dispatchOrphanedReadyTasks re-runs it — and the retry gets a full
+      // stalled. Three guards keep the retry from corrupting state:
+      //  - attemptCount < MAX bounds it to a single retry (every dispatch bumps
+      //    the count, so the first stall sees attemptCount === 1).
+      //  - the parent goal must still be active — otherwise the same tick's
+      //    dispatchOrphanedReadyTasks (which does not filter by goal status)
+      //    would launch fresh work for an already failed/cancelled workflow.
+      //  - the abandoned attempt is closed (stalled) before the reset, so a
+      //    later completion finalizes the retry's attempt rather than this one
+      //    (finalizeRunningAttempt picks the first running attempt by order).
+      // The reset clears the activity clock (startedAt + latestCheckpoint) and
+      // run identity so dispatchOrphanedReadyTasks re-runs it with a full
       // timeout window. Clearing startedAt is load-bearing: the dispatcher sets
-      // `startedAt ?? now`, so a stale startedAt would survive and the retry
-      // would re-stall on the very next tick instead of getting its own window.
+      // `startedAt ?? now`, so a stale clock would survive and re-stall the
+      // retry on the next tick instead of giving it its own window.
+      const goal = deps.goals.get(task.goalId);
+      const goalActive = goal !== undefined && !isTerminalGoalStatus(goal.status);
       if (
         task.retryPolicy === "auto_once" &&
-        task.attemptCount < AUTO_ONCE_MAX_ATTEMPTS
+        task.attemptCount < AUTO_ONCE_MAX_ATTEMPTS &&
+        goalActive
       ) {
+        const abandoned = task.attempts.find((a) => a.status === "running");
+        if (abandoned) {
+          deps.tasks.updateAttempt(abandoned.attemptId, {
+            status: "stalled",
+            endedAt: nowMs,
+          });
+        }
         deps.tasks.update({
           ...task,
           status: "ready",

--- a/packages/plugins/brain-orchestrator/src/handlers/scheduler.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/scheduler.ts
@@ -41,6 +41,13 @@ const MAX_FAILED_DISPATCHES_BEFORE_TERMINAL_FAIL = 5;
 // enough that dispatch should have completed.
 const READY_WATCHDOG_MULTIPLIER = 2;
 
+// A step with retryPolicy="auto_once" earns exactly one fresh re-dispatch when
+// its run goes silent past the stall threshold. attemptCount is bumped on every
+// dispatch, so the first stall sees attemptCount === 1 and the retry lifts it to
+// 2 — a second stall (attemptCount === 2) is terminal. Without this, the
+// retryPolicy field is inert: nothing else in the scheduler reads it.
+const AUTO_ONCE_MAX_ATTEMPTS = 2;
+
 // Magic-string match for the gateway-scope transient. The openclaw subagent
 // proxy throws this when the request scope isn't bound — a benign race
 // during nested workflow chains. We mustn't burn the retry budget on it.
@@ -414,19 +421,51 @@ export function reconcileStaleRuns(
       const threshold = task.timeoutMs ?? defaultStallThresholdMs;
       const lastActivity =
         task.latestCheckpoint?.checkpointAt ?? task.startedAt ?? 0;
-      if (nowMs - lastActivity > threshold) {
+      if (nowMs - lastActivity <= threshold) continue;
+
+      const silentMin = Math.round((nowMs - lastActivity) / 60_000);
+
+      // auto_once: hand a silent run one fresh re-dispatch before declaring it
+      // stalled. Reset to "ready" with a cleared activity clock (startedAt +
+      // latestCheckpoint) and no activeRunId so this tick's
+      // dispatchOrphanedReadyTasks re-runs it — and the retry gets a full
+      // timeout window. Clearing startedAt is load-bearing: the dispatcher sets
+      // `startedAt ?? now`, so a stale startedAt would survive and the retry
+      // would re-stall on the very next tick instead of getting its own window.
+      if (
+        task.retryPolicy === "auto_once" &&
+        task.attemptCount < AUTO_ONCE_MAX_ATTEMPTS
+      ) {
         deps.tasks.update({
           ...task,
-          status: "stalled",
-          failureReason: `watchdog: exceeded ${Math.round(threshold / 1000)}s timeout (silent ${Math.round((nowMs - lastActivity) / 60_000)}min)`,
+          status: "ready",
+          activeRunId: undefined,
+          activeSessionKey: undefined,
+          startedAt: undefined,
+          latestCheckpoint: undefined,
+          readyAt: nowMs,
+          failureReason: undefined,
         });
         refreshGoalStatus(deps, task.goalId);
         reconciled++;
         deps.runtime.log(
           "warn",
-          `scheduler: reconciled stale task "${task.name}" (silent ${Math.round((nowMs - lastActivity) / 60_000)}min, threshold ${Math.round(threshold / 60_000)}min)`,
+          `scheduler: re-dispatching stalled auto_once task "${task.name}" (silent ${silentMin}min, retry ${task.attemptCount}/${AUTO_ONCE_MAX_ATTEMPTS - 1})`,
         );
+        continue;
       }
+
+      deps.tasks.update({
+        ...task,
+        status: "stalled",
+        failureReason: `watchdog: exceeded ${Math.round(threshold / 1000)}s timeout (silent ${silentMin}min)`,
+      });
+      refreshGoalStatus(deps, task.goalId);
+      reconciled++;
+      deps.runtime.log(
+        "warn",
+        `scheduler: reconciled stale task "${task.name}" (silent ${silentMin}min, threshold ${Math.round(threshold / 60_000)}min)`,
+      );
     }
   }
 


### PR DESCRIPTION
Ports the two commits stranded on the old repo's `feat-auto-once-stall-retry` branch (work predating the public cutover), re-authored with the noreply identity.

- `retryPolicy=auto_once` was inert — stored and propagated but never read; a stalled auto_once run was terminally marked like any other. `reconcileStaleRuns` now grants exactly one fresh re-dispatch (task reset to ready with a cleared activity clock so the retry earns a full timeout window), gated by attemptCount.
- Follow-up guard: stale attempt + terminal goal can't trigger the retry.

Applied cleanly over the retention-sweep changes; brain-orchestrator: 821 tests pass (6 new). Sanitize gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)