### PR TITLE
feat(digest): port daily digest into a product package with a contract-pinned, fail-open pipeline

### DIFF
--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -124,6 +124,7 @@ const VALID_RUNTIMES: readonly RuntimeId[] = [
   "openclaw",
   "dream-cycle",
   "dashboard",
+  "digest",
 ];
 
 // Canonical venv location for the dream-cycle Python package. Picked to
@@ -758,6 +759,116 @@ function installDreamCycle(home: string, wikiRoot?: string): number {
 }
 
 /**
+ * Install the daily-digest Python sibling package.
+ *
+ * The digest SHARES the dream-cycle venv (~/.venvs/dream-cycle): it reuses
+ * dream-cycle's brain client to register its workflow, and its optional
+ * inline-summary fallback imports dream_cycle. So this ensures that venv +
+ * dream_cycle exist (installing dream-cycle first if needed), then pip-installs
+ * the digest package into it and registers the bundled digest workflow +
+ * 7am schedule with the brain — making `digital-me install --runtime digest`
+ * a one-stop setup with no manual workflow_import.
+ */
+function installDigest(home: string, wikiRoot?: string): number {
+  const venvDir = path.join(home, ".venvs", DREAM_CYCLE_VENV_DIRNAME);
+  const venvPython = path.join(venvDir, "bin", "python3");
+
+  // Shared-venv prerequisite: the digest reuses dream-cycle's brain client and
+  // (optionally) its inline engine. If the venv isn't there yet, stand up
+  // dream-cycle first — idempotent, so this is safe when both are requested.
+  if (!existsSync(venvPython)) {
+    console.log(
+      "install digest: dream-cycle venv not found — installing dream-cycle " +
+        "first (the digest shares its venv).",
+    );
+    const dcRc = installDreamCycle(home, wikiRoot);
+    if (dcRc !== 0) {
+      console.error(
+        "install digest: prerequisite dream-cycle install failed; aborting.",
+      );
+      return dcRc;
+    }
+  }
+
+  // Source checkout → editable install; npm-installed CLI → PyPI package.
+  const repoRoot = resolveRepoRoot();
+  let pipTarget: readonly string[];
+  if (repoRoot) {
+    const packagePath = path.join(repoRoot, "packages", "services", "digest");
+    if (!existsSync(path.join(packagePath, "pyproject.toml"))) {
+      console.error(
+        `install digest: package not found at ${packagePath}. Expected pyproject.toml.`,
+      );
+      return 2;
+    }
+    pipTarget = ["-e", `${packagePath}[dev]`];
+  } else {
+    console.log(
+      "install digest: no source checkout detected — installing the " +
+        "published digital-me-digest package from PyPI.",
+    );
+    pipTarget = ["digital-me-digest"];
+  }
+
+  const venvPip = path.join(venvDir, "bin", "pip");
+  console.log(`install digest: pip install ${pipTarget.join(" ")} ...`);
+  const pipResult = spawnSync(venvPip, ["install", ...pipTarget], {
+    stdio: "inherit",
+  });
+  if (pipResult.error || pipResult.status !== 0) {
+    console.error(
+      `install digest: pip install failed (exit ${pipResult.status ?? "?"}).`,
+    );
+    return pipResult.status ?? 1;
+  }
+
+  // Smoke-check the console script registered correctly.
+  const consoleScript = path.join(venvDir, "bin", "digital-me-digest");
+  const smokeResult = spawnSync(consoleScript, ["--help"], { encoding: "utf-8" });
+  if (smokeResult.status !== 0) {
+    console.error(
+      `install digest: console script smoke-test failed ` +
+        `(exit ${smokeResult.status ?? "?"}). Install may be incomplete.`,
+    );
+    return smokeResult.status ?? 1;
+  }
+
+  // Register the bundled digest workflow + 7am schedule with the brain.
+  const installWorkflowsArgs = ["-m", "digest.install_workflows"];
+  if (wikiRoot) {
+    installWorkflowsArgs.push("--wiki-root", wikiRoot);
+  }
+  console.log(`install digest: importing bundled workflow into the brain ...`);
+  const wfResult = spawnSync(venvPython, installWorkflowsArgs, {
+    stdio: "inherit",
+  });
+  if (wfResult.status !== 0) {
+    console.error(
+      `install digest: workflow import returned exit ${wfResult.status ?? "?"}. ` +
+        `The venv is ready, but the workflow isn't imported. ` +
+        `Common causes: openclaw gateway not running, or auth token missing. ` +
+        `Re-run later with: ${venvPython} -m digest.install_workflows`,
+    );
+  }
+
+  console.log(
+    `\n[OK] installed digest:\n` +
+      `       python:    ${venvPython}\n` +
+      `       script:    ${consoleScript}\n` +
+      `       wiki root: ${wikiRoot ?? "(default; pass --wiki-root to override)"}\n` +
+      `\n` +
+      `Before the first real post, set your chat channel (no default ships):\n` +
+      `  • config.yaml →  digest:\n` +
+      `                     discord_channel: <channel:ID or target>\n` +
+      `                     channel_platform: discord   # or 'slack', etc.\n` +
+      `    or env:  DIGITAL_ME_DIGEST_CHANNEL=... DIGITAL_ME_DIGEST_PLATFORM=slack\n` +
+      `  • The digest is delivered at 07:00 daily (schedule 'daily-activity-digest').\n` +
+      `  • Verify end-to-end with: digital-me doctor`,
+  );
+  return 0;
+}
+
+/**
  * Install the Dashboard service — Vite+React frontend + Express server.
  *
  * Lays the package out at $HOME/.local/share/digital-me/dashboard/, runs
@@ -1268,6 +1379,9 @@ async function install(
     } else if (r === "dream-cycle") {
       const rc = installDreamCycle(home, wikiRoot);
       if (rc !== 0) exit = rc;
+    } else if (r === "digest") {
+      const rc = installDigest(home, wikiRoot);
+      if (rc !== 0) exit = rc;
     } else if (r === "dashboard") {
       const rc = installDashboard(home, wikiRoot);
       if (rc !== 0) exit = rc;
@@ -1469,9 +1583,10 @@ async function setup(
   // (WARN, don't abort) so a failure never blocks the rest of setup.
   if (minimal) {
     console.log(
-      "[SKIP] --minimal: skipping the dream-cycle Python venv + dashboard build.\n" +
+      "[SKIP] --minimal: skipping the dream-cycle Python venv + dashboard build + digest.\n" +
         "       Add them later with:  digital-me install --runtime dream-cycle" +
-        "  and  digital-me install --runtime dashboard",
+        "  and  digital-me install --runtime dashboard" +
+        "  and  digital-me install --runtime digest",
     );
     console.log("");
   } else {
@@ -1489,6 +1604,16 @@ async function setup(
       console.log(
         `[WARN] dashboard install returned exit ${dashRc}. setup will continue ` +
           `but the dashboard won't boot until this is fixed. ` +
+          `(Re-run setup with --minimal to skip it.)`,
+      );
+    }
+
+    // digest shares the dream-cycle venv, so it must install AFTER dream-cycle.
+    const digestRc = installDigest(home, wikiRoot);
+    if (digestRc !== 0) {
+      console.log(
+        `[WARN] digest install returned exit ${digestRc}. setup will continue ` +
+          `but the daily digest won't post until this is fixed. ` +
           `(Re-run setup with --minimal to skip it.)`,
       );
     }

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -19,15 +19,20 @@ function makeDeps(overrides: Partial<DoctorDeps> = {}): DoctorDeps {
 }
 
 describe("RUNTIME_EXPECTATIONS", () => {
-  it("ships paths for all 6 runtimes", () => {
+  it("ships paths for all 7 runtimes", () => {
     expect(Object.keys(RUNTIME_EXPECTATIONS).sort()).toEqual([
       "claude-code",
       "codex",
       "dashboard",
+      "digest",
       "dream-cycle",
       "hermes",
       "openclaw",
     ]);
+    // digest shares the dream-cycle venv — its marker is the console script there.
+    expect(RUNTIME_EXPECTATIONS["digest"]).toContain(
+      "$HOME/.venvs/dream-cycle/bin/digital-me-digest",
+    );
     expect(RUNTIME_EXPECTATIONS["claude-code"]).toContain(
       "$HOME/.claude/hooks/dm_memory_search_inject.sh",
     );

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -59,7 +59,8 @@ export type RuntimeId =
   | "hermes"
   | "openclaw"
   | "dream-cycle"
-  | "dashboard";
+  | "dashboard"
+  | "digest";
 
 /** What each runtime expects to find on disk. */
 export const RUNTIME_EXPECTATIONS: Readonly<
@@ -117,6 +118,12 @@ export const RUNTIME_EXPECTATIONS: Readonly<
     "$HOME/digital-me/.data/dashboard.json",
     "$HOME/digital-me/.data/dashboard.db",
   ],
+  // digest is a Python sibling package that SHARES the dream-cycle venv (it
+  // reuses dream-cycle's brain client for workflow registration, and its
+  // optional inline-summary fallback imports dream_cycle). After
+  // `digital-me install --runtime digest`, the console script in that shared
+  // venv marks it as set up.
+  digest: ["$HOME/.venvs/dream-cycle/bin/digital-me-digest"],
 };
 
 export function runDoctor(

--- a/packages/services/digest/LICENSE
+++ b/packages/services/digest/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Amyssjj
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/services/digest/README.md
+++ b/packages/services/digest/README.md
@@ -45,13 +45,44 @@ This package pins that seam:
 All machine-specific values resolve via `arg → env → default` (see
 [`config.py`](src/digest/config.py)). Set per install:
 
-| Value | Env var | Default |
-|---|---|---|
-| Wiki root | `DIGITAL_ME_WIKI_ROOT` | `~/digital-me` |
-| Brain DB | `DIGITAL_ME_BRAIN_DB` | `~/.openclaw/data/brain.db` |
-| Discord channel | `DIGITAL_ME_DIGEST_CHANNEL` or `config.yaml` `digest.discord_channel` | **none** (required for a real publish) |
-| openclaw CLI | `OPENCLAW_CLI` | `openclaw` on `PATH` |
-| Secondary memory log | `DIGITAL_ME_DIGEST_MEMORY_DIR` | none (skipped) |
+| Value | Env var | `config.yaml` key | Default |
+|---|---|---|---|
+| Wiki root | `DIGITAL_ME_WIKI_ROOT` | — | `~/digital-me` |
+| Brain DB | `DIGITAL_ME_BRAIN_DB` | — | `~/.openclaw/data/brain.db` |
+| Channel target | `DIGITAL_ME_DIGEST_CHANNEL` | `digest.discord_channel` | **none** (required for a real publish) |
+| Channel platform | `DIGITAL_ME_DIGEST_PLATFORM` | `digest.channel_platform` | `discord` |
+| openclaw CLI | `OPENCLAW_CLI` | — | `openclaw` on `PATH` |
+| Secondary memory log | `DIGITAL_ME_DIGEST_MEMORY_DIR` | — | none (skipped) |
+
+### Discord, Slack, or anything else
+
+The digest is **platform-agnostic**: it never speaks a chat protocol directly —
+it delegates delivery to `openclaw message send --channel <platform> --target
+<channel>`. To switch from Discord to Slack you change **config, not code**:
+
+```yaml
+# config.yaml
+digest:
+  channel_platform: slack          # the --channel value openclaw routes on
+  discord_channel: "<slack target>"  # your Slack channel/target id
+```
+
+Whether a given platform actually delivers depends on openclaw supporting that
+transport — the digest just hands it the platform + target.
+
+## Install
+
+```bash
+digital-me install --runtime digest    # just the digest
+digital-me setup                        # everything, digest included
+```
+
+The digest is a Python sibling package that **shares the dream-cycle venv**
+(`~/.venvs/dream-cycle`) — it reuses dream-cycle's brain client to register its
+workflow, and its optional inline-summary fallback imports `dream_cycle`. The
+installer ensures that venv exists (installing dream-cycle first if needed),
+pip-installs the digest into it, and registers the `daily-activity-digest`
+workflow + a 7:00am schedule with the brain — no manual `workflow_import`.
 
 ## Usage
 

--- a/packages/services/digest/README.md
+++ b/packages/services/digest/README.md
@@ -1,0 +1,62 @@
+# Digital Me — Daily Digest
+
+A small service that, once a day, gathers the cross-agent activity from your
+Digital Me ecosystem (wiki growth, taste signals, what each agent worked on),
+has an LLM agent summarize it, and publishes a digest card to Discord.
+
+It runs as three workflow steps:
+
+```
+stage ──► summarize ──► publish
+(exec)    (agent)        (exec)
+```
+
+- **stage** — gather the day's raw data, write a staging file. No LLM.
+- **summarize** — an agent reads the staging file and builds a `presentation`
+  (title, tone, blocks) + markdown, returned via `tasks.handoff`.
+- **publish** — read the handoff, **validate it against the contract**, and post
+  to Discord.
+
+## The seam contract (why this package exists)
+
+`summarize` (an LLM agent that can be swapped on any runtime update) and
+`publish` are two sides of one seam. Historically the shape that crossed that
+seam was implicit, so a producer drift — e.g. the agent emitting
+`{"type":"text","content":"…"}` when the publisher expected `text` — silently
+produced an empty digest that nobody noticed until 7am.
+
+This package pins that seam:
+
+1. **A versioned contract** — [`presentation.schema.json`](src/digest/presentation.schema.json).
+   The summarize prompt mirrors it (the producer is *told* the shape) and
+   `validate_presentation()` enforces it on read (a violation is a loud, located
+   error, not a vacuum). A test asserts the validator's enums match the schema
+   file, so prompt, validator, and schema cannot drift.
+2. **A tolerant reader** — `_block_text` / `_normalize_presentation` absorb
+   reasonable variants (`content` as well as `text`, nested dicts, `fields`) so
+   minor drift degrades instead of breaks.
+3. **Fail open** — if the handoff is missing or violates the contract, publish
+   renders deterministically from the staged data (no LLM); if even that is
+   empty it posts a minimal "nothing to report" card. The digest is **never**
+   silently dropped — only a real infra failure (Discord post) fails the step.
+
+## Configuration (nothing personal is baked into source)
+
+All machine-specific values resolve via `arg → env → default` (see
+[`config.py`](src/digest/config.py)). Set per install:
+
+| Value | Env var | Default |
+|---|---|---|
+| Wiki root | `DIGITAL_ME_WIKI_ROOT` | `~/digital-me` |
+| Brain DB | `DIGITAL_ME_BRAIN_DB` | `~/.openclaw/data/brain.db` |
+| Discord channel | `DIGITAL_ME_DIGEST_CHANNEL` or `config.yaml` `digest.discord_channel` | **none** (required for a real publish) |
+| openclaw CLI | `OPENCLAW_CLI` | `openclaw` on `PATH` |
+| Secondary memory log | `DIGITAL_ME_DIGEST_MEMORY_DIR` | none (skipped) |
+
+## Usage
+
+```bash
+python -m digest.daily_digest --stage   /tmp/daily-digest-staging.json
+python -m digest.daily_digest --publish /tmp/daily-digest-staging.json --dry-run
+python -m digest.daily_digest --publish /tmp/daily-digest-staging.json
+```

--- a/packages/services/digest/pyproject.toml
+++ b/packages/services/digest/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "digital-me-digest"
+version = "0.1.0"
+description = "Daily cross-agent activity digest for the Digital Me ecosystem, with a contract-pinned, fail-open publish pipeline."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+  { name = "Digital Me OS contributors" },
+]
+keywords = ["digest", "agents", "discord", "digital-me", "knowledge-management"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+  "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+]
+
+[project.scripts]
+digital-me-digest = "digest.daily_digest:main_cli"
+
+[project.urls]
+Homepage = "https://github.com/Amyssjj/digital-me"
+Repository = "https://github.com/Amyssjj/digital-me"
+
+[tool.hatch.build.targets.wheel]
+# `packages` bundles the whole src/digest/ tree, including workflows/*.json and
+# presentation.schema.json. Do NOT add a force-include for those (it would
+# re-add the same paths and hatchling aborts the wheel build on the collision).
+packages = ["src/digest"]

--- a/packages/services/digest/src/digest/__init__.py
+++ b/packages/services/digest/src/digest/__init__.py
@@ -1,0 +1,8 @@
+# Digital Me — Daily Digest
+# Gathers each day's cross-agent activity, has an LLM agent summarize it, and
+# publishes a Discord digest. The summarize->publish seam is governed by an
+# explicit versioned contract (presentation.schema.json) and the publisher
+# fails OPEN to a deterministic render, so a producer drift degrades the digest
+# instead of silently dropping it.
+
+__version__ = "0.1.0"

--- a/packages/services/digest/src/digest/config.py
+++ b/packages/services/digest/src/digest/config.py
@@ -1,0 +1,169 @@
+"""Path + destination resolution for the daily digest.
+
+The digest ships as a standalone package that can point at any wiki and post
+to any Discord channel — nothing personal is baked into the source. Every
+machine-specific value resolves through the same arg → env → default contract
+the dream-cycle package uses (see DIGITAL_ME_WIKI_ROOT / DIGITAL_ME_BRAIN_DB).
+
+Resolution order for each value:
+  1. explicit constructor arg (tests / callers)
+  2. environment variable
+  3. a safe, non-personal default (or None when there is no safe default)
+
+Privacy contract: NO Discord channel id, NO `~/.claude/projects/-Users-<name>`
+memory path, and NO absolute user paths live in this repo. The channel id and
+the optional memory-log directory have NO default — they are supplied per
+install via env or config.yaml, so the OSS source carries zero personal data.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_WIKI_ROOT = Path.home() / "digital-me"
+
+
+def _env_path(name: str) -> Optional[Path]:
+    val = os.environ.get(name)
+    return Path(os.path.expandvars(os.path.expanduser(val))) if val else None
+
+
+def resolve_wiki_root(wiki_root: Optional[Path] = None) -> Path:
+    """arg → $DIGITAL_ME_WIKI_ROOT → ~/digital-me."""
+    if wiki_root is not None:
+        return Path(wiki_root).expanduser().resolve()
+    env = _env_path("DIGITAL_ME_WIKI_ROOT")
+    if env is not None:
+        return env.resolve()
+    return DEFAULT_WIKI_ROOT
+
+
+def resolve_brain_db(brain_db: Optional[Path] = None) -> Path:
+    """arg → $DIGITAL_ME_BRAIN_DB → ~/.openclaw/data/brain.db."""
+    if brain_db is not None:
+        return Path(brain_db).expanduser().resolve()
+    env = _env_path("DIGITAL_ME_BRAIN_DB")
+    if env is not None:
+        return env.resolve()
+    return Path.home() / ".openclaw" / "data" / "brain.db"
+
+
+def resolve_openclaw_cli(openclaw_cli: Optional[str] = None) -> Optional[str]:
+    """arg → $OPENCLAW_CLI → `openclaw` on PATH → ~/.local/bin/openclaw.
+
+    Returns None when no openclaw binary can be located — the publisher
+    surfaces that as a clear error instead of shelling out to a hardcoded
+    user path that won't exist on another machine.
+    """
+    if openclaw_cli:
+        return openclaw_cli
+    env = os.environ.get("OPENCLAW_CLI")
+    if env:
+        return env
+    found = shutil.which("openclaw")
+    if found:
+        return found
+    fallback = Path.home() / ".local" / "bin" / "openclaw"
+    return str(fallback) if fallback.exists() else None
+
+
+def resolve_discord_channel(channel: Optional[str] = None) -> Optional[str]:
+    """arg → $DIGITAL_ME_DIGEST_CHANNEL → config.yaml `digest.discord_channel`.
+
+    NO default. A real `--publish` to Discord requires this to be set per
+    install; `--dry-run` works without it. Keeping it out of source means the
+    OSS repo never carries a personal channel id.
+    """
+    if channel:
+        return channel
+    env = os.environ.get("DIGITAL_ME_DIGEST_CHANNEL")
+    if env:
+        return env
+    return _channel_from_config()
+
+
+def resolve_memory_dir(memory_dir: Optional[Path] = None) -> Optional[Path]:
+    """arg → $DIGITAL_ME_DIGEST_MEMORY_DIR → None (skip the secondary log).
+
+    The original code hardcoded a personal Claude-memory path
+    (`~/.claude/projects/-Users-<name>/memory`). That is a per-user location
+    with no safe default, so it is opt-in via env only; when unset the digest
+    simply skips the secondary memory-log copy (the wiki `digests/` copy is
+    always written).
+    """
+    if memory_dir is not None:
+        return Path(memory_dir).expanduser().resolve()
+    env = _env_path("DIGITAL_ME_DIGEST_MEMORY_DIR")
+    return env.resolve() if env is not None else None
+
+
+def _channel_from_config() -> Optional[str]:
+    """Read `digest.discord_channel` from config.yaml if present. Best-effort:
+    never raises, returns None on any problem (missing file, no pyyaml, etc.)."""
+    cfg_env = _env_path("DIGITAL_ME_CONFIG_PATH")
+    cfg_path = cfg_env if cfg_env is not None else resolve_wiki_root() / "config.yaml"
+    if not cfg_path.exists():
+        return None
+    try:
+        import yaml  # local import: only needed when a config file exists
+        raw = yaml.safe_load(cfg_path.read_text()) or {}
+        digest = raw.get("digest") or {}
+        chan = digest.get("discord_channel")
+        return str(chan) if chan else None
+    except Exception:
+        return None
+
+
+@dataclass(frozen=True)
+class DigestPaths:
+    """Resolved, machine-specific values. Build once at import via
+    ``load_paths()`` and expose as module constants in daily_digest."""
+    wiki_root: Path
+    brain_db: Path
+    discord_channel: Optional[str]
+    openclaw_cli: Optional[str]
+    memory_dir: Optional[Path]
+
+    @property
+    def wiki_dir(self) -> Path:
+        return self.wiki_root / "wiki"
+
+    @property
+    def digest_dir(self) -> Path:
+        return self.wiki_root / "digests"
+
+    @property
+    def dream_cycle_logs(self) -> Path:
+        return self.wiki_root / "dream_cycle" / "logs"
+
+    @property
+    def skills_proposals(self) -> Path:
+        return self.wiki_root / "skills-proposals"
+
+    @property
+    def config_path(self) -> Path:
+        env = _env_path("DIGITAL_ME_CONFIG_PATH")
+        return env if env is not None else self.wiki_root / "config.yaml"
+
+
+def load_paths(
+    *,
+    wiki_root: Optional[Path] = None,
+    brain_db: Optional[Path] = None,
+    discord_channel: Optional[str] = None,
+    openclaw_cli: Optional[str] = None,
+    memory_dir: Optional[Path] = None,
+) -> DigestPaths:
+    """Resolve all machine-specific values via the arg → env → default chain."""
+    return DigestPaths(
+        wiki_root=resolve_wiki_root(wiki_root),
+        brain_db=resolve_brain_db(brain_db),
+        discord_channel=resolve_discord_channel(discord_channel),
+        openclaw_cli=resolve_openclaw_cli(openclaw_cli),
+        memory_dir=resolve_memory_dir(memory_dir),
+    )

--- a/packages/services/digest/src/digest/config.py
+++ b/packages/services/digest/src/digest/config.py
@@ -84,7 +84,25 @@ def resolve_discord_channel(channel: Optional[str] = None) -> Optional[str]:
     env = os.environ.get("DIGITAL_ME_DIGEST_CHANNEL")
     if env:
         return env
-    return _channel_from_config()
+    return _config_get("discord_channel")
+
+
+def resolve_channel_platform(platform: Optional[str] = None) -> str:
+    """arg → $DIGITAL_ME_DIGEST_PLATFORM → config.yaml `digest.channel_platform`
+    → "discord".
+
+    This is the chat platform the digest delegates delivery to (the `--channel`
+    value passed to `openclaw message send`). The digest itself is platform-
+    agnostic: a Slack user sets this to "slack" (plus a slack channel target) and
+    nothing in the digest code changes — delivery rides openclaw's transport,
+    which is the layer that actually speaks Discord/Slack/etc.
+    """
+    if platform:
+        return platform
+    env = os.environ.get("DIGITAL_ME_DIGEST_PLATFORM")
+    if env:
+        return env
+    return _config_get("channel_platform") or "discord"
 
 
 def resolve_memory_dir(memory_dir: Optional[Path] = None) -> Optional[Path]:
@@ -102,9 +120,9 @@ def resolve_memory_dir(memory_dir: Optional[Path] = None) -> Optional[Path]:
     return env.resolve() if env is not None else None
 
 
-def _channel_from_config() -> Optional[str]:
-    """Read `digest.discord_channel` from config.yaml if present. Best-effort:
-    never raises, returns None on any problem (missing file, no pyyaml, etc.)."""
+def _config_get(key: str) -> Optional[str]:
+    """Read `digest.<key>` from config.yaml if present. Best-effort: never
+    raises, returns None on any problem (missing file, no pyyaml, etc.)."""
     cfg_env = _env_path("DIGITAL_ME_CONFIG_PATH")
     cfg_path = cfg_env if cfg_env is not None else resolve_wiki_root() / "config.yaml"
     if not cfg_path.exists():
@@ -113,8 +131,8 @@ def _channel_from_config() -> Optional[str]:
         import yaml  # local import: only needed when a config file exists
         raw = yaml.safe_load(cfg_path.read_text()) or {}
         digest = raw.get("digest") or {}
-        chan = digest.get("discord_channel")
-        return str(chan) if chan else None
+        val = digest.get(key)
+        return str(val) if val else None
     except Exception:
         return None
 
@@ -126,6 +144,7 @@ class DigestPaths:
     wiki_root: Path
     brain_db: Path
     discord_channel: Optional[str]
+    channel_platform: str
     openclaw_cli: Optional[str]
     memory_dir: Optional[Path]
 
@@ -156,6 +175,7 @@ def load_paths(
     wiki_root: Optional[Path] = None,
     brain_db: Optional[Path] = None,
     discord_channel: Optional[str] = None,
+    channel_platform: Optional[str] = None,
     openclaw_cli: Optional[str] = None,
     memory_dir: Optional[Path] = None,
 ) -> DigestPaths:
@@ -164,6 +184,7 @@ def load_paths(
         wiki_root=resolve_wiki_root(wiki_root),
         brain_db=resolve_brain_db(brain_db),
         discord_channel=resolve_discord_channel(discord_channel),
+        channel_platform=resolve_channel_platform(channel_platform),
         openclaw_cli=resolve_openclaw_cli(openclaw_cli),
         memory_dir=resolve_memory_dir(memory_dir),
     )

--- a/packages/services/digest/src/digest/daily_digest.py
+++ b/packages/services/digest/src/digest/daily_digest.py
@@ -1,0 +1,1805 @@
+#!/usr/bin/env python3
+"""
+Daily digest — split into 3 workflow steps:
+
+  Step 1 (this script with --stage):
+    Gathers raw data only. No LLM summarization.
+    Writes: tldr counts, wiki_entries, taste_entries, agent_raw_prompts
+            (mix of pre-summarized deterministic topics and raw user prompts
+            for COO to summarize in step 2).
+
+  Step 2 (COO spawn, in workflow):
+    Reads the staged raw data. Summarizes each raw prompt into one human
+    sentence. Builds the presentation JSON. Writes a polished markdown
+    version. Saves both back to the staging file.
+
+  Step 3 (this script with --publish):
+    Reads staging.presentation, posts to Discord. Writes staging.markdown
+    to memory log if present.
+
+Modes (mutually exclusive):
+  default        Single-shot: stage + ad-hoc summarize via gemini-flash +
+                 post (legacy; kept for manual one-off runs).
+  --stage <path> Step 1 only: write raw-data staging JSON.
+  --publish <path>
+                 Step 3 only: post a COO-completed presentation.
+
+Other flags:
+  --date YYYY-MM-DD  Target date (default: yesterday in PT)
+  --dry-run          Don't write or post anything; print payload
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from digest.config import load_paths
+
+ORCH_DB = Path(os.path.expanduser("~/.openclaw/data/task-orchestrator.db"))
+# Live orchestrator DB (gateway-owned). The summarize spawn returns the
+# built presentation+markdown via tasks.handoff (NOT by writing the staging
+# file — that needs an interpreter and trips OpenClaw's exec-approval gate).
+# publish reads that handoff envelope back from here. This is the same
+# stage -> spawn -> apply-reads-handoff pattern the dream cycle uses.
+#
+# All machine-specific values resolve through digest.config via the
+# arg → env → default contract. NOTHING personal (Discord channel id, user
+# paths, memory dir) is baked into this source — see config.py's privacy note.
+_PATHS = load_paths()
+BRAIN_DB = _PATHS.brain_db
+MEMORY_DIR = _PATHS.memory_dir            # Optional[Path]: None → skip secondary log
+REPO_DIGEST_DIR = _PATHS.digest_dir
+DREAM_CYCLE_LOGS = _PATHS.dream_cycle_logs
+WIKI_ROOT = _PATHS.wiki_dir
+SKILLS_PROPOSALS = _PATHS.skills_proposals
+
+SUMMARY_CACHE = Path(os.path.expanduser("~/.cache/daily-digest/topic-summaries.json"))
+
+# config.yaml is the single source of truth for which runtimes contribute
+# transcripts and where they live. `digital-me setup` auto-populates
+# `sources:` from each runtime package's `TRANSCRIPT_SOURCE` manifest, so
+# adding a new agent doesn't require editing this script. The defaults below
+# are last-resort fallbacks used only when config can't be parsed.
+DIGITAL_ME_CONFIG = _PATHS.config_path
+
+_DEFAULT_SOURCE_PATHS: dict[str, str] = {
+    "claude-code-jsonl": "~/.claude/projects",
+    "codex-jsonl": "~/.codex/sessions",
+    "openclaw-agent-jsonl": "~/.openclaw/agents",
+    "hermes-session-json": "~/.hermes/sessions",
+}
+_DEFAULT_GLOBS: dict[str, str] = {
+    "hermes-session-json": "session_*.json",
+}
+
+# Optional[str]: supplied per-install via $DIGITAL_ME_DIGEST_CHANNEL or
+# config.yaml `digest.discord_channel`. Required only for a real --publish.
+DISCORD_CHANNEL = _PATHS.discord_channel
+# Optional[str]: resolved from $OPENCLAW_CLI / PATH / ~/.local/bin; None if absent.
+OPENCLAW_CLI = _PATHS.openclaw_cli
+TZ = ZoneInfo("America/Los_Angeles")
+
+# `tone` values supported by openclaw message send --presentation:
+#   success | danger | info | warning  (subset of MessagePresentation tones)
+TONE_NORMAL = "success"
+TONE_QUIET = "info"  # nothing distilled, low-signal day
+
+
+def _load_transcript_sources() -> dict[str, dict]:
+    """Read `sources:` from digital-me/config.yaml into a dict keyed by
+    format. Falls back to baked-in defaults when the config is missing,
+    unparseable, or doesn't list a given format — so this script keeps
+    working on a fresh setup before `digital-me setup` has been run.
+    """
+    parsed: list[dict] = []
+    if DIGITAL_ME_CONFIG.exists():
+        try:
+            import yaml  # PyYAML; vendored in the user's Python env
+
+            data = yaml.safe_load(DIGITAL_ME_CONFIG.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                raw = data.get("sources")
+                if isinstance(raw, list):
+                    parsed = [s for s in raw if isinstance(s, dict)]
+        except Exception:
+            parsed = []
+
+    home = os.path.expanduser("~")
+    sources: dict[str, dict] = {}
+    for s in parsed:
+        fmt = s.get("format")
+        path = s.get("path")
+        if not isinstance(fmt, str) or not isinstance(path, str):
+            continue
+        sources[fmt] = {
+            "name": s.get("name", fmt),
+            "path": path.replace("$HOME", home).replace("${HOME}", home),
+            "format": fmt,
+            "glob": s.get("glob"),
+        }
+
+    # Fallback for any format missing from config — preserves the
+    # legacy behavior so this script keeps producing output even if
+    # the user hasn't re-run `digital-me setup` yet.
+    for fmt, default_path in _DEFAULT_SOURCE_PATHS.items():
+        if fmt in sources:
+            continue
+        sources[fmt] = {
+            "name": fmt,
+            "path": os.path.expanduser(default_path),
+            "format": fmt,
+            "glob": _DEFAULT_GLOBS.get(fmt),
+        }
+    return sources
+
+
+# ---------- Dream cycle log parsing ----------
+
+def _parse_dream_cycle_log(date_str: str) -> dict:
+    """Parse the markdown log emitted by dream_cycle.run for that date."""
+    path = DREAM_CYCLE_LOGS / f"{date_str}.md"
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    result: dict = {"compile": {}, "_path": str(path)}
+    current_section = None
+    for line in text.splitlines():
+        if line.startswith("## "):
+            current_section = line[3:].strip()
+            result[current_section] = {}
+        elif line.startswith("- ") and current_section:
+            m = re.match(r"- (\w+): (.*)", line)
+            if m:
+                k, v = m.group(1), m.group(2).strip()
+                # files_written / skill_files come as a Python literal list str
+                if v.startswith("[") and v.endswith("]"):
+                    try:
+                        import ast
+                        v = ast.literal_eval(v)
+                    except (ValueError, SyntaxError):
+                        pass
+                else:
+                    try:
+                        v = int(v)
+                    except ValueError:
+                        pass
+                result[current_section][k] = v
+    return result
+
+
+def _extract_domains(text: str) -> str:
+    """Parse `domain:` from frontmatter — supports three shapes:
+    inline list `domain: [a, b]`, block list `domain:\\n  - a\\n  - b`,
+    or single string `domain: infra` (used by skill-proposal files)."""
+    # Try inline list form: `domain: [a, b, c]`
+    m = re.search(r"^domain:\s*\[([^\]]*)\]", text, re.MULTILINE)
+    if m:
+        items = [d.strip().strip("'\"") for d in m.group(1).split(",") if d.strip()]
+        return ", ".join(items)
+    # Try block-list form
+    m = re.search(r"^domain:\s*\n((?:\s*-\s*[\w\-]+\s*\n)+)", text, re.MULTILINE)
+    if m:
+        items = re.findall(r"-\s*([\w\-]+)", m.group(1))
+        return ", ".join(items)
+    # Single-string form: `domain: infra`
+    m = re.search(r"^domain:\s*([\w\-]+)\s*$", text, re.MULTILINE)
+    if m:
+        return m.group(1)
+    return ""
+
+
+def _extract_yaml_date(text: str, key: str) -> str:
+    """Pull a YYYY-MM-DD value from frontmatter (handles quoted + unquoted forms)."""
+    m = re.search(rf"^{key}:\s*['\"]?(\d{{4}}-\d{{2}}-\d{{2}})['\"]?", text, re.MULTILINE)
+    return m.group(1) if m else ""
+
+
+def _confined_read(path: Path) -> Optional[str]:
+    """Read a text file, but ONLY if it resolves inside the wiki root.
+
+    The wiki/skill paths passed here come from the dream-cycle activity log
+    (`files_written` / `skill_files`) — a semi-trusted local artifact. Confining
+    the read to the wiki tree stops a poisoned log from turning the digest into
+    an arbitrary-file-read → Discord-exfiltration primitive. Returns None when
+    the path resolves outside the tree or is unreadable.
+    """
+    try:
+        resolved = path.expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+    if not resolved.is_relative_to(_PATHS.wiki_root):
+        print(f"[daily-digest] refusing to read outside wiki root: {path}",
+              file=sys.stderr)
+        return None
+    try:
+        return resolved.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _extract_entry_summary(wiki_path: Path) -> tuple[str, str, str, str]:
+    """Return (title, domains, created_date, updated_date) from a wiki entry's frontmatter."""
+    text = _confined_read(wiki_path)
+    if text is None:
+        return (wiki_path.stem, "", "", "")
+    title = wiki_path.stem.replace("-", " ")
+    m = re.search(r"^title:\s*(.+)$", text, re.MULTILINE)
+    if m:
+        title = m.group(1).strip().strip("'\"")
+    domains = _extract_domains(text)
+    created = _extract_yaml_date(text, "created")
+    updated = _extract_yaml_date(text, "updated")
+    return title, domains, created, updated
+
+
+def _extract_principle_summary(skill_path: Path) -> tuple[str, str, str, str]:
+    """Return (title, domains, created_date, updated_date) from a skill-proposal file."""
+    text = _confined_read(skill_path)
+    if text is None:
+        return (skill_path.stem, "", "", "")
+    title = skill_path.stem.replace("-", " ")
+    m = re.search(r"^title:\s*(.+)$", text, re.MULTILINE)
+    if m:
+        title = m.group(1).strip().strip("'\"")
+    domains = _extract_domains(text)
+    created = _extract_yaml_date(text, "created")
+    updated = _extract_yaml_date(text, "updated")
+    return title, domains, created, updated
+
+
+# ---------- Per-agent activity ----------
+
+# Strip date-stamped prefixes added by cron prompts, e.g. "[Wed 2026-05-13 07:00 PDT] Read and follow ..."
+_CRON_PREFIX = re.compile(r"^\s*\[[^\]]+\]\s*")
+# Recognize workflow-prompt pointers in any of the common paths
+_WORKFLOW_PATH = re.compile(r"(?:workflow-prompts|\.clawdbot/prompts(?:/[\w\-]+)?)/([\w\-]+)\.md")
+# Messages we should SKIP (boilerplate / wrappers) and look past
+_SKIP_PREFIXES = (
+    "<environment_context>",
+    "<INSTRUCTIONS>",
+    "[Inter-session message]",
+    "# AGENTS.md",
+    "The following is the Codex agent history",
+    "sourceSession=",
+    "Conversation info (untrusted metadata)",
+)
+# Special-case tags that ARE meaningful (don't skip, but render cleanly)
+_TAG_TOPICS = {
+    "<task-orchestrator-board>": "board status check",
+}
+# Recognize "You are a X worker" / "You are a X agent" — extract role
+_ROLE_PATTERN = re.compile(r"^You are an?\s+([^.]+?)(?:\.|$)", re.IGNORECASE)
+_TOPIC_FALLBACK_CHARS = 100
+
+
+def _extract_first_user_prompt(jsonl_path: Path, *, scan_lines: int = 40) -> str:
+    """Read first ~N lines of a JSONL session and return the first *meaningful*
+    user message — skipping boilerplate wrappers (<environment_context>,
+    [Inter-session message]) and looking for the next user turn after them."""
+    try:
+        with jsonl_path.open("r", encoding="utf-8", errors="ignore") as f:
+            for i, line in enumerate(f):
+                if i >= scan_lines:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                msg = r.get("message") if isinstance(r.get("message"), dict) else None
+                payload = r.get("payload") if isinstance(r.get("payload"), dict) else None
+                role = None
+                content = None
+                # Claude Code: type=user, message.content
+                if r.get("type") == "user":
+                    role = "user"
+                    content = msg.get("content") if msg else None
+                # OpenClaw: type=message, message.role=user, message.content
+                elif r.get("type") == "message" and msg and msg.get("role") == "user":
+                    role = "user"
+                    content = msg.get("content")
+                # Codex: type=response_item, payload.role=user, payload.content
+                elif r.get("type") == "response_item" and payload and payload.get("role") == "user":
+                    role = "user"
+                    content = payload.get("content")
+                if role != "user" or content is None:
+                    continue
+                text = ""
+                if isinstance(content, str):
+                    text = content
+                elif isinstance(content, list) and content:
+                    head = content[0]
+                    if isinstance(head, dict):
+                        text = head.get("text", "") or head.get("input_text", "") or ""
+                    else:
+                        text = str(head)
+                text = _CRON_PREFIX.sub("", text).strip()
+                if not text:
+                    continue
+                # Skip known wrappers and keep scanning for the real message.
+                # Special case: [Inter-session message] wraps a real routed
+                # message after the wrapper header — extract that.
+                if text.startswith("[Inter-session message]"):
+                    parts = text.split("\n\n", 1)
+                    if len(parts) == 2 and parts[1].strip():
+                        inner = parts[1].strip()
+                        if not inner.startswith(_SKIP_PREFIXES):
+                            return inner
+                    continue
+                if text.startswith(_SKIP_PREFIXES):
+                    continue
+                return text
+    except OSError:
+        return ""
+    return ""
+
+
+def _topic_from_prompt(text: str) -> str:
+    """Compress a raw user prompt to a short topic string."""
+    if not text:
+        return ""
+    # Special-case tag prompts.
+    for tag, label in _TAG_TOPICS.items():
+        if text.startswith(tag):
+            return label
+    # Workflow pointer? Use the workflow name.
+    m = _WORKFLOW_PATH.search(text)
+    if m:
+        return f"workflow: {m.group(1)}"
+    # Role declaration? Use the role description.
+    m = _ROLE_PATTERN.match(text.strip())
+    if m:
+        role = m.group(1).strip()
+        if len(role) <= _TOPIC_FALLBACK_CHARS:
+            return f"role: {role}"
+    # Drop boilerplate trailers; keep first sentence-ish.
+    first_para = text.split("\n", 1)[0]
+    if len(first_para) > _TOPIC_FALLBACK_CHARS:
+        cut = first_para[:_TOPIC_FALLBACK_CHARS].rsplit(" ", 1)[0]
+        return cut + "…"
+    return first_para
+
+
+def _dedup_topics(topics: list[str], max_distinct: int | None = None) -> list[tuple[str, int]]:
+    """Collapse repeated cron-prompt topics; returns [(topic, count)] sorted by count.
+    Pass max_distinct=None (default) to keep all distinct topics."""
+    counts: Counter = Counter()
+    for t in topics:
+        if not t:
+            continue
+        counts[t] += 1
+    return counts.most_common(max_distinct)
+
+
+# ---------- LLM summarization for human-readable topics ----------
+
+import hashlib
+
+_DETERMINISTIC_TOPIC = re.compile(r"^(workflow|role): .+$|^board status check$|^/[\w\-:]+$")
+
+
+def _load_summary_cache() -> dict:
+    try:
+        return json.loads(SUMMARY_CACHE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_summary_cache(cache: dict) -> None:
+    try:
+        SUMMARY_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        SUMMARY_CACHE.write_text(json.dumps(cache, indent=2))
+    except OSError:
+        pass
+
+
+_summarize_engine = None
+def _get_engine():
+    """Lazily build the legacy inline Gemini engine, if available.
+
+    The inline engine is DEPRECATED / fallback-only — the sanctioned LLM path
+    is the agent-spawn summarize step. It lives in the optional `dream_cycle`
+    package; when that package isn't importable we disable the inline path and
+    the digest renders deterministically. No hardcoded source path: `dream_cycle`
+    is resolved from the active environment like any other dependency.
+    """
+    global _summarize_engine, _LLM_DISABLED
+    if _summarize_engine is None:
+        try:
+            from dream_cycle.config import load_config  # type: ignore
+            from dream_cycle.engine import get_engine  # type: ignore
+            _summarize_engine = get_engine(load_config())
+        except Exception as e:
+            _LLM_DISABLED = True
+            print(f"[daily-digest] inline LLM engine unavailable ({e}); "
+                  "rendering deterministically", file=sys.stderr)
+            return None
+    return _summarize_engine
+
+
+# --- LLM hang/circuit-breaker guards -----------------------------------------
+# OpenClawEngine.llm_call has NO network timeout: if the Gemini endpoint is
+# saturated or down, the call blocks forever, the per-prompt fallback never
+# fires, and the whole digest render hangs (this is what silently killed the
+# digest — same failure class as the COO-spawn stall, different surface).
+# We bound every call with a hard wall-clock timeout and trip a circuit breaker
+# after a couple of consecutive failures so the run degrades to the regex
+# fallback instead of stalling.
+_LLM_TIMEOUT_S = int(os.environ.get("DIGEST_LLM_TIMEOUT_S", "8"))
+_LLM_MAX_CONSEC_FAILS = int(os.environ.get("DIGEST_LLM_MAX_FAILS", "2"))
+_LLM_DISABLED = os.environ.get("DIGEST_NO_LLM") == "1"
+_LLM_CONSEC_FAILS = 0
+
+
+class _LLMTimeout(Exception):
+    pass
+
+
+def _bounded_llm_call(eng, prompt: str, system: str) -> str:
+    """Call eng.llm_call with a hard SIGALRM timeout. Raises on timeout/error.
+
+    SIGALRM only arms in the main thread; this CLI is single-threaded so that
+    holds. If ever called off-thread, we skip the alarm (best-effort).
+    """
+    import signal
+    import threading
+
+    use_alarm = threading.current_thread() is threading.main_thread()
+    if use_alarm:
+        def _handler(signum, frame):
+            raise _LLMTimeout()
+        prev = signal.signal(signal.SIGALRM, _handler)
+        signal.alarm(_LLM_TIMEOUT_S)
+    try:
+        return eng.llm_call(prompt[:2000], system=system).strip()
+    finally:
+        if use_alarm:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, prev)
+
+
+_SUMMARIZE_SYSTEM = (
+    "You rewrite a user's session prompt as ONE concise sentence describing what "
+    "they're working on. Start with a past-tense verb (e.g., 'Reviewed', 'Investigated', "
+    "'Refactored', 'Asked', 'Fixed'). Strip code paths, IDs, and quoted blocks. "
+    "Maximum 20 words. Reply with ONLY the sentence — no preamble, no quotes."
+)
+
+
+def _clean_prompt_fallback(raw: str) -> str:
+    """Readable one-liner from a raw prompt when the LLM summarizer is
+    unavailable (e.g. HTTP 429 rate-limit). Pulls the slash-command name out of
+    Claude Code <command-*> wrappers, strips XML-ish tags + fenced code, and
+    collapses whitespace so the digest never renders raw markup."""
+    if not raw:
+        return ""
+    # Claude Code wraps slash commands: <command-name>/goal</command-name> …
+    m = re.search(r"<command-name>\s*(/?[\w\-:]+)\s*</command-name>", raw)
+    if m:
+        name = m.group(1)
+        args = re.search(r"<command-args>\s*(.*?)\s*</command-args>", raw, re.S)
+        arg_txt = re.sub(r"\s+", " ", (args.group(1) if args else "")).strip()
+        label = f"Invoked {name}"
+        if arg_txt:
+            label += f" — {arg_txt[:80]}"
+        return label[:140]
+    txt = re.sub(r"```.*?```", " ", raw, flags=re.S)  # fenced code
+    txt = re.sub(r"<[^>]+>", " ", txt)                 # XML-ish tags
+    txt = txt.replace("`", "")
+    txt = re.sub(r"\s+", " ", txt).strip()
+    return txt[:140]
+
+
+def _summarize_prompt(raw_prompt: str, cache: dict) -> str:
+    """Return a one-sentence human description of what the user is doing.
+
+    Skips the LLM call for already-clean deterministic topics (workflow:X,
+    role:X, board status check, slash commands) — they're readable as-is.
+    Caches everything else by SHA-16 of the prompt text so daily reruns
+    don't re-summarize repeated prompts.
+    """
+    if not raw_prompt:
+        return ""
+    if _DETERMINISTIC_TOPIC.match(raw_prompt):
+        # Convert workflow:X / role:X into a sentence
+        if raw_prompt.startswith("workflow: "):
+            return f"Ran workflow `{raw_prompt[len('workflow: '):]}`"
+        if raw_prompt.startswith("role: "):
+            return f"Acted as {raw_prompt[len('role: '):]}"
+        if raw_prompt == "board status check":
+            return "Checked task-orchestrator board status"
+        if raw_prompt.startswith("/"):
+            return f"Invoked slash command {raw_prompt}"
+    key = hashlib.sha256(raw_prompt.encode("utf-8")).hexdigest()[:16]
+    if key in cache:
+        return cache[key]
+    # Circuit breaker: once the LLM has stalled/errored repeatedly, stop calling
+    # it for the rest of the run and summarize deterministically. Bounds the
+    # worst case to ~(_LLM_MAX_CONSEC_FAILS * _LLM_TIMEOUT_S) seconds instead of
+    # hanging forever or paying the timeout on every single prompt.
+    global _LLM_CONSEC_FAILS, _LLM_DISABLED
+    if _LLM_DISABLED:
+        return _clean_prompt_fallback(raw_prompt)
+    try:
+        eng = _get_engine()
+        if eng is None:
+            return _clean_prompt_fallback(raw_prompt)
+        out = _bounded_llm_call(eng, raw_prompt, _SUMMARIZE_SYSTEM)
+        _LLM_CONSEC_FAILS = 0
+        # Strip surrounding quotes if any
+        out = out.strip('"').strip("'").strip()
+        # Sanity bound
+        if not out or len(out) > 300:
+            out = _clean_prompt_fallback(raw_prompt)
+        cache[key] = out
+        return out
+    except BaseException as e:  # incl. _LLMTimeout (raised from a signal)
+        _LLM_CONSEC_FAILS += 1
+        reason = "timed out" if isinstance(e, _LLMTimeout) else repr(e)
+        print(f"[daily-digest] summarize {reason} "
+              f"({_LLM_CONSEC_FAILS}/{_LLM_MAX_CONSEC_FAILS})", file=sys.stderr)
+        if _LLM_CONSEC_FAILS >= _LLM_MAX_CONSEC_FAILS:
+            _LLM_DISABLED = True
+            print("[daily-digest] LLM summarizer disabled for this run — "
+                  "rendering remaining prompts deterministically", file=sys.stderr)
+        return _clean_prompt_fallback(raw_prompt)
+
+
+def _summarize_and_group(raw_prompts: list[str], cache: dict) -> list[tuple[str, int]]:
+    """Summarize each prompt and group by summary. Returns [(summary, count)]."""
+    summaries = [_summarize_prompt(p, cache) for p in raw_prompts if p]
+    counts: Counter = Counter(s for s in summaries if s)
+    return counts.most_common()
+
+
+def _claude_code_raw_prompts(start_ms: int, end_ms: int, root: Path) -> list[str]:
+    """Flat list of first-user-prompts across all Claude Code sessions in window."""
+    if not root.exists():
+        return []
+    prompts: list[str] = []
+    for project_dir in root.iterdir():
+        if not project_dir.is_dir():
+            continue
+        for jsonl in project_dir.rglob("*.jsonl"):
+            try:
+                mtime_ms = int(jsonl.stat().st_mtime * 1000)
+            except OSError:
+                continue
+            if start_ms <= mtime_ms < end_ms:
+                prompt = _extract_first_user_prompt(jsonl)
+                topic = _topic_from_prompt(prompt)  # may collapse to workflow:X / role:X
+                # Prefer the cleaned topic if it's deterministic; otherwise pass
+                # the raw prompt for LLM summarization.
+                prompts.append(topic if _DETERMINISTIC_TOPIC.match(topic or "") else prompt)
+    return prompts
+
+
+def _decode_claude_project_name(encoded: str) -> str:
+    """Decode a Claude project dir name: dashes become slashes, the home prefix
+    collapses to ~, and a `.../claude/worktrees/<slug>` tail renders as a
+    `[worktree:<slug>]` label."""
+    name = encoded.replace("-", "/")
+    home = str(Path.home())
+    if name.startswith(home):
+        name = "~" + name[len(home):]
+    if name == "~" or name == "~/":
+        return "~ (home directory)"
+    # Worktrees show as `.../claude/worktrees/<slug>` after the double-slash collapse
+    m = re.match(r"(.+?)//claude/worktrees/(.+)", name)
+    if m:
+        return f"{m.group(1)} [worktree:{m.group(2)}]"
+    return name
+
+
+def _codex_raw_prompts(start_ms: int, end_ms: int, root: Path) -> list[str]:
+    """Flat list of first-user-prompts across all Codex sessions in window."""
+    if not root.exists():
+        return []
+    prompts: list[str] = []
+    for jsonl in root.rglob("*.jsonl"):
+        try:
+            mtime_ms = int(jsonl.stat().st_mtime * 1000)
+        except OSError:
+            continue
+        if not (start_ms <= mtime_ms < end_ms):
+            continue
+        prompt = _extract_first_user_prompt(jsonl)
+        topic = _topic_from_prompt(prompt)
+        prompts.append(topic if _DETERMINISTIC_TOPIC.match(topic or "") else prompt)
+    return prompts
+
+
+def _openclaw_agents_raw_prompts(
+    start_ms: int, end_ms: int, root: Path,
+) -> dict[str, list[str]]:
+    """Per-agent flat lists of first-user-prompts (or deterministic topics)."""
+    if not root.exists():
+        return {}
+    out: dict[str, list[str]] = {}
+    for agent_dir in sorted(root.iterdir()):
+        if not agent_dir.is_dir():
+            continue
+        prompts: list[str] = []
+        for f in agent_dir.rglob("*.jsonl"):
+            if f.name.endswith(".trajectory.jsonl"):
+                continue
+            try:
+                mtime_ms = int(f.stat().st_mtime * 1000)
+            except OSError:
+                continue
+            if start_ms <= mtime_ms < end_ms:
+                prompt = _extract_first_user_prompt(f)
+                topic = _topic_from_prompt(prompt)
+                prompts.append(topic if _DETERMINISTIC_TOPIC.match(topic or "") else prompt)
+        if prompts:
+            out[agent_dir.name] = prompts
+    return out
+
+
+def _extract_first_user_prompt_from_hermes_session(json_path: Path) -> str:
+    """Read a Hermes `session_*.json` file and return its first meaningful
+    user message. Hermes stores the whole session as one JSON object with
+    a `messages: [{role, content}]` list — unlike the JSONL-per-turn shape
+    Claude Code / Codex / OpenClaw use."""
+    try:
+        with json_path.open("r", encoding="utf-8", errors="ignore") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        return ""
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        text = ""
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list) and content:
+            head = content[0]
+            if isinstance(head, dict):
+                text = head.get("text") or head.get("input_text") or ""
+            else:
+                text = str(head)
+        text = _CRON_PREFIX.sub("", text).strip()
+        if not text or text.startswith(_SKIP_PREFIXES):
+            continue
+        if text.startswith("[Inter-session message]"):
+            parts = text.split("\n\n", 1)
+            if len(parts) == 2 and parts[1].strip():
+                inner = parts[1].strip()
+                if not inner.startswith(_SKIP_PREFIXES):
+                    return inner
+            continue
+        return text
+    return ""
+
+
+def _hermes_raw_prompts(
+    start_ms: int, end_ms: int, root: Path, glob: str | None,
+) -> list[str]:
+    """Flat list of first-user-prompts across all Hermes sessions in window."""
+    if not root.exists():
+        return []
+    pattern = glob or "session_*.json"
+    prompts: list[str] = []
+    for f in root.glob(pattern):
+        try:
+            mtime_ms = int(f.stat().st_mtime * 1000)
+        except OSError:
+            continue
+        if not (start_ms <= mtime_ms < end_ms):
+            continue
+        prompt = _extract_first_user_prompt_from_hermes_session(f)
+        if not prompt:
+            continue
+        topic = _topic_from_prompt(prompt)
+        prompts.append(topic if _DETERMINISTIC_TOPIC.match(topic or "") else prompt)
+    return prompts
+
+
+def _coo_goals(start_ms: int, end_ms: int) -> list[tuple[str, int]]:
+    """Goals worked on by COO (orchestrator-tracked) yesterday — secondary signal
+    for the COO line; supplements session-count with goal names."""
+    db = sqlite3.connect(f"file:{ORCH_DB}?mode=ro", uri=True)
+    rows = db.execute(
+        """
+        SELECT g.name AS goal_name, COUNT(*) AS n
+          FROM tasks t
+          JOIN goals g ON g.id = t.goal_id
+         WHERE t.status = 'completed'
+           AND t.completed_at BETWEEN ? AND ?
+           AND json_extract(t.dispatch, '$.agentId') = 'coo'
+         GROUP BY g.name
+         ORDER BY n DESC
+        """,
+        (start_ms, end_ms),
+    ).fetchall()
+    db.close()
+    return rows
+
+
+def _count_active_agents(cc_projects, codex_sessions, openclaw_agents) -> int:
+    """Active agent count: distinct OpenClaw agents + Claude Code (if any) + Codex (if any)."""
+    n = len(openclaw_agents)
+    if cc_projects:
+        n += 1
+    if codex_sessions:
+        n += 1
+    return n
+
+
+# ---------- Render ----------
+
+def render_full(date_str: str) -> tuple[str, dict]:
+    """Render the full markdown digest + a structured dict for components.
+
+    The dream cycle that captures `date_str`'s activity runs in the early
+    morning of the *following* day. So a digest for 2026-05-14 reads the
+    dream cycle log dated 2026-05-15 (which fired at 2:47 AM with data
+    covering everything up to that moment).
+    """
+    target = datetime.date.fromisoformat(date_str)
+    dream_cycle_date = (target + datetime.timedelta(days=1)).isoformat()
+    log = _parse_dream_cycle_log(dream_cycle_date)
+    # Fallback: if the morning-after log isn't available yet, read the
+    # same-day log so we don't go fully empty.
+    if not log:
+        log = _parse_dream_cycle_log(date_str)
+    compile_stats = log.get("compile", {})
+
+    files_written = compile_stats.get("files_written") or []
+    if not isinstance(files_written, list):
+        files_written = []
+    # Per-file truth (executive view), not per-write counts from the log.
+    # files_written can list the same path multiple times if the dream cycle
+    # wrote to it multiple times; dedupe + classify by frontmatter dates.
+    seen_paths: set = set()
+    unique_wiki_paths = [p for p in files_written if not (p in seen_paths or seen_paths.add(p))]
+    wiki_new = 0
+    wiki_updated = 0
+    for raw_path in unique_wiki_paths:
+        _, _, created, updated = _extract_entry_summary(Path(raw_path))
+        if created == dream_cycle_date:
+            wiki_new += 1
+        elif updated == dream_cycle_date:
+            wiki_updated += 1
+
+    skill_new = compile_stats.get("skill_candidates_new", 0) or 0
+    skill_merged = compile_stats.get("skill_candidates_merged", 0) or 0
+    skill_evidence = compile_stats.get("skill_evidence_appended", 0) or 0
+    skill_promoted = compile_stats.get("skill_promotions", 0) or 0
+    taste_total = skill_new + skill_merged + skill_evidence + skill_promoted
+    skill_files = compile_stats.get("skill_files") or []
+    if not isinstance(skill_files, list):
+        skill_files = []
+    # Staged taste mode: compile defers skill writes to apply_taste.
+    apply_taste_files = log.get("apply_taste", {}).get("skill_files") or []
+    if isinstance(apply_taste_files, list):
+        skill_files = list(skill_files) + apply_taste_files
+    if taste_total == 0:
+        taste_total = len(set(skill_files))
+
+    # PT calendar-day window
+    target = datetime.date.fromisoformat(date_str)
+    start_dt = datetime.datetime.combine(target, datetime.time.min, TZ)
+    end_dt = start_dt + datetime.timedelta(days=1)
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+
+    # Collect raw prompts per agent, summarize, then group. Source
+    # paths come from digital-me/config.yaml (auto-populated by
+    # `digital-me setup` from each runtime's TRANSCRIPT_SOURCE manifest);
+    # falls back to baked-in defaults if the config is missing.
+    sources = _load_transcript_sources()
+    cache = _load_summary_cache()
+    cc_raw = _claude_code_raw_prompts(
+        start_ms, end_ms, Path(sources["claude-code-jsonl"]["path"]),
+    )
+    codex_raw = _codex_raw_prompts(
+        start_ms, end_ms, Path(sources["codex-jsonl"]["path"]),
+    )
+    openclaw_raw = _openclaw_agents_raw_prompts(
+        start_ms, end_ms, Path(sources["openclaw-agent-jsonl"]["path"]),
+    )
+    hermes_raw = _hermes_raw_prompts(
+        start_ms,
+        end_ms,
+        Path(sources["hermes-session-json"]["path"]),
+        sources["hermes-session-json"].get("glob"),
+    )
+    cc_topics = _summarize_and_group(cc_raw, cache)
+    codex_topics = _summarize_and_group(codex_raw, cache)
+    hermes_topics = _summarize_and_group(hermes_raw, cache)
+    openclaw_topics = {
+        agent: _summarize_and_group(prompts, cache)
+        for agent, prompts in openclaw_raw.items()
+    }
+    _save_summary_cache(cache)
+    coo_goals = _coo_goals(start_ms, end_ms)
+    active_agents = (
+        (1 if cc_topics else 0)
+        + (1 if codex_topics else 0)
+        + (1 if hermes_topics else 0)
+        + len(openclaw_topics)
+    )
+
+    # ----- Render markdown -----
+    lines: list[str] = [f"# Daily Digest — {date_str}", ""]
+    lines.append("## TL;DR")
+    lines.append("")
+    lines.append("| Active agents | Wiki created | Wiki updated | Taste distilled |")
+    lines.append("|---|---|---|---|")
+    taste_breakdown = (
+        f"**{taste_total}** "
+        f"(new: {skill_new}, merged: {skill_merged}, "
+        f"evidence: {skill_evidence}, promoted: {skill_promoted})"
+    )
+    lines.append(
+        f"| **{active_agents}** | **{wiki_new}** | **{wiki_updated}** | {taste_breakdown} |"
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## Deep Dive")
+    lines.append("")
+    def _entry_label(created: str, updated: str) -> str:
+        """Determine 'created' vs 'updated' relative to the dream cycle run date."""
+        if created and created == dream_cycle_date:
+            return "🟢 created"
+        if updated and updated == dream_cycle_date and created and created < dream_cycle_date:
+            return "🔵 updated"
+        # Fallback: if neither matches, show 'touched' (rare; usually a file
+        # that was overwritten without bumping `updated:`).
+        return "⚪ touched"
+
+    lines.append("### Wiki (edited yesterday — created + updated)")
+    if files_written:
+        seen = set()
+        unique_paths = [p for p in files_written if not (p in seen or seen.add(p))]
+        for i, raw_path in enumerate(unique_paths, 1):
+            p = Path(raw_path)
+            title, domains, created, updated = _extract_entry_summary(p)
+            label = _entry_label(created, updated)
+            domain_tag = f" — _{domains}_" if domains else ""
+            lines.append(f"{i}. [{label}] **{title}**{domain_tag}")
+    else:
+        lines.append("_(no wiki entries written yesterday)_")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("### Taste distilled")
+    if skill_files:
+        seen = set()
+        unique_paths = [p for p in skill_files if not (p in seen or seen.add(p))]
+        for i, raw_path in enumerate(unique_paths, 1):
+            p = Path(raw_path)
+            title, domains, created, updated = _extract_principle_summary(p)
+            label = _entry_label(created, updated)
+            domain_tag = f" — _{domains}_" if domains else ""
+            lines.append(f"{i}. [{label}] **{title}**{domain_tag}")
+    else:
+        lines.append("_(no taste principles distilled yesterday)_")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## Projects that Agents working")
+    lines.append("")
+
+    def _render_agent(label: str, topics: list[tuple[str, int]]) -> None:
+        """One bullet per topic. No paths, no cwd, no project labels."""
+        if not topics:
+            lines.append(f"- **{label}:** _no activity_")
+            return
+        lines.append(f"- **{label}:**")
+        for topic, n in topics:
+            suffix = f" (×{n})" if n > 1 else ""
+            lines.append(f"    - {topic}{suffix}")
+
+    _render_agent("Claude Code CLI", cc_topics)
+
+    by_count = sorted(
+        openclaw_topics.items(), key=lambda x: -sum(n for _, n in x[1])
+    )
+    for agent_name, topics in by_count:
+        _render_agent(f"OpenClaw - {agent_name}", topics)
+
+    _render_agent("Hermes Agent", hermes_topics)
+    _render_agent("Codex CLI", codex_topics)
+
+    full_md = "\n".join(lines)
+
+    structured = {
+        "date": date_str,
+        "dream_cycle_date": dream_cycle_date,
+        "active_agents": active_agents,
+        "wiki_new": wiki_new,
+        "wiki_updated": wiki_updated,
+        "taste_total": taste_total,
+        "skill_new": skill_new,
+        "skill_merged": skill_merged,
+        "skill_evidence": skill_evidence,
+        "skill_promoted": skill_promoted,
+        "files_written": files_written,
+        "skill_files": skill_files,
+        "cc_topics": cc_topics,
+        "codex_topics": codex_topics,
+        "hermes_topics": hermes_topics,
+        "openclaw_topics": openclaw_topics,
+        "coo_goals": coo_goals,
+    }
+    return full_md, structured
+
+
+def render_components(s: dict) -> dict:
+    tone = TONE_QUIET if s["taste_total"] == 0 else TONE_NORMAL
+    blocks: list[dict] = []
+
+    # TL;DR — aligned table inside a code fence (Discord doesn't render md tables)
+    tldr_table = (
+        "```\n"
+        "Agents  Wiki+   Wiki~   Taste\n"
+        f"{s['active_agents']:<7} {s['wiki_new']:<7} {s['wiki_updated']:<7} {s['taste_total']}\n"
+        "```"
+    )
+    if s["taste_total"]:
+        tldr_table += (
+            f"\nTaste breakdown: new {s['skill_new']} · merged {s['skill_merged']} · "
+            f"evidence {s['skill_evidence']} · promoted {s['skill_promoted']}"
+        )
+    blocks.append({"type": "text", "text": f"**TL;DR**\n{tldr_table}"})
+
+    dc_date = s.get("dream_cycle_date", "")
+
+    def _entry_label(created: str, updated: str) -> str:
+        if created and created == dc_date:
+            return "🟢 created"
+        if updated and updated == dc_date and created and created < dc_date:
+            return "🔵 updated"
+        return "⚪ touched"
+
+    # Wiki summary — title + domain + created/updated label
+    if s["files_written"]:
+        blocks.append({"type": "divider"})
+        blocks.append({"type": "text", "text": "**Wiki edited (created + updated)**"})
+        seen: set = set()
+        unique_paths = [p for p in s["files_written"] if not (p in seen or seen.add(p))]
+        wiki_lines = []
+        for i, raw_path in enumerate(unique_paths, 1):
+            p = Path(raw_path)
+            title, domains, created, updated = _extract_entry_summary(p)
+            label = _entry_label(created, updated)
+            domain_str = f" — _{domains}_" if domains else ""
+            wiki_lines.append(f"{i}. [{label}] **{title}**{domain_str}")
+        blocks.append({"type": "text", "text": "\n".join(wiki_lines)})
+
+    # Taste summary — title + domain + created/updated label
+    blocks.append({"type": "divider"})
+    if s["skill_files"]:
+        blocks.append({"type": "text", "text": "**Taste distilled**"})
+        seen = set()
+        unique_paths = [p for p in s["skill_files"] if not (p in seen or seen.add(p))]
+        taste_lines = []
+        for i, raw_path in enumerate(unique_paths, 1):
+            p = Path(raw_path)
+            title, domains, created, updated = _extract_principle_summary(p)
+            label = _entry_label(created, updated)
+            domain_str = f" — _{domains}_" if domains else ""
+            taste_lines.append(f"{i}. [{label}] **{title}**{domain_str}")
+        blocks.append({"type": "text", "text": "\n".join(taste_lines)})
+    else:
+        blocks.append({"type": "text", "text": "**Taste distilled** — _none yesterday_"})
+
+    # What each agent worked on — one topic per line, no paths
+    blocks.append({"type": "divider"})
+    blocks.append({"type": "text", "text": "**What each agent worked on**"})
+
+    def _agent_block(label: str, topics: list[tuple[str, int]]) -> str:
+        if not topics:
+            return f"**{label}** — _no activity_"
+        bullets = "\n".join(
+            f"  • {topic}" + (f" (×{n})" if n > 1 else "")
+            for topic, n in topics
+        )
+        return f"**{label}**\n{bullets}"
+
+    agent_blocks = [_agent_block("Claude Code CLI", s["cc_topics"])]
+    by_count = sorted(
+        s["openclaw_topics"].items(), key=lambda x: -sum(n for _, n in x[1])
+    )
+    for agent_name, topics in by_count:
+        agent_blocks.append(_agent_block(f"OpenClaw — {agent_name}", topics))
+    if not s["openclaw_topics"]:
+        agent_blocks.append("**OpenClaw agents** — _no activity_")
+    agent_blocks.append(_agent_block("Hermes Agent", s.get("hermes_topics", [])))
+    agent_blocks.append(_agent_block("Codex CLI", s["codex_topics"]))
+
+    # Each agent block as its own text block so the divider visual stays tight
+    for block in agent_blocks:
+        blocks.append({"type": "text", "text": block})
+
+    return {
+        "title": f"📋 Daily Digest — {s['date']}",
+        "tone": tone,
+        "blocks": blocks,
+    }
+
+
+def post_discord(presentation: dict, fallback_text: str, *, dry_run: bool) -> None:
+    # --message is CLI-required but renders ABOVE the presentation card on
+    # Discord, so passing the title duplicates it visually. Use a zero-width
+    # space so the field is non-empty but invisible in the rendered message.
+    fallback_message = "​"
+    presentation = _normalize_presentation(presentation)
+    if not any(
+        _block_text(b).strip()
+        for b in presentation.get("blocks") or []
+        if isinstance(b, dict) and b.get("type") == "text"
+    ):
+        # Fail open: never post a blank card. main() normally guarantees a
+        # visible floor; this is the final belt-and-suspenders guard.
+        title = presentation.get("title") or "Daily Digest"
+        presentation = {
+            **presentation,
+            "blocks": [{"type": "text", "text": f"_{title}: nothing to report._"}],
+        }
+    batches = list(_presentation_batches(presentation))
+    if dry_run:
+        print("[dry-run] presentation payload batches:")
+        print(json.dumps(batches, indent=2))
+        return
+    if not OPENCLAW_CLI:
+        raise SystemExit(
+            "[daily-digest] openclaw CLI not found — set $OPENCLAW_CLI or "
+            "install openclaw on PATH"
+        )
+    if not DISCORD_CHANNEL:
+        raise SystemExit(
+            "[daily-digest] no Discord channel configured — set "
+            "$DIGITAL_ME_DIGEST_CHANNEL or config.yaml digest.discord_channel"
+        )
+    for index, batch in enumerate(batches, start=1):
+        cmd = [
+            OPENCLAW_CLI, "message", "send",
+            "--channel", "discord",
+            "--target", DISCORD_CHANNEL,
+            "--presentation", json.dumps(batch),
+            "--message", fallback_message,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            # FAIL LOUDLY — orchestrator should see the task as failed so the
+            # silent-Discord-post bug from 2026-05-15 can't recur.
+            raise SystemExit(
+                f"[daily-digest] Discord post failed (batch {index}/{len(batches)}, exit {result.returncode}):\n"
+                f"stderr: {result.stderr.strip()}\n"
+                f"stdout: {result.stdout.strip()}"
+            )
+    print(
+        f"[daily-digest] Posted to Discord "
+        f"({len(presentation.get('blocks', []))} blocks in {len(batches)} messages)"
+    )
+
+
+def _block_text(block: dict) -> str:
+    """Return visible text from native, Slack-style, or handoff-style blocks."""
+    text = block.get("text")
+    if text is None:
+        text = block.get("content")
+    if isinstance(text, dict):
+        return str(text.get("text") or text.get("content") or "")
+    if text is None and isinstance(block.get("fields"), list):
+        fields = []
+        for field in block["fields"]:
+            if isinstance(field, dict):
+                fields.append(str(field.get("text") or field.get("content") or ""))
+            elif field is not None:
+                fields.append(str(field))
+        return "\n".join(fields)
+    return str(text or "")
+
+
+_READABLE_TEXT_CHARS = 1800
+_PIMR_HEADINGS = ("problem", "problems", "insight", "insights", "method", "result", "results")
+
+
+def _prepare_digest_text(text: str) -> str:
+    """Normalize rough Markdown before it becomes Discord component text."""
+    if not text:
+        return ""
+    # The summarize handoff has previously returned literal backslash-n text;
+    # render it as real line breaks when it is clearly being used as Markdown.
+    if "\\n" in text and text.count("\\n") >= max(2, text.count("\n")):
+        text = text.replace("\\n", "\n")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _looks_like_digest_heading(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if re.match(r"^#{1,4}\s+\S", stripped):
+        return True
+    if re.match(r"^\*\*[^*]{1,80}\*\*:?$", stripped):
+        return True
+    return bool(re.match(r"^(?:" + "|".join(_PIMR_HEADINGS) + r")\b\s*:", stripped, re.I))
+
+
+def _normalize_digest_line(line: str) -> str:
+    stripped = line.strip()
+    if re.match(r"^[-*]\s+", stripped):
+        return "• " + stripped[2:].strip()
+    return line.rstrip()
+
+
+def _append_divider(blocks: list[dict]) -> None:
+    if blocks and blocks[-1].get("type") != "divider":
+        blocks.append({"type": "divider"})
+
+
+def _split_readable_text(text: str, *, max_chars: int = _READABLE_TEXT_CHARS) -> list[dict]:
+    """Break one large Markdown blob into scan-friendly Discord text blocks."""
+    text = _prepare_digest_text(text)
+    if not text:
+        return []
+
+    blocks: list[dict] = []
+    current: list[str] = []
+
+    def flush() -> None:
+        nonlocal current
+        body = "\n".join(line for line in current).strip()
+        current = []
+        if not body:
+            return
+        if len(body) <= max_chars:
+            blocks.append({"type": "text", "text": body})
+            return
+        chunk: list[str] = []
+        chunk_len = 0
+        for raw_line in body.splitlines():
+            line = raw_line.rstrip()
+            line_len = len(line) + (1 if chunk else 0)
+            if chunk and chunk_len + line_len > max_chars:
+                blocks.append({"type": "text", "text": "\n".join(chunk).strip()})
+                chunk = []
+                chunk_len = 0
+            if len(line) > max_chars:
+                words = line.split()
+                for word in words:
+                    extra = len(word) + (1 if chunk else 0)
+                    if chunk and chunk_len + extra > max_chars:
+                        blocks.append({"type": "text", "text": "\n".join(chunk).strip()})
+                        chunk = []
+                        chunk_len = 0
+                    if len(word) > max_chars:
+                        for start in range(0, len(word), max_chars):
+                            blocks.append({"type": "text", "text": word[start:start + max_chars]})
+                        continue
+                    if chunk:
+                        chunk[-1] = chunk[-1] + " " + word
+                    else:
+                        chunk.append(word)
+                    chunk_len += extra
+                continue
+            chunk.append(line)
+            chunk_len += line_len
+        if chunk:
+            blocks.append({"type": "text", "text": "\n".join(chunk).strip()})
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped in {"---", "***", "___"}:
+            flush()
+            _append_divider(blocks)
+            continue
+        if _looks_like_digest_heading(stripped) and current:
+            flush()
+            _append_divider(blocks)
+        current.append(_normalize_digest_line(line))
+    flush()
+
+    while blocks and blocks[0].get("type") == "divider":
+        blocks.pop(0)
+    while blocks and blocks[-1].get("type") == "divider":
+        blocks.pop()
+    return blocks
+
+
+def _normalize_presentation(presentation: dict) -> dict:
+    """Accept native blocks, Slack-style variants, and rough Markdown blobs.
+
+    The summarize worker sometimes returns Slack-ish `section`/`header`/`divider`
+    blocks or one giant text block. The Discord publisher expects readable
+    `text`/`divider` components; normalization prevents blank or wall-of-text
+    digest posts while still preserving the worker's content.
+    """
+    normalized: list[dict] = []
+    for raw in presentation.get("blocks") or []:
+        if not isinstance(raw, dict):
+            continue
+        kind = raw.get("type")
+        if kind in {"divider", "separator"}:
+            _append_divider(normalized)
+            continue
+        if kind == "header":
+            text = _prepare_digest_text(_block_text(raw))
+            if text:
+                normalized.extend(_split_readable_text(f"**{text.strip('* ')}**"))
+            continue
+        text = _block_text(raw)
+        if text.strip():
+            normalized.extend(_split_readable_text(text))
+    while normalized and normalized[-1].get("type") == "divider":
+        normalized.pop()
+    return {**presentation, "blocks": normalized}
+
+
+# ── Presentation contract (presentation.schema.json) ────────────────────────
+# The summarize step (an LLM agent, swapped on every runtime update) and this
+# publisher are two sides of one seam. The rules below are the written,
+# versioned contract both sides agree on — they mirror presentation.schema.json,
+# which is ALSO injected into the summarize prompt so the producer is TOLD the
+# contract instead of guessing. Validating here turns producer drift (e.g.
+# `content` vs `text`, the 2026-06-28 outage) into a loud, LOCATED error rather
+# than a silently empty 7am digest — and the publish path then fails OPEN to a
+# deterministic floor instead of refusing to publish.
+_VALID_TONES = {"success", "danger", "info", "warning"}
+_VALID_BLOCK_TYPES = {"text", "header", "divider"}
+
+
+def validate_presentation(presentation: dict) -> list[str]:
+    """Return a list of contract violations ([] = valid). Pure; never raises.
+
+    Mirrors presentation.schema.json. A text/header block must carry non-empty
+    visible text — accepted under the canonical `text` key OR the tolerated
+    `content`/`fields` variants `_block_text` absorbs (tolerant reader).
+    """
+    if not isinstance(presentation, dict):
+        return ["presentation is not an object"]
+    errors: list[str] = []
+    title = presentation.get("title")
+    if not isinstance(title, str) or not title.strip():
+        errors.append("title: missing or empty")
+    tone = presentation.get("tone")
+    if tone not in _VALID_TONES:
+        errors.append(f"tone: {tone!r} not in {sorted(_VALID_TONES)}")
+    blocks = presentation.get("blocks")
+    if not isinstance(blocks, list) or not blocks:
+        errors.append("blocks: missing or empty")
+        return errors
+    has_visible = False
+    for i, block in enumerate(blocks):
+        if not isinstance(block, dict):
+            errors.append(f"blocks[{i}]: not an object")
+            continue
+        btype = block.get("type")
+        if btype not in _VALID_BLOCK_TYPES:
+            errors.append(
+                f"blocks[{i}].type: {btype!r} not in {sorted(_VALID_BLOCK_TYPES)}"
+            )
+            continue
+        if btype in ("text", "header"):
+            if _block_text(block).strip():
+                has_visible = True
+            else:
+                errors.append(f"blocks[{i}] ({btype}): empty text")
+    if not has_visible:
+        errors.append("no visible text blocks")
+    return errors
+
+
+def _minimal_presentation(date_iso: str) -> dict:
+    """The fail-open floor: a guaranteed-valid 'nothing to report' card.
+
+    Last resort. If the staging file, the agent handoff, AND the regex render
+    all yield nothing visible (e.g. a totally empty data day), the digest still
+    delivers a valid card + a warning rather than dropping silently."""
+    return {
+        "title": f"Daily Digest — {date_iso}",
+        "tone": "info",
+        "blocks": [
+            {"type": "text", "text": f"_No activity recorded for {date_iso}._"},
+        ],
+    }
+
+
+def _presentation_batches(presentation: dict) -> list[dict]:
+    """Split one presentation into Discord-safe component container batches."""
+    title = presentation.get("title")
+    tone = presentation.get("tone")
+    # Discord Components V2 containers reject oversized child lists. The CLI
+    # adds a hidden fallback text child, so cap authored children below the
+    # Discord container ceiling.
+    max_children = 7
+    # Discord also rejects containers whose combined text is too large even
+    # when every individual text component is valid. Keep each message under a
+    # conservative text budget so a long Wiki/Taste section does not poison the
+    # whole publish step.
+    max_text_chars = 2800
+    blocks = _split_oversized_text_blocks(
+        list(presentation.get("blocks") or []),
+        max_text_chars=max_text_chars,
+    )
+    batches: list[dict] = []
+    offset = 0
+    while offset < len(blocks) or not batches:
+        include_title = bool(title) and not batches
+        capacity = max_children - (1 if include_title else 0)
+        chunk: list[dict] = []
+        text_chars = len(title or "") if include_title else 0
+        while offset < len(blocks) and len(chunk) < capacity:
+            block = blocks[offset]
+            block_chars = len(str(block.get("text") or ""))
+            if chunk and text_chars + block_chars > max_text_chars:
+                break
+            chunk.append(block)
+            text_chars += block_chars
+            offset += 1
+        while chunk and chunk[0].get("type") == "divider":
+            chunk = chunk[1:]
+        if not chunk and batches:
+            continue
+        batch: dict = {"blocks": chunk}
+        if include_title:
+            batch["title"] = title
+        if tone:
+            batch["tone"] = tone
+        batches.append(batch)
+    return batches
+
+
+def _split_oversized_text_blocks(blocks: list[dict], *, max_text_chars: int) -> list[dict]:
+    """Split long text components on line boundaries before Discord submit."""
+    split_blocks: list[dict] = []
+    for block in blocks:
+        if block.get("type") != "text":
+            split_blocks.append(block)
+            continue
+        text = str(block.get("text") or "")
+        if len(text) <= max_text_chars:
+            split_blocks.append(block)
+            continue
+        lines = text.splitlines()
+        current: list[str] = []
+        current_len = 0
+        for line in lines:
+            line_len = len(line) + (1 if current else 0)
+            if current and current_len + line_len > max_text_chars:
+                split_blocks.append({**block, "text": "\n".join(current)})
+                current = []
+                current_len = 0
+            if len(line) > max_text_chars:
+                for start in range(0, len(line), max_text_chars):
+                    split_blocks.append({**block, "text": line[start:start + max_text_chars]})
+                continue
+            current.append(line)
+            current_len += line_len
+        if current:
+            split_blocks.append({**block, "text": "\n".join(current)})
+    return split_blocks
+
+
+def write_raw_staging(path: Path, target_iso: str, dream_cycle_iso: str) -> None:
+    """Gather raw data for COO to summarize in step 2.
+
+    Output JSON shape (everything below is data; presentation/markdown are
+    left null for COO to fill):
+      {
+        "date": "<target_iso>",                # yesterday in PT
+        "dream_cycle_date": "<target+1>",      # the log file we read from
+        "tldr": {
+          "active_agents": int,
+          "wiki_new": int, "wiki_updated": int,
+          "taste_total": int,
+          "skill_new": int, "skill_merged": int,
+          "skill_evidence": int, "skill_promoted": int, "skill_neither": int
+        },
+        "wiki_entries": [
+          {"title": str, "domains": str, "status": "created"|"updated"|"touched"}
+        ],
+        "taste_entries": [
+          {"title": str, "domains": str, "status": "...", "fingerprint": str}
+        ],
+        "agent_raw_prompts": {
+          "Claude Code CLI": [str, ...],   # mix of pre-summarized + raw prompts
+          "OpenClaw - <name>": [str, ...],
+          "Codex CLI": [str, ...]
+        },
+        "presentation": null,    # COO fills in (title, tone, blocks)
+        "markdown": null         # COO writes a polished markdown version
+      }
+    """
+    log = _parse_dream_cycle_log(dream_cycle_iso) or _parse_dream_cycle_log(target_iso)
+    compile_stats = log.get("compile", {})
+
+    files_written = compile_stats.get("files_written") or []
+    if not isinstance(files_written, list):
+        files_written = []
+    seen_paths: set = set()
+    unique_wiki_paths = [p for p in files_written if not (p in seen_paths or seen_paths.add(p))]
+
+    def _classify(created: str, updated: str) -> str:
+        if created and created == dream_cycle_iso:
+            return "created"
+        if updated and updated == dream_cycle_iso and created and created < dream_cycle_iso:
+            return "updated"
+        return "touched"
+
+    wiki_entries = []
+    wiki_new = wiki_updated = 0
+    for raw_path in unique_wiki_paths:
+        title, domains, created, updated = _extract_entry_summary(Path(raw_path))
+        status = _classify(created, updated)
+        if status == "created":
+            wiki_new += 1
+        elif status == "updated":
+            wiki_updated += 1
+        wiki_entries.append({"title": title, "domains": domains, "status": status})
+
+    skill_files = compile_stats.get("skill_files") or []
+    if not isinstance(skill_files, list):
+        skill_files = []
+    # Staged taste mode: compile defers skill writes to apply_taste.
+    apply_taste_files = log.get("apply_taste", {}).get("skill_files") or []
+    if isinstance(apply_taste_files, list):
+        skill_files = list(skill_files) + apply_taste_files
+    seen_paths = set()
+    unique_skill_paths = [p for p in skill_files if not (p in seen_paths or seen_paths.add(p))]
+    taste_entries = []
+    for raw_path in unique_skill_paths:
+        title, domains, created, updated = _extract_principle_summary(Path(raw_path))
+        # _extract_principle_summary returns fingerprint as 4th tuple slot
+        # historically; we need it. Re-pull via direct file read for robustness.
+        fingerprint = _read_fingerprint(Path(raw_path))
+        taste_entries.append({
+            "title": title,
+            "domains": domains,
+            "status": _classify(created, updated),
+            "fingerprint": fingerprint,
+        })
+
+    taste_total = (
+        (compile_stats.get("skill_candidates_new") or 0)
+        + (compile_stats.get("skill_candidates_merged") or 0)
+        + (compile_stats.get("skill_evidence_appended") or 0)
+        + (compile_stats.get("skill_promotions") or 0)
+    )
+    if taste_total == 0:
+        taste_total = len(unique_skill_paths)
+
+    # PT calendar-day window for session walks
+    target = datetime.date.fromisoformat(target_iso)
+    start_dt = datetime.datetime.combine(target, datetime.time.min, TZ)
+    end_dt = start_dt + datetime.timedelta(days=1)
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+
+    sources = _load_transcript_sources()
+    cc_raw = _claude_code_raw_prompts(
+        start_ms, end_ms, Path(sources["claude-code-jsonl"]["path"]),
+    )
+    codex_raw = _codex_raw_prompts(
+        start_ms, end_ms, Path(sources["codex-jsonl"]["path"]),
+    )
+    openclaw_raw = _openclaw_agents_raw_prompts(
+        start_ms, end_ms, Path(sources["openclaw-agent-jsonl"]["path"]),
+    )
+    hermes_raw = _hermes_raw_prompts(
+        start_ms,
+        end_ms,
+        Path(sources["hermes-session-json"]["path"]),
+        sources["hermes-session-json"].get("glob"),
+    )
+
+    agent_raw_prompts: dict[str, list[str]] = {}
+    if cc_raw:
+        agent_raw_prompts["Claude Code CLI"] = cc_raw
+    for agent_name, prompts in sorted(openclaw_raw.items(), key=lambda x: -len(x[1])):
+        agent_raw_prompts[f"OpenClaw - {agent_name}"] = prompts
+    if hermes_raw:
+        agent_raw_prompts["Hermes Agent"] = hermes_raw
+    if codex_raw:
+        agent_raw_prompts["Codex CLI"] = codex_raw
+
+    active_agents = (
+        (1 if cc_raw else 0)
+        + (1 if codex_raw else 0)
+        + (1 if hermes_raw else 0)
+        + len(openclaw_raw)
+    )
+
+    payload = {
+        "date": target_iso,
+        "dream_cycle_date": dream_cycle_iso,
+        "tldr": {
+            "active_agents": active_agents,
+            "wiki_new": wiki_new,
+            "wiki_updated": wiki_updated,
+            "taste_total": taste_total,
+            "skill_new": compile_stats.get("skill_candidates_new", 0) or 0,
+            "skill_merged": compile_stats.get("skill_candidates_merged", 0) or 0,
+            "skill_evidence": compile_stats.get("skill_evidence_appended", 0) or 0,
+            "skill_promoted": compile_stats.get("skill_promotions", 0) or 0,
+            "skill_neither": compile_stats.get("skill_neither", 0) or 0,
+        },
+        "wiki_entries": wiki_entries,
+        "taste_entries": taste_entries,
+        "agent_raw_prompts": agent_raw_prompts,
+        "presentation": None,
+        "markdown": None,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _read_fingerprint(skill_path: Path) -> str:
+    try:
+        text = skill_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    m = re.search(r"^principle_fingerprint:\s*(.+(?:\n  .+)*)", text, re.MULTILINE)
+    if m:
+        return re.sub(r"\s+", " ", m.group(1)).strip().strip("'\"")
+    m = re.search(r"^fingerprint:\s*(.+)$", text, re.MULTILINE)
+    if m:
+        return m.group(1).strip().strip("'\"")
+    return ""
+
+
+_ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def read_staging(path: Path) -> dict:
+    staged = json.loads(path.read_text(encoding="utf-8"))
+    # The staging file is produced by an upstream step / LLM handoff. `date`
+    # flows into titles and (potentially) filenames, so reject anything that
+    # isn't a bare YYYY-MM-DD here — the publish path then falls back to the
+    # CLI/now-derived target date instead of trusting an injected value.
+    if isinstance(staged, dict):
+        d = staged.get("date")
+        if not (isinstance(d, str) and _ISO_DATE.match(d)):
+            staged["date"] = None
+    return staged
+
+
+def _extract_handoff_payload(envelope: str) -> dict | None:
+    """Unwrap a tasks.handoff envelope and return the COO's
+    {"presentation": {...}, "markdown": "..."} payload, or None.
+
+    The COO is instructed to put the built presentation+markdown JSON in the
+    handoff `summary` (optionally fenced as ```json). The envelope itself is
+    {"deliverableState","summary","artifactPaths","recommendedNextStep"}.
+    Handles: payload directly, payload inside `summary`, fenced or bare JSON.
+    """
+    if not envelope:
+        return None
+    candidates: list[str] = []
+    try:
+        obj = json.loads(envelope)
+        if isinstance(obj, dict):
+            if "presentation" in obj or "markdown" in obj:
+                return obj
+            summ = obj.get("summary")
+            if isinstance(summ, str):
+                candidates.append(summ)
+    except (json.JSONDecodeError, TypeError):
+        pass
+    candidates.append(envelope)
+    for cand in candidates:
+        m = re.search(r"```(?:json)?\s*(\{.*\})\s*```", cand, re.S)
+        text = m.group(1) if m else cand
+        try:
+            d = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(d, dict) and (d.get("presentation") or d.get("markdown")):
+            return d
+    return None
+
+
+def load_coo_handoff() -> tuple[dict | None, str | None]:
+    """Read the most-recent digest goal's COO summarize handoff from brain.db.
+
+    Scoped to the LATEST digest goal so a stalled run (empty output) falls
+    through to the deterministic fallback instead of resurrecting stale
+    content from an older successful day. Read-only; never raises.
+    """
+    if not BRAIN_DB.exists():
+        return None, None
+    try:
+        con = sqlite3.connect(f"file:{BRAIN_DB}?mode=ro", uri=True)
+        try:
+            row = con.execute(
+                "SELECT t.latest_output FROM tasks t "
+                "JOIN goals g ON g.id = t.goal_id "
+                "WHERE g.name LIKE '%digest%' AND t.name LIKE '%summar%' "
+                "ORDER BY g.created_at DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error as e:
+        print(f"[daily-digest] brain.db read failed: {e}", file=sys.stderr)
+        return None, None
+    if not row or not row[0]:
+        return None, None
+    payload = _extract_handoff_payload(row[0])
+    if not payload:
+        return None, None
+    pres = payload.get("presentation")
+    md = payload.get("markdown")
+    if isinstance(pres, dict) and pres.get("blocks"):
+        return pres, (md if isinstance(md, str) else None)
+    return None, (md if isinstance(md, str) else None)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Daily activity digest")
+    parser.add_argument("--date", type=str, default=None,
+                        help="Target date YYYY-MM-DD (default: yesterday in PT)")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--stage", type=str, default=None,
+                        help="Compute and write presentation JSON to this path. "
+                             "No Discord post. Memory log still written.")
+    parser.add_argument("--publish", type=str, default=None,
+                        help="Read presentation JSON from this path and post to "
+                             "Discord. No re-computation.")
+    args = parser.parse_args(argv)
+
+    if args.stage and args.publish:
+        raise SystemExit("--stage and --publish are mutually exclusive")
+
+    # Determine target date once.
+    if args.date:
+        target = datetime.date.fromisoformat(args.date)
+    else:
+        now_pt = datetime.datetime.now(TZ)
+        target = (now_pt - datetime.timedelta(days=1)).date()
+    target_iso = target.isoformat()
+    dream_cycle_iso = (target + datetime.timedelta(days=1)).isoformat()
+
+    # PUBLISH mode: read COO-completed staging, post to Discord, write memory log.
+    if args.publish:
+        staging_path = Path(args.publish)
+        if not staging_path.exists():
+            raise SystemExit(f"--publish staging file not found: {staging_path}")
+        staged = read_staging(staging_path)
+        date_iso = staged.get("date") or target_iso
+        markdown = staged.get("markdown") or ""
+        global _LLM_DISABLED
+
+        # Seam contract: each candidate source must satisfy the presentation
+        # contract (presentation.schema.json) before we accept it. A violation
+        # is logged with its exact path and we fall through to the next source.
+        # Source priority (the publisher FAILS OPEN — it always delivers a
+        # valid digest; only an infra failure makes the step fail):
+        #   1. staging-file presentation (back-compat: a producer that writes it)
+        #   2. agent summarize handoff in brain.db (the sanctioned path)
+        #   3. deterministic regex render from staged data (no inline LLM)
+        #   4. minimal 'nothing to report' card (guaranteed-valid floor)
+        def _accept(candidate: dict, source: str) -> Optional[dict]:
+            errs = validate_presentation(candidate or {})
+            if errs:
+                if candidate:  # only noise-log a source that actually had data
+                    print(
+                        f"[daily-digest] {source}: contract violation "
+                        f"({len(errs)}): {'; '.join(errs[:5])}",
+                        file=sys.stderr,
+                    )
+                return None
+            print(f"[daily-digest] using {source}")
+            return candidate
+
+        presentation = _accept(staged.get("presentation") or {}, "staging-file presentation")
+
+        if presentation is None:
+            hp, hmd = load_coo_handoff()
+            if hp:
+                presentation = _accept(hp, "agent summarize handoff (brain.db)")
+                if presentation is not None and hmd and not markdown:
+                    markdown = hmd
+
+        if presentation is None:
+            # Deterministic floor — the agent summarize is best-effort polish,
+            # never a hard dependency. Force the regex summarizer (no inline
+            # Gemini) so the fallback never reintroduces the deprecated SPOF.
+            _LLM_DISABLED = True
+            print(
+                "[daily-digest] no valid agent handoff — rendering "
+                "deterministically from staged data (regex, no LLM)",
+                file=sys.stderr,
+            )
+            full_md, structured = render_full(date_iso)
+            presentation = _accept(render_components(structured), "deterministic regex render")
+            if not markdown:
+                markdown = full_md
+
+        if presentation is None:
+            # Last resort: a guaranteed-valid card. Never drop the digest.
+            print(
+                "[daily-digest] all sources empty — publishing minimal "
+                "'nothing to report' card (fail-open floor)",
+                file=sys.stderr,
+            )
+            presentation = _minimal_presentation(date_iso)
+
+        fallback = (presentation.get("title") or "Daily Digest")[:1900]
+        if args.dry_run:
+            presentation = _normalize_presentation(presentation)
+            print("[publish dry-run] presentation:")
+            print(json.dumps(presentation, indent=2))
+            return 0
+        # Write the markdown to the wiki digests dir (always) + the optional
+        # secondary memory log (only when DIGITAL_ME_DIGEST_MEMORY_DIR is set —
+        # no personal default ships in source).
+        if markdown:
+            REPO_DIGEST_DIR.mkdir(parents=True, exist_ok=True)
+            fname = f"{target_iso}-daily-digest.md"
+            (REPO_DIGEST_DIR / fname).write_text(markdown, encoding="utf-8")
+            written = [str(REPO_DIGEST_DIR)]
+            if MEMORY_DIR is not None:
+                MEMORY_DIR.mkdir(parents=True, exist_ok=True)
+                (MEMORY_DIR / fname).write_text(markdown, encoding="utf-8")
+                written.append(str(MEMORY_DIR))
+            print(f"[daily-digest] Wrote {fname} to {', '.join(written)}")
+        post_discord(presentation, fallback, dry_run=False)
+        return 0
+
+    # STAGE mode: gather raw data only, no LLM summary, no Discord post.
+    if args.stage:
+        staging_path = Path(args.stage)
+        if args.dry_run:
+            print(f"[stage dry-run] would write raw staging to {staging_path}")
+            return 0
+        write_raw_staging(staging_path, target_iso, dream_cycle_iso)
+        print(f"[daily-digest] Staged raw data to {staging_path}")
+        return 0
+
+    # DEFAULT (legacy single-shot): compute, summarize via gemini-flash, post.
+    full_md, structured = render_full(target_iso)
+    presentation = render_components(structured)
+    if args.dry_run:
+        print("=== Full markdown ===")
+        print(full_md)
+        print()
+        print("=== Presentation payload ===")
+        print(json.dumps(presentation, indent=2)[:3000])
+        return 0
+    REPO_DIGEST_DIR.mkdir(parents=True, exist_ok=True)
+    fname = f"{target_iso}-daily-digest.md"
+    (REPO_DIGEST_DIR / fname).write_text(full_md, encoding="utf-8")
+    written = [str(REPO_DIGEST_DIR)]
+    if MEMORY_DIR is not None:
+        MEMORY_DIR.mkdir(parents=True, exist_ok=True)
+        (MEMORY_DIR / fname).write_text(full_md, encoding="utf-8")
+        written.append(str(MEMORY_DIR))
+    print(f"[daily-digest] Wrote {fname} to {', '.join(written)}")
+    post_discord(presentation, full_md, dry_run=False)
+    return 0
+
+
+def main_cli() -> None:
+    """Zero-arg console-script entry point (see pyproject [project.scripts])."""
+    raise SystemExit(main(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    main_cli()

--- a/packages/services/digest/src/digest/daily_digest.py
+++ b/packages/services/digest/src/digest/daily_digest.py
@@ -86,6 +86,10 @@ _DEFAULT_GLOBS: dict[str, str] = {
 # Optional[str]: supplied per-install via $DIGITAL_ME_DIGEST_CHANNEL or
 # config.yaml `digest.discord_channel`. Required only for a real --publish.
 DISCORD_CHANNEL = _PATHS.discord_channel
+# Chat platform delivery rides openclaw's transport (the `--channel` value).
+# Defaults to "discord"; a Slack user sets digest.channel_platform=slack (+ a
+# slack target) and no digest code changes — see config.resolve_channel_platform.
+CHANNEL_PLATFORM = _PATHS.channel_platform
 # Optional[str]: resolved from $OPENCLAW_CLI / PATH / ~/.local/bin; None if absent.
 OPENCLAW_CLI = _PATHS.openclaw_cli
 TZ = ZoneInfo("America/Los_Angeles")
@@ -1077,7 +1081,7 @@ def post_discord(presentation: dict, fallback_text: str, *, dry_run: bool) -> No
     for index, batch in enumerate(batches, start=1):
         cmd = [
             OPENCLAW_CLI, "message", "send",
-            "--channel", "discord",
+            "--channel", CHANNEL_PLATFORM,
             "--target", DISCORD_CHANNEL,
             "--presentation", json.dumps(batch),
             "--message", fallback_message,
@@ -1092,7 +1096,7 @@ def post_discord(presentation: dict, fallback_text: str, *, dry_run: bool) -> No
                 f"stdout: {result.stdout.strip()}"
             )
     print(
-        f"[daily-digest] Posted to Discord "
+        f"[daily-digest] Posted to {CHANNEL_PLATFORM} "
         f"({len(presentation.get('blocks', []))} blocks in {len(batches)} messages)"
     )
 

--- a/packages/services/digest/src/digest/install_workflows.py
+++ b/packages/services/digest/src/digest/install_workflows.py
@@ -1,0 +1,112 @@
+"""Import the bundled digest workflow into the openclaw brain.
+
+Called by `digital-me install --runtime digest` after the venv + pip install
+succeed. Discovers `digest/workflows/*.json`, materializes the dispatch
+placeholders ({{python_path}}, {{wiki_root}}, plus the workflow's own
+defaults), and registers each workflow + its sibling schedule — so a fresh
+install lands a ticking 7am digest with no manual `workflow_import` step.
+
+Reuse, not reinvention: the brain client + workflow materialization + the
+idempotent delete-then-import + sibling-schedule registration all live in the
+dream-cycle package, which is installed in the same venv as the digest (the
+digest's optional inline-summary fallback already imports it). We point that
+proven machinery at the digest's own workflows directory rather than
+duplicating ~200 lines of brain-client code. If that shared infrastructure
+ever graduates into its own package, this import line is the only thing that
+moves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+from digest.config import resolve_wiki_root
+
+# Shared infra from the sibling dream-cycle package (same venv).
+from dream_cycle.install_workflows import (  # type: ignore
+    _build_install_vars,
+    install_workflows,
+)
+from dream_cycle.brain_client import BrainClientError  # type: ignore
+
+
+def _bundled_workflows_dir() -> Path:
+    """The workflows/ directory shipped inside the installed digest package."""
+    return Path(__file__).parent / "workflows"
+
+
+def discover_bundled_workflows(directory: Optional[Path] = None) -> list[Path]:
+    """List bundled workflow JSON files, excluding sibling `*.schedule.json`
+    companions (handled during import), sorted for deterministic order."""
+    d = directory or _bundled_workflows_dir()
+    if not d.exists():
+        return []
+    return sorted(
+        p for p in d.glob("*.json")
+        if p.is_file() and not p.name.endswith(".schedule.json")
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="digital-me-digest install-workflows",
+        description=(
+            "Import the bundled digest workflow into the openclaw brain. "
+            "Run by `digital-me install --runtime digest`."
+        ),
+    )
+    parser.add_argument(
+        "--wiki-root",
+        type=Path,
+        default=None,
+        help="Wiki root path (overrides $DIGITAL_ME_WIKI_ROOT; defaults to ~/digital-me).",
+    )
+    parser.add_argument(
+        "--workflows-dir",
+        type=Path,
+        default=None,
+        help="Override bundled workflows directory (default: digest/workflows/).",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    wiki_root = resolve_wiki_root(args.wiki_root)
+    python_path = sys.executable
+
+    vars = _build_install_vars(wiki_root, python_path)
+    paths = discover_bundled_workflows(args.workflows_dir)
+
+    if not paths:
+        print(
+            "install-workflows: no bundled digest workflows found — "
+            "check that the package installed correctly.",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(f"install-workflows: wiki_root={wiki_root}", file=sys.stderr)
+    print(f"install-workflows: python_path={python_path}", file=sys.stderr)
+    print(f"install-workflows: found {len(paths)} workflow(s)", file=sys.stderr)
+
+    try:
+        results = install_workflows(paths, vars)
+    except BrainClientError as e:
+        print(f"install-workflows: gateway unreachable: {e}", file=sys.stderr)
+        return 3
+
+    exit_code = 0
+    for path, ok, msg in results:
+        marker = "[OK]" if ok else "[FAIL]"
+        print(f"  {marker} {path.name}: {msg}", file=sys.stderr)
+        if not ok:
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/services/digest/src/digest/presentation.schema.json
+++ b/packages/services/digest/src/digest/presentation.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "digital-me/digest/presentation/v1",
+  "title": "Daily Digest Presentation",
+  "description": "The contract at the summarize->publish seam. The summarize step (an LLM agent) MUST emit an object of this shape; the publisher validates against it and falls open to a deterministic render on any violation. This file is the canonical contract: the summarize prompt mirrors it and validate_presentation() enforces it (a test asserts the validator's enums match this file, so the two cannot drift).",
+  "type": "object",
+  "required": ["title", "tone", "blocks"],
+  "additionalProperties": true,
+  "properties": {
+    "title": { "type": "string", "minLength": 1 },
+    "tone": { "enum": ["success", "danger", "info", "warning"] },
+    "blocks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": { "enum": ["text", "header", "divider"] },
+          "text": { "type": "string" }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "type": { "enum": ["text", "header"] } } },
+            "then": {
+              "required": ["text"],
+              "properties": { "text": { "type": "string", "minLength": 1 } }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/services/digest/src/digest/workflows/digest.json
+++ b/packages/services/digest/src/digest/workflows/digest.json
@@ -1,0 +1,92 @@
+{
+  "id": "daily-activity-digest",
+  "name": "Daily Activity Digest",
+  "description": "Single morning digest in 3 steps. Step 1 (stage, exec): gather the day's cross-agent activity with NO inline LLM and write a staging file. Step 2 (summarize, agent spawn): read the staging file and build a presentation + markdown that conforms to presentation.schema.json, returned via tasks.handoff (NOT by writing the staging file — that needs an interpreter and trips OpenClaw's exec-approval gate). Step 3 (publish, exec): read the handoff from brain.db, VALIDATE it against the contract, and post to Discord — failing OPEN to a deterministic regex render if the handoff is missing or violates the contract. Parameterized by {{wiki_root}} + {{python_path}} so a fresh install lands the same workflow against any user's wiki + venv. The summarize<->publish seam is pinned by an explicit versioned schema so a producer drift (e.g. block key `content` vs `text`) is caught loudly instead of silently dropping the digest.",
+  "version": 1,
+  "display": {
+    "mechanism_view": true
+  },
+  "variables": [
+    {
+      "name": "wiki_root",
+      "description": "Absolute path to the digital-me wiki root. The installer supplies this from --wiki-root or $DIGITAL_ME_WIKI_ROOT.",
+      "required": true
+    },
+    {
+      "name": "python_path",
+      "description": "Absolute path to a python3 interpreter that has the digest package installed. The installer auto-supplies the venv interpreter.",
+      "required": true
+    },
+    {
+      "name": "staging_path",
+      "description": "Absolute path to the staging file the stage step writes and the summarize + publish steps read. Default lives in /tmp so it doesn't pollute the wiki tree.",
+      "required": false,
+      "defaultValue": "/tmp/daily-digest-staging.json"
+    },
+    {
+      "name": "summarize_agent_id",
+      "description": "agentId for the summarize step. Should be an agent that can read a file and call tasks.handoff. Defaults to claude-code-cli (the local-CLI exec worker).",
+      "required": false,
+      "defaultValue": "claude-code-cli"
+    }
+  ],
+  "steps": [
+    {
+      "stepKey": "stage",
+      "name": "Gather raw data and stage for the summarizer",
+      "promptTemplate": "Run digest.daily_digest --stage with the staging path from this dispatch's command. Gathers the day's cross-agent activity (counts, wiki entries, taste entries, raw prompts) with NO inline LLM and writes the staging JSON.",
+      "blockedByKeys": [],
+      "dispatch": {
+        "mode": "exec",
+        "command": [
+          "{{python_path}}",
+          "-m",
+          "digest.daily_digest",
+          "--stage",
+          "{{staging_path}}"
+        ],
+        "cwd": "{{wiki_root}}"
+      },
+      "priority": "normal",
+      "onUpstreamFailure": "wait",
+      "timeoutMs": 300000,
+      "sortOrder": 0
+    },
+    {
+      "stepKey": "summarize",
+      "name": "Summarizer builds the presentation from staged data",
+      "promptTemplate": "You are building the daily activity digest from raw data staged at `{{staging_path}}`.\n\n## TOOL POLICY (critical — read first)\n- READ the staging file at `{{staging_path}}` with your Read/file tool, then parse the JSON yourself.\n- Do NOT use Bash/cat or any interpreter (node -e / python3 -c / jq / awk) — they are approval-gated and will hang unattended. Do NOT write or edit any file. You return your result ONLY via `tasks.handoff` (see Output).\n\nStaging file shape:\n```\n{\n  \"date\": \"YYYY-MM-DD\",\n  \"tldr\": {active_agents, wiki_new, wiki_updated, taste_total, skill_new, skill_merged, skill_evidence, skill_promoted, skill_neither},\n  \"wiki_entries\": [{title, domains, status: \"created\"|\"updated\"|\"touched\"}, ...],\n  \"taste_entries\": [{title, domains, status, fingerprint}, ...],\n  \"agent_raw_prompts\": { \"<agent label>\": [str, ...] }\n}\n```\n\n## Your job\nRead and understand the day's activity, then build a `presentation` with these blocks IN ORDER:\n1. TL;DR text block: a code-fenced aligned table `Agents  Wiki+  Wiki~  Taste` with the counts from `tldr`. If taste_total>0, add a one-line breakdown.\n2. `{\"type\":\"divider\"}`\n3. Wiki: a `header` block `Wiki`, then a `text` block listing each wiki entry as `N. [created | updated | touched] **title** — _domains_`.\n4. `{\"type\":\"divider\"}`\n5. Taste: a `header` block `Taste`, then a `text` block listing each taste entry the same way (fingerprint as an italic second line).\n6. `{\"type\":\"divider\"}`\n7. Executive Summary: a `header` block `Executive Summary`, then ONE `text` block — a concise 3–6 sentence narrative of what got accomplished across ALL agents. Synthesize; lead with the single most important thing. Plain editorial prose, no per-agent bullets, strip code paths/IDs. If quiet, say so in one sentence.\n\n## OUTPUT CONTRACT (presentation.schema.json — conform EXACTLY)\nThe publisher VALIDATES your output against this schema and will reject a violation (then fall back to a plain render). Match it exactly:\n```json\n{\n  \"title\": \"Daily Digest — <date>\",          // non-empty string; a leading emoji is fine\n  \"tone\": \"success | info | warning | danger\", // success if any wiki/taste growth; info if quiet; warning if breakage\n  \"blocks\": [\n    {\"type\": \"text\", \"text\": \"<string>\"},      // text blocks: key MUST be \"text\" (NOT \"content\"), non-empty\n    {\"type\": \"header\", \"text\": \"<string>\"},    // header blocks: key MUST be \"text\", non-empty\n    {\"type\": \"divider\"}                          // dividers carry no text\n  ]\n}\n```\nCRITICAL: every text/header block's visible string goes under the key `text` (a plain string), never `content`. `type` is one of text|header|divider only.\n\nAlso write a parallel plain-markdown version of the same content.\n\n## How you return data (the ONLY way)\nCall `tasks.handoff` with:\n- `deliverableState`: \"complete\"\n- `summary`: a single fenced ```json block whose object is EXACTLY {\"presentation\": {title, tone, blocks:[...]}, \"markdown\": \"<full markdown>\"}. Nothing else is parsed.\n- `recommendedNextStep`: \"publish digest\"\nThe publish step reads this handoff back from the orchestrator DB. If you write the staging file instead of handing off, publish will fall back to a plain render and your work is lost.",
+      "blockedByKeys": ["stage"],
+      "dispatch": {
+        "mode": "exec",
+        "command": ["true"],
+        "agentId": "{{summarize_agent_id}}"
+      },
+      "priority": "normal",
+      "onUpstreamFailure": "skip",
+      "timeoutMs": 600000,
+      "sortOrder": 1
+    },
+    {
+      "stepKey": "publish",
+      "name": "Validate the handoff and publish the digest to Discord",
+      "promptTemplate": "Run digest.daily_digest --publish with the staging path from this dispatch's command. Reads the summarizer's handoff from brain.db, validates it against presentation.schema.json, and posts to Discord + writes the markdown log. Fails OPEN: if the handoff is missing or violates the contract, it renders deterministically from the staged data (no inline LLM) so the digest still ships.",
+      "blockedByKeys": ["summarize"],
+      "dispatch": {
+        "mode": "exec",
+        "command": [
+          "{{python_path}}",
+          "-m",
+          "digest.daily_digest",
+          "--publish",
+          "{{staging_path}}"
+        ],
+        "cwd": "{{wiki_root}}"
+      },
+      "priority": "normal",
+      "onUpstreamFailure": "continue",
+      "timeoutMs": 120000,
+      "sortOrder": 2
+    }
+  ]
+}

--- a/packages/services/digest/src/digest/workflows/digest.schedule.json
+++ b/packages/services/digest/src/digest/workflows/digest.schedule.json
@@ -1,0 +1,8 @@
+{
+  "scheduleId": "daily-activity-digest",
+  "cronExpr": "0 7 * * *",
+  "timezone": "America/Los_Angeles",
+  "enabled": true,
+  "variables": {},
+  "_comment": "Companion schedule for digest.json. The installer registers this with the openclaw orchestrator right after import, so an install lands a ticking 7:00am-PT digest with no manual cron step. wiki_root + python_path are auto-supplied at materialize time; staging_path + summarize_agent_id use the workflow's own defaults. NOTE: schedule_add may default to UTC if it has no timezone param — register this at 0 7 * * * America/Los_Angeles (or the UTC equivalent 0 14/15 depending on DST) to keep the early-morning PT run."
+}

--- a/packages/services/digest/tests/test_config.py
+++ b/packages/services/digest/tests/test_config.py
@@ -1,0 +1,106 @@
+"""Config resolution + the privacy contract.
+
+The privacy test is a hard gate: this package ships in the public OSS repo, so
+NO personal data (a real username, an absolute /Users path, a hardcoded Discord
+channel snowflake) may appear in source. The patterns are matched generically
+so this test file itself carries no secret.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from digest import config
+
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src" / "digest"
+
+
+def _source_files():
+    return sorted(SRC_DIR.rglob("*.py")) + sorted(SRC_DIR.rglob("*.json"))
+
+
+# ── Privacy: no personal data in shipped source ─────────────────────────────
+
+# (pattern, human-readable reason). Matched case-insensitively against source.
+_FORBIDDEN = [
+    (r"/Users/[A-Za-z0-9]", "absolute macOS user path"),
+    (r"/home/[A-Za-z0-9]", "absolute Linux user home path"),
+    (r"-Users-[A-Za-z0-9]", "dash-encoded user path (Claude project dir)"),
+    (r"channel:\d{10,}", "hardcoded Discord channel snowflake"),
+    (r"\bjingshi\b", "owner username"),
+]
+
+
+@pytest.mark.parametrize("path", _source_files(), ids=lambda p: p.name)
+def test_no_personal_data_in_source(path):
+    text = path.read_text(encoding="utf-8")
+    for pattern, reason in _FORBIDDEN:
+        m = re.search(pattern, text, re.IGNORECASE)
+        assert m is None, f"{path.name}: leaked {reason}: {m.group(0)!r}"
+
+
+def test_discord_channel_is_not_a_literal():
+    """The channel must come from env/config, never a source default."""
+    src = (SRC_DIR / "daily_digest.py").read_text(encoding="utf-8")
+    # DISCORD_CHANNEL must be assigned from resolved config, not a string literal.
+    assert re.search(r'DISCORD_CHANNEL\s*=\s*["\']', src) is None
+
+
+# ── Config resolution: arg → env → default ──────────────────────────────────
+
+def test_wiki_root_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("DIGITAL_ME_WIKI_ROOT", str(tmp_path))
+    assert config.resolve_wiki_root() == tmp_path.resolve()
+
+
+def test_wiki_root_arg_wins(tmp_path):
+    assert config.resolve_wiki_root(tmp_path) == tmp_path.resolve()
+
+
+def test_brain_db_env_override(monkeypatch, tmp_path):
+    db = tmp_path / "brain.db"
+    monkeypatch.setenv("DIGITAL_ME_BRAIN_DB", str(db))
+    assert config.resolve_brain_db() == db.resolve()
+
+
+def test_discord_channel_no_default(monkeypatch, tmp_path):
+    """No env, no config.yaml → None (never a baked-in channel)."""
+    monkeypatch.delenv("DIGITAL_ME_DIGEST_CHANNEL", raising=False)
+    monkeypatch.setenv("DIGITAL_ME_WIKI_ROOT", str(tmp_path))  # empty wiki, no config
+    monkeypatch.delenv("DIGITAL_ME_CONFIG_PATH", raising=False)
+    assert config.resolve_discord_channel() is None
+
+
+def test_discord_channel_from_env(monkeypatch):
+    monkeypatch.setenv("DIGITAL_ME_DIGEST_CHANNEL", "channel:test-123")
+    assert config.resolve_discord_channel() == "channel:test-123"
+
+
+def test_discord_channel_from_config(monkeypatch, tmp_path):
+    pytest.importorskip("yaml")
+    (tmp_path / "config.yaml").write_text(
+        "digest:\n  discord_channel: channel:from-config\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("DIGITAL_ME_DIGEST_CHANNEL", raising=False)
+    monkeypatch.setenv("DIGITAL_ME_WIKI_ROOT", str(tmp_path))
+    monkeypatch.delenv("DIGITAL_ME_CONFIG_PATH", raising=False)
+    assert config.resolve_discord_channel() == "channel:from-config"
+
+
+def test_openclaw_cli_env_override(monkeypatch):
+    monkeypatch.setenv("OPENCLAW_CLI", "/custom/openclaw")
+    assert config.resolve_openclaw_cli() == "/custom/openclaw"
+
+
+def test_memory_dir_defaults_none(monkeypatch):
+    monkeypatch.delenv("DIGITAL_ME_DIGEST_MEMORY_DIR", raising=False)
+    assert config.resolve_memory_dir() is None
+
+
+def test_paths_derive_from_wiki_root(tmp_path):
+    p = config.load_paths(wiki_root=tmp_path)
+    assert p.wiki_dir == tmp_path.resolve() / "wiki"
+    assert p.digest_dir == tmp_path.resolve() / "digests"
+    assert p.skills_proposals == tmp_path.resolve() / "skills-proposals"

--- a/packages/services/digest/tests/test_config.py
+++ b/packages/services/digest/tests/test_config.py
@@ -94,6 +94,29 @@ def test_openclaw_cli_env_override(monkeypatch):
     assert config.resolve_openclaw_cli() == "/custom/openclaw"
 
 
+def test_channel_platform_defaults_discord(monkeypatch, tmp_path):
+    monkeypatch.delenv("DIGITAL_ME_DIGEST_PLATFORM", raising=False)
+    monkeypatch.setenv("DIGITAL_ME_WIKI_ROOT", str(tmp_path))  # no config.yaml
+    monkeypatch.delenv("DIGITAL_ME_CONFIG_PATH", raising=False)
+    assert config.resolve_channel_platform() == "discord"
+
+
+def test_channel_platform_env_override(monkeypatch):
+    monkeypatch.setenv("DIGITAL_ME_DIGEST_PLATFORM", "slack")
+    assert config.resolve_channel_platform() == "slack"
+
+
+def test_channel_platform_from_config(monkeypatch, tmp_path):
+    pytest.importorskip("yaml")
+    (tmp_path / "config.yaml").write_text(
+        "digest:\n  channel_platform: slack\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("DIGITAL_ME_DIGEST_PLATFORM", raising=False)
+    monkeypatch.setenv("DIGITAL_ME_WIKI_ROOT", str(tmp_path))
+    monkeypatch.delenv("DIGITAL_ME_CONFIG_PATH", raising=False)
+    assert config.resolve_channel_platform() == "slack"
+
+
 def test_memory_dir_defaults_none(monkeypatch):
     monkeypatch.delenv("DIGITAL_ME_DIGEST_MEMORY_DIR", raising=False)
     assert config.resolve_memory_dir() is None

--- a/packages/services/digest/tests/test_contract.py
+++ b/packages/services/digest/tests/test_contract.py
@@ -1,0 +1,108 @@
+"""The summarize->publish seam contract.
+
+These tests pin the exact failure class that took the digest down on
+2026-06-28: a producer emitting `{"type":"text","content":...}` while the
+publisher only recognized `text`. The contract must (a) accept that variant via
+the tolerant reader and normalize it, and (b) reject a genuinely empty
+presentation so the publish path fails open to a deterministic floor.
+"""
+
+from digest import daily_digest as dd
+
+
+def _good():
+    return {
+        "title": "Daily Digest — 2026-06-28",
+        "tone": "success",
+        "blocks": [
+            {"type": "text", "text": "Agents 4  Wiki+ 1"},
+            {"type": "divider"},
+            {"type": "header", "text": "Wiki"},
+            {"type": "text", "text": "1. created **Foo** — _infra_"},
+        ],
+    }
+
+
+def test_valid_presentation_passes():
+    assert dd.validate_presentation(_good()) == []
+
+
+def test_content_key_block_is_accepted_and_normalized():
+    """Regression for the 2026-06-28 outage: a block keyed `content` instead of
+    `text` must be treated as visible (tolerant reader) and normalized to a
+    `text`-keyed block the Discord publisher renders."""
+    pres = {
+        "title": "Daily Digest — 2026-06-28",
+        "tone": "info",
+        "blocks": [{"type": "text", "content": "Executive summary text"}],
+    }
+    # Tolerant reader sees it → contract is satisfied, NOT a silent empty.
+    assert dd.validate_presentation(pres) == []
+    # Normalization rewrites it into a visible `text` block.
+    norm = dd._normalize_presentation(pres)
+    visible = [dd._block_text(b) for b in norm["blocks"] if b.get("type") == "text"]
+    assert any("Executive summary text" in v for v in visible)
+
+
+def test_empty_blocks_flagged():
+    pres = {"title": "t", "tone": "info", "blocks": []}
+    errs = dd.validate_presentation(pres)
+    assert any("blocks" in e for e in errs)
+
+
+def test_only_dividers_has_no_visible_text():
+    pres = {"title": "t", "tone": "info", "blocks": [{"type": "divider"}]}
+    assert "no visible text blocks" in dd.validate_presentation(pres)
+
+
+def test_empty_text_block_flagged():
+    pres = {"title": "t", "tone": "info", "blocks": [{"type": "text", "text": "   "}]}
+    errs = dd.validate_presentation(pres)
+    assert any("empty text" in e for e in errs)
+    assert "no visible text blocks" in errs
+
+
+def test_bad_tone_flagged():
+    pres = _good()
+    pres["tone"] = "celebratory"
+    assert any(e.startswith("tone:") for e in dd.validate_presentation(pres))
+
+
+def test_bad_block_type_flagged():
+    pres = _good()
+    pres["blocks"].append({"type": "section", "text": "x"})
+    assert any(".type:" in e for e in dd.validate_presentation(pres))
+
+
+def test_missing_title_flagged():
+    pres = _good()
+    pres["title"] = ""
+    assert any(e.startswith("title:") for e in dd.validate_presentation(pres))
+
+
+def test_non_dict_is_invalid():
+    assert dd.validate_presentation(None) == ["presentation is not an object"]
+    assert dd.validate_presentation([]) == ["presentation is not an object"]
+
+
+def test_minimal_presentation_is_valid():
+    """The fail-open floor must always satisfy its own contract."""
+    assert dd.validate_presentation(dd._minimal_presentation("2026-06-28")) == []
+
+
+def test_validator_agrees_with_schema_file():
+    """presentation.schema.json is the canonical contract — the in-code
+    validator's enums MUST match it, so the shipped schema file is load-bearing
+    (drift fails this test) rather than decorative."""
+    import json
+    from pathlib import Path
+
+    schema = json.loads(
+        (Path(dd.__file__).parent / "presentation.schema.json").read_text()
+    )
+    schema_tones = set(schema["properties"]["tone"]["enum"])
+    schema_block_types = set(
+        schema["properties"]["blocks"]["items"]["properties"]["type"]["enum"]
+    )
+    assert dd._VALID_TONES == schema_tones
+    assert dd._VALID_BLOCK_TYPES == schema_block_types

--- a/packages/services/digest/tests/test_imports.py
+++ b/packages/services/digest/tests/test_imports.py
@@ -1,0 +1,33 @@
+"""Smoke: the package imports cleanly (no hardcoded path side-effects at import)."""
+
+
+def test_import_package():
+    import digest  # noqa: F401
+
+    assert digest.__version__
+
+
+def test_import_config():
+    from digest import config  # noqa: F401
+
+    assert hasattr(config, "load_paths")
+
+
+def test_import_daily_digest():
+    """Importing must not require any personal path to exist — module-level
+    config resolution falls back to safe defaults."""
+    from digest import daily_digest as dd
+
+    assert callable(dd.main)
+    assert callable(dd.validate_presentation)
+    assert callable(dd.main_cli)
+
+
+def test_schema_file_is_shipped():
+    from pathlib import Path
+    import json
+
+    schema = Path(__file__).resolve().parent.parent / "src" / "digest" / "presentation.schema.json"
+    assert schema.exists(), "presentation.schema.json must ship with the package"
+    data = json.loads(schema.read_text())
+    assert data["properties"]["blocks"]["items"]["properties"]["text"]["type"] == "string"

--- a/packages/services/digest/tests/test_security.py
+++ b/packages/services/digest/tests/test_security.py
@@ -1,0 +1,50 @@
+"""Path-handling safety: log-derived reads stay inside the wiki tree, and the
+staging `date` can't carry a traversal value into titles/filenames."""
+
+import json
+
+from digest import config
+from digest import daily_digest as dd
+
+
+def test_confined_read_blocks_paths_outside_wiki_root(monkeypatch, tmp_path):
+    """`files_written`/`skill_files` come from a semi-trusted local log; a path
+    outside the wiki root must NOT be read (no arbitrary-file-read → Discord)."""
+    wiki_root = tmp_path / "digital-me"
+    (wiki_root / "wiki").mkdir(parents=True)
+    inside = wiki_root / "wiki" / "entry.md"
+    inside.write_text("title: Inside", encoding="utf-8")
+    outside = tmp_path / "secret.txt"
+    outside.write_text("SECRET", encoding="utf-8")
+
+    monkeypatch.setattr(dd, "_PATHS", config.load_paths(wiki_root=wiki_root))
+
+    assert dd._confined_read(inside) == "title: Inside"
+    assert dd._confined_read(outside) is None
+    # `..` traversal from inside the tree is also refused.
+    assert dd._confined_read(wiki_root / "wiki" / ".." / ".." / "secret.txt") is None
+
+
+def test_extract_entry_summary_refuses_outside_path(monkeypatch, tmp_path):
+    wiki_root = tmp_path / "digital-me"
+    (wiki_root / "wiki").mkdir(parents=True)
+    outside = tmp_path / "id_rsa"
+    outside.write_text("PRIVATE KEY", encoding="utf-8")
+    monkeypatch.setattr(dd, "_PATHS", config.load_paths(wiki_root=wiki_root))
+
+    title, domains, created, updated = dd._extract_entry_summary(outside)
+    # Falls back to the stem only — never reads/leaks the file contents.
+    assert "PRIVATE KEY" not in (title + domains + created + updated)
+    assert title == "id_rsa"
+
+
+def test_read_staging_rejects_non_iso_date(tmp_path):
+    p = tmp_path / "staging.json"
+    p.write_text(json.dumps({"date": "../../../etc/cron.d/evil", "presentation": None}))
+    assert dd.read_staging(p)["date"] is None
+
+
+def test_read_staging_keeps_valid_iso_date(tmp_path):
+    p = tmp_path / "staging.json"
+    p.write_text(json.dumps({"date": "2026-06-28", "presentation": None}))
+    assert dd.read_staging(p)["date"] == "2026-06-28"


### PR DESCRIPTION
## Why

The daily digest was the **one pipeline that never got ported** into the product repo — it lived only in the personal wiki repo (`~/digital-me/workflows/digest/`), often uncommitted. That orphan status is the root cause of the recurring *"the digest stops sending after every openclaw update"* outage: the `stage → summarize → publish` pipeline spans several un-versioned layers whose contracts are implicit, so any update can desync one link and silently drop the digest (the 2026-06-28 break was the summarizer emitting `{"type":"text","content":…}` while the publisher only read `text`).

This gives the digest the same home `dream-cycle` already has (`packages/services/digest/`) and makes the fragile seam an **explicit, versioned, fail-open contract**.

## What

**Seam contract**
- [`presentation.schema.json`](../blob/claude/condescending-bouman-737912/packages/services/digest/src/digest/presentation.schema.json) — the canonical contract. The summarize prompt mirrors it; `validate_presentation()` enforces it on read; a test asserts the validator's enums and the schema file can't drift.
- **Fail open** — publish resolves `staging → agent handoff → deterministic regex render → minimal "nothing to report" card`. A producer drift now *degrades* the digest instead of dropping it. The tolerant reader absorbs `content`/`fields`/nested variants.

**Privacy** (this ships in the public repo)
- Nothing personal in source. Brain db, wiki root, **Discord channel**, openclaw CLI, and memory dir all resolve via `config.py`'s `arg → env → default` chain. A hard-gate test fails the build if a username, absolute user path, or hardcoded channel id appears in source.

**Security** (from the review below)
- Log-derived file reads (`files_written`/`skill_files`) are confined to the wiki root — no arbitrary-file-read → Discord exfil from a poisoned dream-cycle log.
- The staging `date` is validated as bare `YYYY-MM-DD` on ingest.

## Verification

- **35 tests pass** (contract incl. the 2026-06-28 regression, privacy scan, config resolution, security confinement + date guard).
- Wheel builds and ships the schema + workflow json.
- `stage` + `publish` proven e2e against real `brain.db` data; fail-open path exercised.
- Reviewed by 3 independent finder agents (privacy/security, correctness, removed-behavior/packaging): privacy clean, no logic bugs, no dropped behavior; the two path-handling findings are fixed in this PR.

## Follow-ups (not in this PR)
- Wire `digital-me install --runtime digest` to materialize + register the workflow (mirrors dream-cycle's `install_workflows.py`).
- Post-update e2e smoke gate so a desync is caught at update time, not at 7am.

🤖 Generated with [Claude Code](https://claude.com/claude-code)