### PR TITLE
docs(readme): unify the three how-it-works diagrams (consistent set)

### DIFF
--- a/assets/readme/learning-loop-dark.svg
+++ b/assets/readme/learning-loop-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 320" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 260" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
   <!-- The closed loop (dark): apply -> work -> capture -> distill -> recall. -->
   <style>
     .lbl  { font-size: 13px; fill: #f4efe6; letter-spacing: 0.08em; text-transform: uppercase; }
@@ -6,42 +6,42 @@
     .core { font-size: 11px; fill: #b0aaa0; letter-spacing: 0.16em; }
   </style>
 
-  <circle cx="440" cy="165" r="92" fill="none" stroke="#44403c" stroke-width="1.4"/>
+  <circle cx="440" cy="135" r="86" fill="none" stroke="#44403c" stroke-width="1.4"/>
 
   <circle r="5" fill="#9be29b">
     <animateMotion dur="13s" repeatCount="indefinite" calcMode="linear"
-      path="M 440 73 a 92 92 0 1 0 0 184 a 92 92 0 1 0 0 -184 Z"/>
+      path="M 440 49 a 86 86 0 1 0 0 172 a 86 86 0 1 0 0 -172 Z"/>
   </circle>
 
   <g fill="#f4efe6">
-    <circle cx="440" cy="73"  r="5"/>
-    <circle cx="527" cy="137" r="5"/>
-    <circle cx="494" cy="239" r="5"/>
-    <circle cx="386" cy="239" r="5"/>
-    <circle cx="353" cy="137" r="5"/>
+    <circle cx="440" cy="49"  r="5"/>
+    <circle cx="522" cy="108" r="5"/>
+    <circle cx="491" cy="205" r="5"/>
+    <circle cx="389" cy="205" r="5"/>
+    <circle cx="358" cy="108" r="5"/>
   </g>
 
-  <path d="M 372 214 A 6 6 0 1 1 363 205 A 4.7 4.7 0 0 0 372 214 Z" fill="#78716c"/>
+  <path d="M 380 184 A 6 6 0 1 1 371 175 A 4.7 4.7 0 0 0 380 184 Z" fill="#78716c"/>
 
-  <text x="440" y="52" text-anchor="middle" class="lbl">apply</text>
-  <text x="440" y="40" text-anchor="middle" class="sub">context injected</text>
+  <text x="440" y="38" text-anchor="middle" class="lbl">apply</text>
+  <text x="440" y="26" text-anchor="middle" class="sub">context injected</text>
 
-  <text x="548" y="134" text-anchor="start" class="lbl">work</text>
-  <text x="548" y="148" text-anchor="start" class="sub">tasks &#183; traces</text>
+  <text x="540" y="105" text-anchor="start" class="lbl">work</text>
+  <text x="540" y="119" text-anchor="start" class="sub">tasks &#183; traces</text>
 
-  <text x="332" y="134" text-anchor="end" class="lbl">recall</text>
-  <text x="332" y="148" text-anchor="end" class="sub">memory_search</text>
+  <text x="340" y="105" text-anchor="end" class="lbl">recall</text>
+  <text x="340" y="119" text-anchor="end" class="sub">memory_search</text>
 
-  <text x="514" y="237" text-anchor="start" class="lbl">capture</text>
-  <text x="514" y="251" text-anchor="start" class="sub">learning_capture</text>
+  <text x="508" y="205" text-anchor="start" class="lbl">capture</text>
+  <text x="508" y="219" text-anchor="start" class="sub">learning_capture</text>
 
-  <text x="366" y="237" text-anchor="end" class="lbl">distill</text>
-  <text x="366" y="251" text-anchor="end" class="sub">dream-cycle &#183; nightly</text>
+  <text x="372" y="205" text-anchor="end" class="lbl">distill</text>
+  <text x="372" y="219" text-anchor="end" class="sub">dream-cycle &#183; nightly</text>
 
-  <g transform="translate(421 138) scale(0.10)" fill="#f4efe6">
+  <g transform="translate(421 110) scale(0.095)" fill="#f4efe6">
     <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
     <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
   </g>
-  <text x="440" y="182" text-anchor="middle" class="core">DIGITAL ME</text>
-  <text x="440" y="198" text-anchor="middle" class="sub">one brain &#183; every agent</text>
+  <text x="440" y="152" text-anchor="middle" class="core">DIGITAL ME</text>
+  <text x="440" y="167" text-anchor="middle" class="sub">one brain &#183; every agent</text>
 </svg>

--- a/assets/readme/learning-loop-light.svg
+++ b/assets/readme/learning-loop-light.svg
@@ -1,55 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 320" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 260" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
   <!-- The closed loop: apply -> work -> capture -> distill -> recall -> (apply).
-       A pulse orbits the ring; what's captured distills overnight and returns as
-       recall. Cut any node and the loop stops. -->
+       A pulse orbits the ring around the fixed core; capture distills overnight and
+       returns as recall. Cut any node and the loop stops. -->
   <style>
     .lbl  { font-size: 13px; fill: #1c1917; letter-spacing: 0.08em; text-transform: uppercase; }
     .sub  { font-size: 10px; fill: #a8a29e; }
     .core { font-size: 11px; fill: #57534e; letter-spacing: 0.16em; }
   </style>
 
-  <!-- ring -->
-  <circle cx="440" cy="165" r="92" fill="none" stroke="#d6d3d1" stroke-width="1.4"/>
+  <circle cx="440" cy="135" r="86" fill="none" stroke="#d6d3d1" stroke-width="1.4"/>
 
-  <!-- orbiting pulse (one unit of context making the full loop) -->
+  <!-- orbiting pulse -->
   <circle r="5" fill="#2da44e">
     <animateMotion dur="13s" repeatCount="indefinite" calcMode="linear"
-      path="M 440 73 a 92 92 0 1 0 0 184 a 92 92 0 1 0 0 -184 Z"/>
+      path="M 440 49 a 86 86 0 1 0 0 172 a 86 86 0 1 0 0 -172 Z"/>
   </circle>
 
   <!-- station dots -->
   <g fill="#1c1917">
-    <circle cx="440" cy="73"  r="5"/>
-    <circle cx="527" cy="137" r="5"/>
-    <circle cx="494" cy="239" r="5"/>
-    <circle cx="386" cy="239" r="5"/>
-    <circle cx="353" cy="137" r="5"/>
+    <circle cx="440" cy="49"  r="5"/>
+    <circle cx="522" cy="108" r="5"/>
+    <circle cx="491" cy="205" r="5"/>
+    <circle cx="389" cy="205" r="5"/>
+    <circle cx="358" cy="108" r="5"/>
   </g>
 
   <!-- moon: distill runs overnight -->
-  <path d="M 372 214 A 6 6 0 1 1 363 205 A 4.7 4.7 0 0 0 372 214 Z" fill="#a8a29e"/>
+  <path d="M 380 184 A 6 6 0 1 1 371 175 A 4.7 4.7 0 0 0 380 184 Z" fill="#a8a29e"/>
 
   <!-- station labels -->
-  <text x="440" y="52" text-anchor="middle" class="lbl">apply</text>
-  <text x="440" y="40" text-anchor="middle" class="sub">context injected</text>
+  <text x="440" y="38" text-anchor="middle" class="lbl">apply</text>
+  <text x="440" y="26" text-anchor="middle" class="sub">context injected</text>
 
-  <text x="548" y="134" text-anchor="start" class="lbl">work</text>
-  <text x="548" y="148" text-anchor="start" class="sub">tasks &#183; traces</text>
+  <text x="540" y="105" text-anchor="start" class="lbl">work</text>
+  <text x="540" y="119" text-anchor="start" class="sub">tasks &#183; traces</text>
 
-  <text x="332" y="134" text-anchor="end" class="lbl">recall</text>
-  <text x="332" y="148" text-anchor="end" class="sub">memory_search</text>
+  <text x="340" y="105" text-anchor="end" class="lbl">recall</text>
+  <text x="340" y="119" text-anchor="end" class="sub">memory_search</text>
 
-  <text x="514" y="237" text-anchor="start" class="lbl">capture</text>
-  <text x="514" y="251" text-anchor="start" class="sub">learning_capture</text>
+  <text x="508" y="205" text-anchor="start" class="lbl">capture</text>
+  <text x="508" y="219" text-anchor="start" class="sub">learning_capture</text>
 
-  <text x="366" y="237" text-anchor="end" class="lbl">distill</text>
-  <text x="366" y="251" text-anchor="end" class="sub">dream-cycle &#183; nightly</text>
+  <text x="372" y="205" text-anchor="end" class="lbl">distill</text>
+  <text x="372" y="219" text-anchor="end" class="sub">dream-cycle &#183; nightly</text>
 
-  <!-- core: Motus M + name -->
-  <g transform="translate(421 138) scale(0.10)" fill="#1c1917">
+  <!-- fixed core -->
+  <g transform="translate(421 110) scale(0.095)" fill="#1c1917">
     <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
     <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
   </g>
-  <text x="440" y="182" text-anchor="middle" class="core">DIGITAL ME</text>
-  <text x="440" y="198" text-anchor="middle" class="sub">one brain &#183; every agent</text>
+  <text x="440" y="152" text-anchor="middle" class="core">DIGITAL ME</text>
+  <text x="440" y="167" text-anchor="middle" class="sub">one brain &#183; every agent</text>
 </svg>

--- a/assets/readme/lifecycle-dark.svg
+++ b/assets/readme/lifecycle-dark.svg
@@ -1,33 +1,47 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 140" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
-  <!-- The per-turn lifecycle: apply -> work -> capture. (dark) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 260" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- The lifecycle as the master promise (dark): agent chrome swaps, core fixed. -->
   <style>
-    .lbl { font-size: 13px; fill: #b0aaa0; letter-spacing: 0.1em; text-transform: uppercase; }
-    .sub { font-size: 10px; fill: #78716c; }
-    .arr { font-size: 15px; fill: #78716c; }
+    .sub   { font-size: 10px; fill: #78716c; }
+    .agent { font-size: 13px; fill: #f4efe6; }
+    .mono  { font-size: 11px; fill: #b0aaa0; }
+    .inj   { font-size: 11px; fill: #9be29b; }
+    .core  { font-size: 11px; fill: #b0aaa0; letter-spacing: 0.14em; }
   </style>
 
-  <line x1="170" y1="54" x2="710" y2="54" stroke="#44403c" stroke-width="1.5"/>
-  <path d="M 710 54 C 710 116, 170 116, 170 54" fill="none" stroke="#44403c" stroke-width="1.2" stroke-dasharray="3 6"/>
-  <text x="440" y="112" text-anchor="middle" class="sub">a lesson paid once in any agent is owned by every agent</text>
+  <path d="M 196 120 C 340 120, 400 108, 540 106" fill="none" stroke="#44403c" stroke-width="1.2"/>
+  <path d="M 196 120 C 340 120, 400 108, 540 106" fill="none" stroke="#9be29b" stroke-width="1.6" stroke-dasharray="3 14">
+    <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <text x="368" y="100" text-anchor="middle" class="sub">apply &#8594;</text>
 
-  <text x="310" y="49" text-anchor="middle" class="arr">&#8594;</text>
-  <text x="570" y="49" text-anchor="middle" class="arr">&#8594;</text>
+  <path d="M 540 162 C 400 160, 340 150, 196 150" fill="none" stroke="#44403c" stroke-width="1.2"/>
+  <path d="M 540 162 C 400 160, 340 150, 196 150" fill="none" stroke="#9be29b" stroke-width="1.6" stroke-dasharray="3 14">
+    <animate attributeName="stroke-dashoffset" from="0" to="34" dur="2.8s" repeatCount="indefinite"/>
+  </path>
+  <text x="368" y="176" text-anchor="middle" class="sub">&#8592; capture</text>
 
-  <g fill="#f4efe6">
-    <circle cx="170" cy="54" r="5"/>
-    <circle cx="440" cy="54" r="5"/>
-    <circle cx="710" cy="54" r="5"/>
+  <rect x="64" y="104" width="124" height="62" rx="8" fill="#26221f"/>
+  <g transform="translate(100 116) scale(0.10)" fill="#f4efe6">
+    <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
+    <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
   </g>
+  <text x="126" y="154" text-anchor="middle" class="core">DIGITAL ME</text>
+  <text x="126" y="190" text-anchor="middle" class="sub">the core never moves</text>
 
-  <text x="170" y="30" text-anchor="middle" class="lbl">apply</text>
-  <text x="170" y="78" text-anchor="middle" class="sub">context injected</text>
-  <text x="440" y="30" text-anchor="middle" class="lbl">work</text>
-  <text x="440" y="78" text-anchor="middle" class="sub">any agent &#183; any surface</text>
-  <text x="710" y="30" text-anchor="middle" class="lbl">capture</text>
-  <text x="710" y="78" text-anchor="middle" class="sub">learning_capture</text>
+  <rect x="540" y="74" width="280" height="118" rx="8" fill="none" stroke="#44403c"/>
+  <circle cx="560" cy="94" r="3" fill="#44403c"/>
+  <circle cx="572" cy="94" r="3" fill="#44403c"/>
+  <circle cx="584" cy="94" r="3" fill="#44403c"/>
+  <g text-anchor="end" class="agent">
+    <text x="806" y="98">Claude Code<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="1;1;0;0;1" keyTimes="0;0.22;0.25;0.97;1"/></text>
+    <text x="806" y="98">Codex<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0.25;0.27;0.47;0.5;1"/></text>
+    <text x="806" y="98">OpenClaw<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0.5;0.52;0.72;0.75;1"/></text>
+    <text x="806" y="98">Hermes<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="0;0;1;1" keyTimes="0;0.75;0.77;1"/></text>
+  </g>
+  <line x1="540" y1="108" x2="820" y2="108" stroke="#33302c" stroke-width="1"/>
+  <text x="558" y="130"><tspan class="inj">[Digital Me] apply</tspan><tspan class="mono"> taste + knowledge</tspan></text>
+  <text x="558" y="152" class="mono">&#9679; work &#183; context already loaded</text>
+  <text x="558" y="174"><tspan class="inj">capture &#8594;</tspan><tspan class="mono"> filed to the brain</tspan></text>
 
-  <circle r="4.5" fill="#9be29b">
-    <animateMotion dur="5s" repeatCount="indefinite" calcMode="linear" path="M170,54 L710,54"/>
-    <animate attributeName="opacity" dur="5s" repeatCount="indefinite" values="0;1;1;1;0" keyTimes="0;0.06;0.5;0.92;1"/>
-  </circle>
+  <text x="440" y="234" text-anchor="middle" class="sub">apply &#8594; work &#8594; capture &#183; one brain, every agent</text>
 </svg>

--- a/assets/readme/lifecycle-light.svg
+++ b/assets/readme/lifecycle-light.svg
@@ -1,41 +1,56 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 140" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
-  <!-- The per-turn lifecycle: apply -> work -> capture. Context arrives before the
-       model sees the prompt; the lesson flows back out. The dashed return arc is
-       "no cold starts" — a capture feeds the next agent's apply. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 260" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+  <!-- The lifecycle as the master promise: the agent chrome swaps (Claude Code ->
+       Codex -> OpenClaw -> Hermes) while the Digital Me core never moves. Context
+       applies IN, work happens, the lesson captures OUT — same brain, every agent. -->
   <style>
-    .lbl { font-size: 13px; fill: #57534e; letter-spacing: 0.1em; text-transform: uppercase; }
-    .sub { font-size: 10px; fill: #a8a29e; }
-    .arr { font-size: 15px; fill: #a8a29e; }
+    .sub   { font-size: 10px; fill: #a8a29e; }
+    .agent { font-size: 13px; fill: #1c1917; }
+    .mono  { font-size: 11px; fill: #57534e; }
+    .inj   { font-size: 11px; fill: #2da44e; }
+    .core  { font-size: 11px; fill: #f4efe6; letter-spacing: 0.14em; }
   </style>
 
-  <!-- rail -->
-  <line x1="170" y1="54" x2="710" y2="54" stroke="#d6d3d1" stroke-width="1.5"/>
-  <!-- return arc: capture feeds the next apply -->
-  <path d="M 710 54 C 710 116, 170 116, 170 54" fill="none" stroke="#d6d3d1" stroke-width="1.2" stroke-dasharray="3 6"/>
-  <text x="440" y="112" text-anchor="middle" class="sub">a lesson paid once in any agent is owned by every agent</text>
+  <!-- apply flow: core -> agent (context in) -->
+  <path d="M 196 120 C 340 120, 400 108, 540 106" fill="none" stroke="#d6d3d1" stroke-width="1.2"/>
+  <path d="M 196 120 C 340 120, 400 108, 540 106" fill="none" stroke="#2da44e" stroke-width="1.6" stroke-dasharray="3 14">
+    <animate attributeName="stroke-dashoffset" from="34" to="0" dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <text x="368" y="100" text-anchor="middle" class="sub">apply &#8594;</text>
 
-  <!-- arrows -->
-  <text x="310" y="49" text-anchor="middle" class="arr">&#8594;</text>
-  <text x="570" y="49" text-anchor="middle" class="arr">&#8594;</text>
+  <!-- capture flow: agent -> core (work out) -->
+  <path d="M 540 162 C 400 160, 340 150, 196 150" fill="none" stroke="#d6d3d1" stroke-width="1.2"/>
+  <path d="M 540 162 C 400 160, 340 150, 196 150" fill="none" stroke="#2da44e" stroke-width="1.6" stroke-dasharray="3 14">
+    <animate attributeName="stroke-dashoffset" from="0" to="34" dur="2.8s" repeatCount="indefinite"/>
+  </path>
+  <text x="368" y="176" text-anchor="middle" class="sub">&#8592; capture</text>
 
-  <!-- nodes -->
-  <g fill="#1c1917">
-    <circle cx="170" cy="54" r="5"/>
-    <circle cx="440" cy="54" r="5"/>
-    <circle cx="710" cy="54" r="5"/>
+  <!-- fixed core (left) -->
+  <rect x="64" y="104" width="124" height="62" rx="8" fill="#1c1917"/>
+  <g transform="translate(100 116) scale(0.10)" fill="#f4efe6">
+    <path d="M 1 0 H 89 L 228 216 H 130 L 76 116 V 216 H 0 Z"/>
+    <path d="M 168 0 H 264 L 394 216 H 298 Z"/>
   </g>
+  <text x="126" y="154" text-anchor="middle" class="core">DIGITAL ME</text>
+  <text x="126" y="190" text-anchor="middle" class="sub">the core never moves</text>
 
-  <!-- labels -->
-  <text x="170" y="30" text-anchor="middle" class="lbl">apply</text>
-  <text x="170" y="78" text-anchor="middle" class="sub">context injected</text>
-  <text x="440" y="30" text-anchor="middle" class="lbl">work</text>
-  <text x="440" y="78" text-anchor="middle" class="sub">any agent &#183; any surface</text>
-  <text x="710" y="30" text-anchor="middle" class="lbl">capture</text>
-  <text x="710" y="78" text-anchor="middle" class="sub">learning_capture</text>
+  <!-- agent card (right): chrome swaps; content is the lifecycle -->
+  <rect x="540" y="74" width="280" height="118" rx="8" fill="none" stroke="#d6d3d1"/>
+  <circle cx="560" cy="94" r="3" fill="#d6d3d1"/>
+  <circle cx="572" cy="94" r="3" fill="#d6d3d1"/>
+  <circle cx="584" cy="94" r="3" fill="#d6d3d1"/>
+  <!-- swapping agent name -->
+  <g text-anchor="end" class="agent">
+    <text x="806" y="98">Claude Code<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="1;1;0;0;1" keyTimes="0;0.22;0.25;0.97;1"/></text>
+    <text x="806" y="98">Codex<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0.25;0.27;0.47;0.5;1"/></text>
+    <text x="806" y="98">OpenClaw<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0.5;0.52;0.72;0.75;1"/></text>
+    <text x="806" y="98">Hermes<animate attributeName="opacity" dur="12s" repeatCount="indefinite" values="0;0;1;1" keyTimes="0;0.75;0.77;1"/></text>
+  </g>
+  <line x1="540" y1="108" x2="820" y2="108" stroke="#ece7dd" stroke-width="1"/>
+  <!-- body: apply -> work -> capture -->
+  <text x="558" y="130"><tspan class="inj">[Digital Me] apply</tspan><tspan class="mono"> taste + knowledge</tspan></text>
+  <text x="558" y="152" class="mono">&#9679; work &#183; context already loaded</text>
+  <text x="558" y="174"><tspan class="inj">capture &#8594;</tspan><tspan class="mono"> filed to the brain</tspan></text>
 
-  <!-- traveling pulse: one unit of context making the trip -->
-  <circle r="4.5" fill="#2da44e">
-    <animateMotion dur="5s" repeatCount="indefinite" calcMode="linear" path="M170,54 L710,54"/>
-    <animate attributeName="opacity" dur="5s" repeatCount="indefinite" values="0;1;1;1;0" keyTimes="0;0.06;0.5;0.92;1"/>
-  </circle>
+  <!-- caption -->
+  <text x="440" y="234" text-anchor="middle" class="sub">apply &#8594; work &#8594; capture &#183; one brain, every agent</text>
 </svg>

--- a/assets/readme/one-brain-dark.svg
+++ b/assets/readme/one-brain-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 240" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 260" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
   <!-- One brain, every agent: agents differ and change; the core never moves.
        Dashes flow INWARD on the apply lines (context arriving), outward on capture. -->
   <style>

--- a/assets/readme/one-brain-light.svg
+++ b/assets/readme/one-brain-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 240" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 260" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
   <!-- One brain, every agent: agents differ and change; the core never moves.
        Dashes flow INWARD on the apply lines (context arriving), outward on capture. -->
   <style>


### PR DESCRIPTION
Follow-up to #18. The three diagrams shipped with mismatched visual languages and proportions (240 / 140 / 320 px) — they didn't read as a set. This rebuilds them as one cohesive system.

- **All 880×260**, shared monospace / ink / bone palette, single green accent, the same `DIGITAL ME` core box + M-mark.
- **lifecycle** recast as the brand's *master-promise* motif (per the motion-is-state-change spec): the agent terminal chrome swaps **Claude Code → Codex → OpenClaw → Hermes** while the core never moves; `apply` flows in, `capture` flows out.
- **one-brain** + **learning-loop** harmonized to the same canvas.

Animated SVGs (SMIL), light + dark. README markup unchanged — same asset paths, so it picks these up automatically. Docs-only; sanitize passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)