### PR TITLE
docs(readme): How-it-works diagrams (one-brain · lifecycle · learning-loop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ Preferred setup: `npm install -g digital-me` then `digital-me setup`. It detects
 
 > **Status:** pre-release WIP — 1,500+ unit tests, core stores and handlers at 100% coverage. The CLI ships from npm as `digital-me`; the dream-cycle pipeline ships from PyPI as `digital-me-dream-cycle`.
 
+## How it works
+
+**One intelligence — every agent runs on the same brain.** Your agents come and go; Digital Me is the part that stays.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/readme/one-brain-dark.svg">
+  <img alt="Claude Code, OpenClaw, Codex, and Hermes all connect to one Digital Me core — knowledge, taste, goals, traces, and workflows applied to every agent and captured from every agent." src="assets/readme/one-brain-light.svg" width="100%">
+</picture>
+
+**Every agent turn runs one lifecycle — apply → work → capture.** Matching knowledge and taste inject before the model sees the prompt; anything reusable flows back out, so a lesson paid once in any agent is owned by every agent.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/readme/lifecycle-dark.svg">
+  <img alt="The per-turn lifecycle rail: apply (context injected) → work (any agent, any surface) → capture (learning_capture), with a return arc feeding the next agent's apply." src="assets/readme/lifecycle-light.svg" width="100%">
+</picture>
+
+**The loop closes overnight — capture distills into recall.** The nightly dream-cycle compiles raw captures into clean, reviewable wiki entries that the next apply retrieves — so the intelligence compounds instead of evaporating.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/readme/learning-loop-dark.svg">
+  <img alt="The closed learning loop as a ring around the Digital Me core: apply → work → capture → distill (dream-cycle, nightly) → recall (memory_search) → back to apply." src="assets/readme/learning-loop-light.svg" width="100%">
+</picture>
+
+*See these animated, agent by agent → [motusai.co/docs/how-it-works](https://motusai.co/docs/how-it-works).*
+
 ## What you get
 
 When fully installed, every agent runtime shares:

--- a/assets/readme/learning-loop-dark.svg
+++ b/assets/readme/learning-loop-dark.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 320" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- The closed loop (dark): apply -> work -> capture -> distill -> recall. -->
+  <style>
+    .lbl  { font-size: 13px; fill: #f4efe6; letter-spacing: 0.08em; text-transform: uppercase; }
+    .sub  { font-size: 10px; fill: #78716c; }
+    .core { font-size: 11px; fill: #b0aaa0; letter-spacing: 0.16em; }
+  </style>
+
+  <circle cx="440" cy="165" r="92" fill="none" stroke="#44403c" stroke-width="1.4"/>
+
+  <circle r="5" fill="#9be29b">
+    <animateMotion dur="13s" repeatCount="indefinite" calcMode="linear"
+      path="M 440 73 a 92 92 0 1 0 0 184 a 92 92 0 1 0 0 -184 Z"/>
+  </circle>
+
+  <g fill="#f4efe6">
+    <circle cx="440" cy="73"  r="5"/>
+    <circle cx="527" cy="137" r="5"/>
+    <circle cx="494" cy="239" r="5"/>
+    <circle cx="386" cy="239" r="5"/>
+    <circle cx="353" cy="137" r="5"/>
+  </g>
+
+  <path d="M 372 214 A 6 6 0 1 1 363 205 A 4.7 4.7 0 0 0 372 214 Z" fill="#78716c"/>
+
+  <text x="440" y="52" text-anchor="middle" class="lbl">apply</text>
+  <text x="440" y="40" text-anchor="middle" class="sub">context injected</text>
+
+  <text x="548" y="134" text-anchor="start" class="lbl">work</text>
+  <text x="548" y="148" text-anchor="start" class="sub">tasks &#183; traces</text>
+
+  <text x="332" y="134" text-anchor="end" class="lbl">recall</text>
+  <text x="332" y="148" text-anchor="end" class="sub">memory_search</text>
+
+  <text x="514" y="237" text-anchor="start" class="lbl">capture</text>
+  <text x="514" y="251" text-anchor="start" class="sub">learning_capture</text>
+
+  <text x="366" y="237" text-anchor="end" class="lbl">distill</text>
+  <text x="366" y="251" text-anchor="end" class="sub">dream-cycle &#183; nightly</text>
+
+  <g transform="translate(421 138) scale(0.10)" fill="#f4efe6">
+    <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
+    <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
+  </g>
+  <text x="440" y="182" text-anchor="middle" class="core">DIGITAL ME</text>
+  <text x="440" y="198" text-anchor="middle" class="sub">one brain &#183; every agent</text>
+</svg>

--- a/assets/readme/learning-loop-light.svg
+++ b/assets/readme/learning-loop-light.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 320" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- The closed loop: apply -> work -> capture -> distill -> recall -> (apply).
+       A pulse orbits the ring; what's captured distills overnight and returns as
+       recall. Cut any node and the loop stops. -->
+  <style>
+    .lbl  { font-size: 13px; fill: #1c1917; letter-spacing: 0.08em; text-transform: uppercase; }
+    .sub  { font-size: 10px; fill: #a8a29e; }
+    .core { font-size: 11px; fill: #57534e; letter-spacing: 0.16em; }
+  </style>
+
+  <!-- ring -->
+  <circle cx="440" cy="165" r="92" fill="none" stroke="#d6d3d1" stroke-width="1.4"/>
+
+  <!-- orbiting pulse (one unit of context making the full loop) -->
+  <circle r="5" fill="#2da44e">
+    <animateMotion dur="13s" repeatCount="indefinite" calcMode="linear"
+      path="M 440 73 a 92 92 0 1 0 0 184 a 92 92 0 1 0 0 -184 Z"/>
+  </circle>
+
+  <!-- station dots -->
+  <g fill="#1c1917">
+    <circle cx="440" cy="73"  r="5"/>
+    <circle cx="527" cy="137" r="5"/>
+    <circle cx="494" cy="239" r="5"/>
+    <circle cx="386" cy="239" r="5"/>
+    <circle cx="353" cy="137" r="5"/>
+  </g>
+
+  <!-- moon: distill runs overnight -->
+  <path d="M 372 214 A 6 6 0 1 1 363 205 A 4.7 4.7 0 0 0 372 214 Z" fill="#a8a29e"/>
+
+  <!-- station labels -->
+  <text x="440" y="52" text-anchor="middle" class="lbl">apply</text>
+  <text x="440" y="40" text-anchor="middle" class="sub">context injected</text>
+
+  <text x="548" y="134" text-anchor="start" class="lbl">work</text>
+  <text x="548" y="148" text-anchor="start" class="sub">tasks &#183; traces</text>
+
+  <text x="332" y="134" text-anchor="end" class="lbl">recall</text>
+  <text x="332" y="148" text-anchor="end" class="sub">memory_search</text>
+
+  <text x="514" y="237" text-anchor="start" class="lbl">capture</text>
+  <text x="514" y="251" text-anchor="start" class="sub">learning_capture</text>
+
+  <text x="366" y="237" text-anchor="end" class="lbl">distill</text>
+  <text x="366" y="251" text-anchor="end" class="sub">dream-cycle &#183; nightly</text>
+
+  <!-- core: Motus M + name -->
+  <g transform="translate(421 138) scale(0.10)" fill="#1c1917">
+    <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
+    <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
+  </g>
+  <text x="440" y="182" text-anchor="middle" class="core">DIGITAL ME</text>
+  <text x="440" y="198" text-anchor="middle" class="sub">one brain &#183; every agent</text>
+</svg>

--- a/assets/readme/lifecycle-dark.svg
+++ b/assets/readme/lifecycle-dark.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 140" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- The per-turn lifecycle: apply -> work -> capture. (dark) -->
+  <style>
+    .lbl { font-size: 13px; fill: #b0aaa0; letter-spacing: 0.1em; text-transform: uppercase; }
+    .sub { font-size: 10px; fill: #78716c; }
+    .arr { font-size: 15px; fill: #78716c; }
+  </style>
+
+  <line x1="170" y1="54" x2="710" y2="54" stroke="#44403c" stroke-width="1.5"/>
+  <path d="M 710 54 C 710 116, 170 116, 170 54" fill="none" stroke="#44403c" stroke-width="1.2" stroke-dasharray="3 6"/>
+  <text x="440" y="112" text-anchor="middle" class="sub">a lesson paid once in any agent is owned by every agent</text>
+
+  <text x="310" y="49" text-anchor="middle" class="arr">&#8594;</text>
+  <text x="570" y="49" text-anchor="middle" class="arr">&#8594;</text>
+
+  <g fill="#f4efe6">
+    <circle cx="170" cy="54" r="5"/>
+    <circle cx="440" cy="54" r="5"/>
+    <circle cx="710" cy="54" r="5"/>
+  </g>
+
+  <text x="170" y="30" text-anchor="middle" class="lbl">apply</text>
+  <text x="170" y="78" text-anchor="middle" class="sub">context injected</text>
+  <text x="440" y="30" text-anchor="middle" class="lbl">work</text>
+  <text x="440" y="78" text-anchor="middle" class="sub">any agent &#183; any surface</text>
+  <text x="710" y="30" text-anchor="middle" class="lbl">capture</text>
+  <text x="710" y="78" text-anchor="middle" class="sub">learning_capture</text>
+
+  <circle r="4.5" fill="#9be29b">
+    <animateMotion dur="5s" repeatCount="indefinite" calcMode="linear" path="M170,54 L710,54"/>
+    <animate attributeName="opacity" dur="5s" repeatCount="indefinite" values="0;1;1;1;0" keyTimes="0;0.06;0.5;0.92;1"/>
+  </circle>
+</svg>

--- a/assets/readme/lifecycle-light.svg
+++ b/assets/readme/lifecycle-light.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 140" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- The per-turn lifecycle: apply -> work -> capture. Context arrives before the
+       model sees the prompt; the lesson flows back out. The dashed return arc is
+       "no cold starts" — a capture feeds the next agent's apply. -->
+  <style>
+    .lbl { font-size: 13px; fill: #57534e; letter-spacing: 0.1em; text-transform: uppercase; }
+    .sub { font-size: 10px; fill: #a8a29e; }
+    .arr { font-size: 15px; fill: #a8a29e; }
+  </style>
+
+  <!-- rail -->
+  <line x1="170" y1="54" x2="710" y2="54" stroke="#d6d3d1" stroke-width="1.5"/>
+  <!-- return arc: capture feeds the next apply -->
+  <path d="M 710 54 C 710 116, 170 116, 170 54" fill="none" stroke="#d6d3d1" stroke-width="1.2" stroke-dasharray="3 6"/>
+  <text x="440" y="112" text-anchor="middle" class="sub">a lesson paid once in any agent is owned by every agent</text>
+
+  <!-- arrows -->
+  <text x="310" y="49" text-anchor="middle" class="arr">&#8594;</text>
+  <text x="570" y="49" text-anchor="middle" class="arr">&#8594;</text>
+
+  <!-- nodes -->
+  <g fill="#1c1917">
+    <circle cx="170" cy="54" r="5"/>
+    <circle cx="440" cy="54" r="5"/>
+    <circle cx="710" cy="54" r="5"/>
+  </g>
+
+  <!-- labels -->
+  <text x="170" y="30" text-anchor="middle" class="lbl">apply</text>
+  <text x="170" y="78" text-anchor="middle" class="sub">context injected</text>
+  <text x="440" y="30" text-anchor="middle" class="lbl">work</text>
+  <text x="440" y="78" text-anchor="middle" class="sub">any agent &#183; any surface</text>
+  <text x="710" y="30" text-anchor="middle" class="lbl">capture</text>
+  <text x="710" y="78" text-anchor="middle" class="sub">learning_capture</text>
+
+  <!-- traveling pulse: one unit of context making the trip -->
+  <circle r="4.5" fill="#2da44e">
+    <animateMotion dur="5s" repeatCount="indefinite" calcMode="linear" path="M170,54 L710,54"/>
+    <animate attributeName="opacity" dur="5s" repeatCount="indefinite" values="0;1;1;1;0" keyTimes="0;0.06;0.5;0.92;1"/>
+  </circle>
+</svg>

--- a/assets/readme/one-brain-dark.svg
+++ b/assets/readme/one-brain-dark.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 240" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- One brain, every agent: agents differ and change; the core never moves.
+       Dashes flow INWARD on the apply lines (context arriving), outward on capture. -->
+  <style>
+    .agent { font-size: 13px; fill: #f4efe6; }
+    .tag   { font-size: 10px; fill: #78716c; }
+    .core  { font-size: 11px; fill: #b0aaa0; letter-spacing: 0.14em; }
+  </style>
+
+  <!-- connecting lines: left agents -->
+  <g stroke="#44403c" stroke-width="1.2" fill="none">
+    <path id="l1" d="M 200 60  C 280 60, 320 110, 380 118"/>
+    <path id="l2" d="M 200 180 C 280 180, 320 130, 380 124"/>
+    <path id="l3" d="M 680 60  C 600 60, 560 110, 500 118"/>
+    <path id="l4" d="M 680 180 C 600 180, 560 130, 500 124"/>
+  </g>
+  <!-- flow: context applying (inward pulses) -->
+  <g stroke="#9be29b" stroke-width="1.6" fill="none" stroke-dasharray="3 14">
+    <path d="M 200 60  C 280 60, 320 110, 380 118">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 200 180 C 280 180, 320 130, 380 124">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 680 60  C 600 60, 560 110, 500 118">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 680 180 C 600 180, 560 130, 500 124">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.8s" repeatCount="indefinite"/>
+    </path>
+  </g>
+
+  <!-- agents (left) -->
+  <g>
+    <rect x="60" y="40" width="140" height="40" rx="6" fill="none" stroke="#44403c"/>
+    <text x="74" y="58" class="agent">Claude Code</text>
+    <text x="74" y="72" class="tag">deep coding · CLI</text>
+
+    <rect x="60" y="160" width="140" height="40" rx="6" fill="none" stroke="#44403c"/>
+    <text x="74" y="178" class="agent">OpenClaw</text>
+    <text x="74" y="192" class="tag">always on · Discord</text>
+  </g>
+  <!-- agents (right) -->
+  <g>
+    <rect x="680" y="40" width="140" height="40" rx="6" fill="none" stroke="#44403c"/>
+    <text x="694" y="58" class="agent">Codex</text>
+    <text x="694" y="72" class="tag">repo-wide work</text>
+
+    <rect x="680" y="160" width="140" height="40" rx="6" fill="none" stroke="#44403c"/>
+    <text x="694" y="178" class="agent">Hermes</text>
+    <text x="694" y="192" class="tag">self-learning</text>
+  </g>
+
+  <!-- the core: fixed, never animated -->
+  <g>
+    <rect x="380" y="76" width="120" height="92" rx="8" fill="#f4efe6"/>
+    <!-- Motus M mark (two strokes), scaled -->
+    <g transform="translate(415 96) scale(0.115)" fill="#1c1917">
+      <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
+      <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
+    </g>
+    <text x="440" y="152" text-anchor="middle" class="core" fill="#1c1917">DIGITAL ME</text>
+  </g>
+
+  <!-- footer line -->
+  <text x="440" y="222" text-anchor="middle" class="tag">knowledge · taste · goals · traces · workflows — applied to every agent, captured from every agent</text>
+</svg>

--- a/assets/readme/one-brain-light.svg
+++ b/assets/readme/one-brain-light.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 240" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- One brain, every agent: agents differ and change; the core never moves.
+       Dashes flow INWARD on the apply lines (context arriving), outward on capture. -->
+  <style>
+    .agent { font-size: 13px; fill: #1c1917; }
+    .tag   { font-size: 10px; fill: #a8a29e; }
+    .core  { font-size: 11px; fill: #57534e; letter-spacing: 0.14em; }
+  </style>
+
+  <!-- connecting lines: left agents -->
+  <g stroke="#d6d3d1" stroke-width="1.2" fill="none">
+    <path id="l1" d="M 200 60  C 280 60, 320 110, 380 118"/>
+    <path id="l2" d="M 200 180 C 280 180, 320 130, 380 124"/>
+    <path id="l3" d="M 680 60  C 600 60, 560 110, 500 118"/>
+    <path id="l4" d="M 680 180 C 600 180, 560 130, 500 124"/>
+  </g>
+  <!-- flow: context applying (inward pulses) -->
+  <g stroke="#2da44e" stroke-width="1.6" fill="none" stroke-dasharray="3 14">
+    <path d="M 200 60  C 280 60, 320 110, 380 118">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 200 180 C 280 180, 320 130, 380 124">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 680 60  C 600 60, 560 110, 500 118">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 680 180 C 600 180, 560 130, 500 124">
+      <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.8s" repeatCount="indefinite"/>
+    </path>
+  </g>
+
+  <!-- agents (left) -->
+  <g>
+    <rect x="60" y="40" width="140" height="40" rx="6" fill="none" stroke="#d6d3d1"/>
+    <text x="74" y="58" class="agent">Claude Code</text>
+    <text x="74" y="72" class="tag">deep coding · CLI</text>
+
+    <rect x="60" y="160" width="140" height="40" rx="6" fill="none" stroke="#d6d3d1"/>
+    <text x="74" y="178" class="agent">OpenClaw</text>
+    <text x="74" y="192" class="tag">always on · Discord</text>
+  </g>
+  <!-- agents (right) -->
+  <g>
+    <rect x="680" y="40" width="140" height="40" rx="6" fill="none" stroke="#d6d3d1"/>
+    <text x="694" y="58" class="agent">Codex</text>
+    <text x="694" y="72" class="tag">repo-wide work</text>
+
+    <rect x="680" y="160" width="140" height="40" rx="6" fill="none" stroke="#d6d3d1"/>
+    <text x="694" y="178" class="agent">Hermes</text>
+    <text x="694" y="192" class="tag">self-learning</text>
+  </g>
+
+  <!-- the core: fixed, never animated -->
+  <g>
+    <rect x="380" y="76" width="120" height="92" rx="8" fill="#1c1917"/>
+    <!-- Motus M mark (two strokes), scaled -->
+    <g transform="translate(415 96) scale(0.115)" fill="#f4efe6">
+      <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
+      <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
+    </g>
+    <text x="440" y="152" text-anchor="middle" class="core" fill="#f4efe6">DIGITAL ME</text>
+  </g>
+
+  <!-- footer line -->
+  <text x="440" y="222" text-anchor="middle" class="tag">knowledge · taste · goals · traces · workflows — applied to every agent, captured from every agent</text>
+</svg>


### PR DESCRIPTION
Brings the three **how-it-works** charts from motusai.co into the README as the first major section, so a new reader understands what Digital Me is — and how it compounds — up front (the five-why: *what · how · why-it-compounds*).

## Diagrams (`assets/readme/`)
- **one-brain** — one intelligence, every agent (Claude Code · OpenClaw · Codex · Hermes → core)
- **lifecycle** — `apply → work → capture` per turn, with the "no cold starts" return arc
- **learning-loop** — the closed ring `apply → work → capture → distill → recall`

Animated SVGs (SMIL — render + animate on GitHub), **light + dark** via `<picture>`, on the Motus monospace / ink / bone palette. Each diagram carries a one-line caption. `one-brain` reuses prior art; `lifecycle` + `learning-loop` are new and grounded in the actual lifecycle/loop wording.

Docs-only; sanitize gate passes. Links out to the animated, agent-by-agent versions at motusai.co/docs/how-it-works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)