### PR TITLE
docs: recolor npm badge orange (red read as an error state)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/Amyssjj/digital-me/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/Amyssjj/digital-me/ci.yml?branch=main&style=for-the-badge" alt="CI status"></a>
-  <a href="https://www.npmjs.com/package/digital-me"><img src="https://img.shields.io/npm/v/digital-me?label=npm&logo=npm&logoColor=white&color=CB3837&style=for-the-badge" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/digital-me"><img src="https://img.shields.io/npm/v/digital-me?label=npm&logo=npm&logoColor=white&color=F97316&style=for-the-badge" alt="npm version"></a>
   <a href="https://pypi.org/project/digital-me-dream-cycle/"><img src="https://img.shields.io/pypi/v/digital-me-dream-cycle?label=PyPI&logo=pypi&logoColor=white&color=3775A9&style=for-the-badge" alt="PyPI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>


### PR DESCRIPTION
## What

Changes the README npm badge color from npm-brand red (`CB3837`) to orange (`F97316`).

## Why

The badge was hardcoded red, which in the header row reads as an error/warning rather than a version chip — "feels like something's wrong." Orange is neutral/healthy and stays visually distinct from the blue PyPI + License badges and the green CI badge.

Before: ![red](https://img.shields.io/badge/npm-v0.1.0-CB3837?style=for-the-badge&logo=npm&logoColor=white) → After: ![orange](https://img.shields.io/badge/npm-v0.1.0-F97316?style=for-the-badge&logo=npm&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)