### PR TITLE
ci: tame Dependabot — group action bumps + auto-merge patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,5 +37,17 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # One grouped PR for all action bumps instead of one PR per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci(deps)"
+
+# Note on major version updates: they are intentionally left ungrouped so each
+# arrives as its own PR for deliberate review — majors often need migration work
+# (e.g. vitest 4, typescript 6). The dependabot-auto-merge workflow only
+# auto-merges patch/minor, so a major never lands unattended. Majors are NOT
+# ignored here on purpose: that would also suppress security fixes that are only
+# available in a new major (e.g. the vitest 2 → 3 CVE patch, GHSA-5xrq-8626-4rwp).

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot patch/minor PRs once all required CI checks pass.
+# Major bumps are skipped on purpose and require manual review (they often need
+# migration work). Requires "Allow auto-merge" enabled in repo settings; with
+# branch protection's required status checks, GitHub holds the merge until CI is
+# green. Squash merge matches the repo's `title (#N)` history.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Tunes Dependabot so routine dependency maintenance stops being manual toil, while keeping the valuable part (security updates) fully intact.

- **Group GitHub Actions bumps** into one PR instead of one-per-action. Last week's run opened 5 separate Action PRs (#7–#11: checkout, setup-python, pnpm/action-setup, upload-artifact, download-artifact); this collapses them to a single grouped PR.
- **New `dependabot-auto-merge.yml` workflow** — auto-merges Dependabot **patch/minor** PRs once required CI checks pass (squash, delete branch). Majors are skipped on purpose.

## Why

The batch of 10 Dependabot PRs we processed this week exposed two gaps:

1. **Ungrouped Actions** → PR-per-action noise.
2. **No auto-merge + `main` requires up-to-date branches** → every merge re-staled the others, forcing a one-per-CI-cycle manual rebase cascade.

## Deliberately *not* done

- **Majors are not ignored.** Blanket-ignoring `version-update:semver-major` would also suppress security fixes that are only available in a new major — exactly the shape of the vitest 2 → 3 CVE patch ([GHSA-5xrq-8626-4rwp](https://github.com/advisories/GHSA-5xrq-8626-4rwp)) we shipped in #16. Majors still arrive as individual PRs for deliberate review, and auto-merge never touches them.

## Owner follow-up (repo settings, not code)

Two toggles make the auto-merge flow work end-to-end:

1. **Settings → General → Pull Requests → enable "Allow auto-merge"** (required for the `--auto` flag).
2. **Settings → Branches → `main` → uncheck "Require branches to be up to date before merging"** — keep the three required status checks, just drop the strict-ordering rule that causes the rebase cascade. (Low-traffic repo; CI also re-runs on `main` after each push.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)