### PR TITLE
release: cli v0.1.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digital-me/cli",
-  "version": "0.1.0-pre",
-  "description": "digital-me \u2014 install, doctor, and orchestrate the digital-me ecosystem (runtimes, brain MCP proxy, dream-cycle).",
+  "version": "0.1.0",
+  "description": "digital-me — install, doctor, and orchestrate the digital-me ecosystem (runtimes, brain MCP proxy, dream-cycle).",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bumps `@digital-me/cli` `0.1.0-pre → 0.1.0` for the first npm release (publishes as the unscoped **`digital-me`**).

**Pre-flight done:** built the bundle, `npm pack`, installed the tarball in a sandbox HOME — `digital-me --help` runs cleanly, bin resolves inside the installed package (no checkout leakage).

**To release after this merges:**
1. Ensure the **`DM_NPM_TOKEN`** repo secret exists (automation / granular-with-Bypass-2FA, publish rights to unscoped `digital-me`).
2. `git tag cli-v0.1.0 && git push origin cli-v0.1.0` → `publish-cli.yml` publishes `digital-me@0.1.0` with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)