### PR TITLE
docs: ground install on npm `digital-me` + accuracy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Until `1.0.0`, minor versions may include breaking changes.
 
 ## [0.1.0-pre] - 2026-06
 
-Initial pre-release. Functional monorepo with ~1,400 unit tests (core stores and
+Initial pre-release. Functional monorepo with 1,500+ unit tests (core stores and
 handlers at 100% coverage); install from source — nothing published to npm yet.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@
 
 New install? Start here: [Getting started](#install)
 
-Preferred setup: run `pnpm dm setup` from a clone. It detects your installed CLIs, scaffolds your data directory, wires every runtime, and ends with a doctor pass. Works on macOS and Linux.
+Preferred setup: `npm install -g digital-me` then `digital-me setup`. It detects your installed CLIs, scaffolds your data directory, wires every runtime, and ends with a doctor pass. Works on macOS and Linux. (Building from source? See [Install from source](#install-from-source).)
 
-> **Status:** pre-release WIP. The packages are functional with ~1,400 unit tests (core stores and handlers at 100% coverage), but nothing is published to npm yet — install from source (see below).
+> **Status:** pre-release WIP — 1,500+ unit tests, core stores and handlers at 100% coverage. The CLI ships from npm as `digital-me`; the dream-cycle pipeline ships from PyPI as `digital-me-dream-cycle`.
 
 ## What you get
 
@@ -43,7 +43,7 @@ When fully installed, every agent runtime shares:
 
 ### Prerequisites
 
-- **Node.js ≥ 22.5** and **pnpm** — the CLI checks and tells you if your Node is too old.
+- **Node.js ≥ 22.5** — to install and run the CLI from npm (`pnpm` is only needed for the *Install from source* path).
 - **[openclaw](https://github.com/openclaw/openclaw)** — mandatory, see below.
 - **Python ≥ 3.11** — optional; only needed for the dream-cycle distillation pipeline (skip with `setup --minimal`).
 
@@ -51,29 +51,29 @@ When fully installed, every agent runtime shares:
 
 Install [openclaw](https://github.com/openclaw/openclaw) **first** and verify `openclaw --version` works. Digital Me is a plugin + CLI-adapter set that rides on top of the openclaw gateway daemon — without it, the brain MCP tools and every runtime adapter have nothing to connect to. `setup` and `install` **hard-stop** with install guidance if openclaw isn't detected (override with `--skip-openclaw-check` for advanced/CI use).
 
-### One-shot install
+### Install (npm)
 
 ```bash
-git clone https://github.com/Amyssjj/digital-me.git ~/digital-me-os
-cd ~/digital-me-os && pnpm install && pnpm build
+# Install the CLI from npm
+npm install -g digital-me
 
 # Detect installed CLIs, scaffold ~/digital-me/, install hooks/skills/configs,
-# link the `digital-me` command onto PATH, run doctor. (`pnpm dm` = the CLI.)
-pnpm dm setup
+# wire every runtime, run doctor:
+digital-me setup
 
 # Or pin a custom wiki location:
-pnpm dm setup --wiki-root ~/notes/brain
+digital-me setup --wiki-root ~/notes/brain
 
 # Node-only? Skip the heavy optional services (dream-cycle Python venv +
 # dashboard build) — add either later with `digital-me install --runtime <id>`:
-pnpm dm setup --minimal
-
-# Then:
-export DIGITAL_ME_WIKI_ROOT=~/digital-me
-# config.yaml is auto-created with `sources` pre-filled from your detected CLIs.
-# Default engine=openclaw reads your LLM key from ~/.openclaw/openclaw.json,
-# so there's usually nothing left to edit. Review ~/digital-me/config.yaml.
+digital-me setup --minimal
 ```
+
+After `setup`, `config.yaml` is auto-created with `sources` pre-filled from your
+detected CLIs; the default `engine=openclaw` reads your LLM key from
+`~/.openclaw/openclaw.json`, so there's usually nothing left to edit. Review
+`~/digital-me/config.yaml` (override the data dir with
+`export DIGITAL_ME_WIKI_ROOT=~/digital-me`).
 
 What `setup` does:
 
@@ -88,10 +88,19 @@ What `setup` does:
 
 Re-running is idempotent — installers merge into existing settings without clobbering your other hooks.
 
-> **The `digital-me` command on your PATH:** `setup` runs `pnpm link --global`
-> for you, so after the one-shot install the bare `digital-me …` commands below
-> work directly. Before that link exists, use `pnpm dm <command>` from the repo
-> (or `node packages/cli/dist/bin/digital-me.js <command>` the long way).
+### Install from source
+
+For contributors, or to run an unreleased version. Build the repo, then drive the
+CLI with `pnpm dm <command>` — the in-repo equivalent of the global `digital-me`
+command. (`setup` runs `pnpm link --global`, so afterwards the bare `digital-me …`
+commands work directly; before that link exists use `pnpm dm <command>` from the
+repo, or `node packages/cli/dist/bin/digital-me.js <command>` the long way.)
+
+```bash
+git clone https://github.com/Amyssjj/digital-me.git ~/digital-me-os
+cd ~/digital-me-os && pnpm install && pnpm build
+pnpm dm setup        # `pnpm dm` = the CLI, run from the clone
+```
 
 ### First-run scenarios
 
@@ -99,8 +108,8 @@ Pick the row that matches you:
 
 | You have… | Run | What you get |
 |---|---|---|
-| openclaw + Claude Code / Codex / Hermes | `pnpm dm setup` | Full install: adapters + brain plugin + dashboard + dream-cycle, `digital-me` on PATH, green doctor |
-| openclaw, but node-only (no Python / no dashboard) | `pnpm dm setup --minimal` | Wiki + agent-runtime wiring + brain plugin only; add the rest later with `digital-me install --runtime dream-cycle\|dashboard` |
+| openclaw + Claude Code / Codex / Hermes | `digital-me setup` | Full install: adapters + brain plugin + dashboard + dream-cycle, `digital-me` on PATH, green doctor |
+| openclaw, but node-only (no Python / no dashboard) | `digital-me setup --minimal` | Wiki + agent-runtime wiring + brain plugin only; add the rest later with `digital-me install --runtime dream-cycle\|dashboard` |
 | **not** openclaw yet | *(install openclaw first)* | `setup` hard-stops and points you at the openclaw install — it's the mandatory foundation |
 | Homebrew / Debian / recent Ubuntu Python | *(see [dream-cycle](#running-the-dream-cycle-distillation-pipeline))* | These enforce PEP 668; install dream-cycle into a venv (recipe below). `digital-me doctor` prints the exact recipe for your Python. |
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -131,22 +131,25 @@ python3 -m venv /tmp/dc-pypi-smoke
 
 ### What's NOT automated yet
 
-- Changelog generation. Add release notes by hand under `docs/CHANGELOG.md` (file not yet created).
+- Changelog generation. Add release notes by hand under `CHANGELOG.md` (repo root).
 
-## TypeScript CLI — `@digital-me/cli` (npm)
+## TypeScript CLI — published as `digital-me` (npm)
 
-The CLI depends on sibling `workspace:*` packages that are **not** published
-individually. Instead, `scripts/build-cli-bundle.mjs` esbuild-bundles the bin
-entry with every workspace dep **inlined** (only `esbuild` stays external — it
-ships a platform binary and is used at runtime), and emits a trimmed,
-registry-ready package under `packages/cli/npm-dist/`. So `npm i -g
-@digital-me/cli` works with no monorepo checkout.
+The workspace package is named `@digital-me/cli`, but it ships to npm under the
+**unscoped `digital-me`** name (`scripts/build-cli-bundle.mjs` rewrites the
+manifest name in `packages/cli/npm-dist/`). The CLI depends on sibling
+`workspace:*` packages that are **not** published individually; the bundler
+esbuild-inlines every workspace dep (only `esbuild` stays external — it ships a
+platform binary and is used at runtime) and emits a trimmed, registry-ready
+package under `packages/cli/npm-dist/`. So `npm i -g digital-me` works with no
+monorepo checkout.
 
 ### One-time setup
 
-1. Reserve/own the `@digital-me` scope on npm.
-2. Create an npm **automation token** with publish rights to the scope, and add
-   it as the repo secret **`NPM_TOKEN`** (Settings → Secrets → Actions).
+1. Reserve/own the unscoped **`digital-me`** name on npm.
+2. Create an npm **automation token** (or granular token with Bypass-2FA) with
+   publish rights to `digital-me`, and add it as the repo secret **`NPM_TOKEN`**
+   (Settings → Secrets → Actions).
 
 ### Cut a release (automated — preferred)
 
@@ -164,8 +167,8 @@ git tag cli-vX.Y.Z && git push origin cli-vX.Y.Z
 
 ```bash
 pnpm build && pnpm build:cli-bundle
-cd packages/cli/npm-dist && npm pack          # → digital-me-cli-X.Y.Z.tgz
+cd packages/cli/npm-dist && npm pack          # → digital-me-X.Y.Z.tgz
 # install the tarball into a throwaway project and run it:
-d=$(mktemp -d); (cd "$d" && npm init -y >/dev/null && npm i "$OLDPWD"/digital-me-cli-*.tgz \
+d=$(mktemp -d); (cd "$d" && npm init -y >/dev/null && npm i "$OLDPWD"/digital-me-*.tgz \
   && ./node_modules/.bin/digital-me help)
 ```

--- a/docs/site/contributing.md
+++ b/docs/site/contributing.md
@@ -23,7 +23,7 @@ first saves a round-trip:
 | Gate | Command | Bar |
 |---|---|---|
 | Lint | `pnpm lint` | clean |
-| Tests | `pnpm test` | green (~1,400 unit tests) |
+| Tests | `pnpm test` | green (1,500+ unit tests) |
 | Coverage | `pnpm test:coverage` | **100% on changed files** |
 | Sanitization | `pnpm sanitize:check` | no personal identifiers, user paths, or org names anywhere in code or docs |
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -10,26 +10,26 @@ capture → recall loop in about five minutes.
   rides on openclaw's gateway daemon; install it first and verify
   `openclaw --version` works. `setup` hard-stops with install guidance if it's
   missing.
-- **Node.js ≥ 22.5** and **pnpm** — the CLI checks and tells you if your Node
-  is too old.
+- **Node.js ≥ 22.5** — to install and run the CLI from npm. (`pnpm` is only
+  needed for the *From source* path below.)
 - **Python ≥ 3.11** — optional; only needed for the dream-cycle distillation
   pipeline (skip it with `--minimal`).
 
 ## Install
 
 ```bash
-git clone https://github.com/Amyssjj/digital-me.git ~/digital-me-os
-cd ~/digital-me-os && pnpm install && pnpm build
+# Install the CLI from npm
+npm install -g digital-me
 
 # Detect installed CLIs, scaffold ~/digital-me/, install hooks/skills/configs,
-# link the `digital-me` command onto PATH, run doctor:
-pnpm dm setup
+# wire every runtime, run doctor:
+digital-me setup
 
 # Node-only? Skip the optional services (dream-cycle venv + dashboard build):
-pnpm dm setup --minimal
+digital-me setup --minimal
 
 # Pin a custom wiki location:
-pnpm dm setup --wiki-root ~/notes/brain
+digital-me setup --wiki-root ~/notes/brain
 ```
 
 What `setup` does:
@@ -45,11 +45,21 @@ What `setup` does:
 Re-running is idempotent — installers merge into existing settings without
 clobbering your other hooks.
 
-> **Packaging status** (pre-release): install from source as above — that one
-> `pnpm dm setup` is the whole build. The dream-cycle pipeline is published on
-> PyPI as [`digital-me-dream-cycle`](https://pypi.org/project/digital-me-dream-cycle/);
-> the npm package is prepared but **not published yet** — `npm install` will
-> not find it until the first release lands.
+### From source
+
+For contributors, or to run an unreleased version: clone and build, then drive
+the CLI with `pnpm dm <command>` from the repo — that's the in-repo equivalent
+of the `digital-me` command before it's linked onto your PATH.
+
+```bash
+git clone https://github.com/Amyssjj/digital-me.git ~/digital-me-os
+cd ~/digital-me-os && pnpm install && pnpm build
+pnpm dm setup        # `pnpm dm` = the CLI, run from the clone
+```
+
+> **Packaging:** the CLI installs from npm as `digital-me`; during `setup`
+> it pip-installs the dream-cycle pipeline from PyPI
+> ([`digital-me-dream-cycle`](https://pypi.org/project/digital-me-dream-cycle/)).
 
 ```motus-demo
 console
@@ -80,11 +90,16 @@ in a vector store you can't read — the wiki is plain files in git.
 
 ## Where things live
 
+With the npm install, the only directory that's yours to own is `~/digital-me`
+— the CLI itself lives in npm's global packages.
+
 | Path | What it is |
 |---|---|
-| `~/digital-me-os` | this repo — code, no personal data |
 | `~/digital-me/` | **your** data: wiki, inbox, config (own it in a private git repo) |
 | `~/.openclaw/` | openclaw gateway home (brain database, plugins) |
+
+*(Installed [from source](#from-source)? The repo checkout lives at
+`~/digital-me-os` — code only, no personal data.)*
 
 ## Next steps
 

--- a/packages/runtimes/openclaw/README.md
+++ b/packages/runtimes/openclaw/README.md
@@ -34,7 +34,7 @@ config schema) and `index.mjs` (the gateway-loaded entry).
 ## Install
 
 ```bash
-# auto-detects ~/openclaw/extensions, or $OPENCLAW_EXTENSIONS_DIR
+# auto-detects ~/.openclaw/extensions, or $OPENCLAW_EXTENSIONS_DIR
 digital-me install --runtime openclaw
 
 # or point at a custom extensions dir
@@ -52,7 +52,7 @@ The installer:
 After installing, enable the plugin in your openclaw config's `plugins.enabled`
 list (if your gateway doesn't auto-discover extensions) and restart the gateway.
 Verify with `digital-me doctor` — it checks for
-`~/openclaw/extensions/digital-me-brain/index.mjs`.
+`~/.openclaw/extensions/digital-me-brain/index.mjs`.
 
 ## Keeping openclaw up to date
 


### PR DESCRIPTION
Grounds the install docs in the real launch packaging and fixes a few stale facts ahead of the public launch.

## What changed
- **Install path → npm.** README + getting-started now lead with `npm install -g digital-me` (the unscoped published name — `build-cli-bundle.mjs` ships `@digital-me/cli` to npm as `digital-me`), with an **Install from source** subsection (`pnpm dm setup`) kept for contributors.
- **Test count** `~1,400` → `1,500+` (README, CHANGELOG, contributing) — actual ≈1,520 TS + 172 Py.
- **RELEASING runbook** corrected to the unscoped `digital-me` name (was `@digital-me` scope) + changelog ref `docs/CHANGELOG.md` → `CHANGELOG.md`.
- **openclaw README** doctor path `~/openclaw/extensions` → `~/.openclaw/extensions`.

## Notes
- Docs-only; no code changes. `sanitize:check` passes.
- The website (motusai.co) consoles/docs are updated to match in a separate repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)