### PR TITLE
docs: mark v0.1.0 released (npm shield + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,14 @@ Until `1.0.0`, minor versions may include breaking changes.
 
 ## [Unreleased]
 
-### Added
-- Open-source community health files: `CONTRIBUTING.md`, `SECURITY.md`,
-  `CODE_OF_CONDUCT.md`, GitHub issue/PR templates, and this changelog.
-- Maintenance automation: Dependabot (npm + pip + actions), `CODEOWNERS`, and
-  `.editorconfig`. (CodeQL code scanning is enabled via GitHub's repo-managed
-  "default setup" in Settings rather than a committed workflow.)
-- `SUPPORT.md` (help-routing) and `.github/FUNDING.yml` (sponsor button).
+_Nothing yet._
 
-### Changed
-- Root `engines.node` raised to `>=22.5` to match all workspace packages and the
-  README (the `node:sqlite` built-in used by the brain stores landed in Node 22.5.0).
+## [0.1.0] - 2026-06-26
 
-## [0.1.0-pre] - 2026-06
-
-Initial pre-release. Functional monorepo with 1,500+ unit tests (core stores and
-handlers at 100% coverage); install from source — nothing published to npm yet.
+Initial public release. Published to npm as `digital-me` (with provenance) and to
+PyPI as `digital-me-dream-cycle`. Functional monorepo with 1,500+ unit tests (core
+stores and handlers at 100% coverage). Pre-1.0 — minor versions may include breaking
+changes.
 
 ### Added
 - `digital-me` CLI: `setup`, `init`, `install --runtime <id>`, `doctor`,
@@ -39,6 +31,15 @@ handlers at 100% coverage); install from source — nothing published to npm yet
   (`digital-me-dream-cycle` on PyPI).
 - Tag-driven release automation for the npm CLI bundle (with provenance) and the
   dream-cycle PyPI package.
+- Open-source community health files: `CONTRIBUTING.md`, `SECURITY.md`,
+  `CODE_OF_CONDUCT.md`, `SUPPORT.md`, GitHub issue/PR templates, and this changelog.
+- Maintenance automation: Dependabot (npm + pip + actions), `CODEOWNERS`,
+  `.editorconfig`, and `.github/FUNDING.yml`. (CodeQL via GitHub's repo-managed
+  "default setup" in Settings rather than a committed workflow.)
 
-[Unreleased]: https://github.com/Amyssjj/digital-me/compare/v0.1.0-pre...HEAD
-[0.1.0-pre]: https://github.com/Amyssjj/digital-me/releases/tag/v0.1.0-pre
+### Changed
+- Root `engines.node` raised to `>=22.5` to match all workspace packages and the
+  README (the `node:sqlite` built-in used by the brain stores landed in Node 22.5.0).
+
+[Unreleased]: https://github.com/Amyssjj/digital-me/compare/cli-v0.1.0...HEAD
+[0.1.0]: https://github.com/Amyssjj/digital-me/releases/tag/cli-v0.1.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/Amyssjj/digital-me/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/Amyssjj/digital-me/ci.yml?branch=main&style=for-the-badge" alt="CI status"></a>
-  <a href="https://github.com/Amyssjj/digital-me/releases/tag/cli-v0.1.0"><img src="https://img.shields.io/badge/release-v0.1.0-F46D01?style=for-the-badge" alt="Release"></a>
+  <a href="https://www.npmjs.com/package/digital-me"><img src="https://img.shields.io/npm/v/digital-me?label=npm&logo=npm&logoColor=white&color=CB3837&style=for-the-badge" alt="npm version"></a>
   <a href="https://pypi.org/project/digital-me-dream-cycle/"><img src="https://img.shields.io/pypi/v/digital-me-dream-cycle?label=PyPI&logo=pypi&logoColor=white&color=3775A9&style=for-the-badge" alt="PyPI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
@@ -25,7 +25,7 @@ New install? Start here: [Getting started](#install)
 
 Preferred setup: `npm install -g digital-me` then `digital-me setup`. It detects your installed CLIs, scaffolds your data directory, wires every runtime, and ends with a doctor pass. Works on macOS and Linux. (Building from source? See [Install from source](#install-from-source).)
 
-> **Status:** pre-release WIP — 1,500+ unit tests, core stores and handlers at 100% coverage. The CLI ships from npm as `digital-me`; the dream-cycle pipeline ships from PyPI as `digital-me-dream-cycle`.
+> **Status:** v0.1 — live and early. Published to npm as `digital-me` (with provenance) and to PyPI as `digital-me-dream-cycle`, with 1,500+ unit tests (core stores and handlers at 100% coverage). Pre-1.0, so APIs may still shift between minor versions.
 
 ## How it works
 


### PR DESCRIPTION
Now that `digital-me@0.1.0` is live: dynamic **npm version shield** (auto-tracks future releases), reworded status (no more "pre-release WIP"), and CHANGELOG `[0.1.0-pre]` → released `[0.1.0]` with shipped items folded in and links pointed at `cli-v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)