### PR TITLE
docs(site): packaging accuracy — PyPI dream-cycle, npm pending

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -45,6 +45,12 @@ What `setup` does:
 Re-running is idempotent — installers merge into existing settings without
 clobbering your other hooks.
 
+> **Packaging status** (pre-release): install from source as above — that one
+> `pnpm dm setup` is the whole build. The dream-cycle pipeline is published on
+> PyPI as [`digital-me-dream-cycle`](https://pypi.org/project/digital-me-dream-cycle/);
+> the npm package is prepared but **not published yet** — `npm install` will
+> not find it until the first release lands.
+
 ```motus-demo
 console
 ```

--- a/docs/site/runtimes.md
+++ b/docs/site/runtimes.md
@@ -83,13 +83,18 @@ rate, workflows, feed. Installed as a `launchd` (macOS) / `systemd --user`
 
 The nightly distillation pipeline that turns raw captured learnings into
 clean wiki entries. Requires Python ≥ 3.11 in a venv (Homebrew/Debian enforce
-PEP 668 — `digital-me doctor` prints the exact recipe for your Python):
+PEP 668 — `digital-me doctor` prints the exact recipe for your Python).
+
+It ships on PyPI as `digital-me-dream-cycle`:
 
 ```bash
 python3 -m venv ~/.venvs/dream-cycle
-~/.venvs/dream-cycle/bin/pip install -e "packages/services/dream-cycle[dev]"
+~/.venvs/dream-cycle/bin/pip install digital-me-dream-cycle
 digital-me dream-cycle                        # run it manually
 ```
+
+Working on the pipeline itself? Install it editable from the repo instead:
+`pip install -e "packages/services/dream-cycle[dev]"`.
 
 The nightly schedule (`dream-cycle-nightly`, 3am) is registered with the
 orchestrator at install time — no manual cron needed.


### PR DESCRIPTION
Registry-verified packaging facts for the website docs: `digital-me-dream-cycle` 0.1.0 is live on PyPI (pip path now primary in Runtimes); npm has nothing published yet, so Getting Started says so explicitly instead of implying `npm install` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)