### PR TITLE
fix(dream-cycle): forward schedule timezone on install (digest 7am-PT depends on it)

### DIFF
--- a/packages/services/dream-cycle/src/dream_cycle/brain_client.py
+++ b/packages/services/dream-cycle/src/dream_cycle/brain_client.py
@@ -234,14 +234,19 @@ class BrainClient:
         cron_expr: str,
         variables: Optional[dict[str, str]] = None,
         enabled: bool = True,
+        timezone: Optional[str] = None,
     ) -> dict[str, Any]:
         """Register a cron-style schedule that ticks the named workflow
         template. Used by install_workflows so a fresh `digital-me install`
         lands a ticking schedule alongside the bundled workflow — no
         manual `tasks.schedule_add` step required.
 
-        Re-install path is idempotent: callers should `schedule_remove`
-        first when overwriting, since the brain rejects duplicate ids."""
+        `timezone` is an IANA name (e.g. "America/Los_Angeles"). When omitted
+        the brain defaults the schedule to UTC — so a workflow that wants a
+        local-time cron MUST pass it, or `0 7 * * *` silently fires at 7am UTC
+        instead of 7am local. Re-install path is idempotent: callers should
+        `schedule_remove` first when overwriting, since the brain rejects
+        duplicate ids."""
         args: dict[str, Any] = {
             "action": "schedule_add",
             "scheduleId": schedule_id,
@@ -251,6 +256,8 @@ class BrainClient:
         }
         if variables:
             args["variables"] = variables
+        if timezone:
+            args["timezone"] = timezone
         return self._invoke("tasks", args)
 
     def schedule_remove(self, schedule_id: str) -> dict[str, Any]:

--- a/packages/services/dream-cycle/src/dream_cycle/install_workflows.py
+++ b/packages/services/dream-cycle/src/dream_cycle/install_workflows.py
@@ -133,6 +133,12 @@ def _register_sibling_schedule(
             schedule_vars[k] = v
 
     enabled = bool(sched.get("enabled", True))
+    # IANA timezone (e.g. "America/Los_Angeles"). If the sibling declares one we
+    # MUST forward it — the brain defaults to UTC otherwise, so a `0 7 * * *`
+    # local-morning cron would silently re-register at 7am UTC on every
+    # re-install. None → brain keeps its UTC default (unchanged behavior).
+    tz_raw = sched.get("timezone")
+    timezone = tz_raw if isinstance(tz_raw, str) and tz_raw.strip() else None
 
     # Idempotent install: drop any prior schedule with this id, then
     # re-create. Swallow not-found on first install.
@@ -147,10 +153,12 @@ def _register_sibling_schedule(
             cron_expr=cron_expr,
             variables=schedule_vars,
             enabled=enabled,
+            timezone=timezone,
         )
     except BrainClientError as e:
         return f"schedule_add failed: {e}"
-    return f"+ schedule '{schedule_id}' cron='{cron_expr}'"
+    tz_note = f" tz='{timezone}'" if timezone else ""
+    return f"+ schedule '{schedule_id}' cron='{cron_expr}'{tz_note}"
 
 
 def install_workflows(

--- a/packages/services/dream-cycle/tests/test_install_workflows.py
+++ b/packages/services/dream-cycle/tests/test_install_workflows.py
@@ -12,9 +12,54 @@ from dream_cycle.brain_client import BrainClientError
 from dream_cycle.install_workflows import (
     _apply_template_defaults,
     _build_install_vars,
+    _register_sibling_schedule,
     discover_bundled_workflows,
     install_workflows,
 )
+
+
+# ── _register_sibling_schedule: timezone forwarding ──────────────────────────
+
+
+def _write_sibling(tmp_path: Path, wf_name: str, sched: dict) -> Path:
+    wf = tmp_path / wf_name
+    wf.write_text(json.dumps({"id": sched.get("scheduleId", "wf")}), encoding="utf-8")
+    wf.with_suffix(".schedule.json").write_text(json.dumps(sched), encoding="utf-8")
+    return wf
+
+
+def test_sibling_schedule_forwards_declared_timezone(tmp_path: Path) -> None:
+    """A schedule.json declaring `timezone` must forward it to schedule_add —
+    otherwise the brain defaults to UTC and a local-morning cron drifts hours."""
+    wf = _write_sibling(
+        tmp_path,
+        "digest.json",
+        {
+            "scheduleId": "daily-activity-digest",
+            "cronExpr": "0 7 * * *",
+            "timezone": "America/Los_Angeles",
+            "enabled": True,
+        },
+    )
+    client = MagicMock()
+    status = _register_sibling_schedule(wf, "daily-activity-digest", {}, client)
+    kwargs = client.schedule_add.call_args.kwargs
+    assert kwargs["timezone"] == "America/Los_Angeles"
+    assert kwargs["cron_expr"] == "0 7 * * *"
+    assert "tz='America/Los_Angeles'" in (status or "")
+
+
+def test_sibling_schedule_without_timezone_passes_none(tmp_path: Path) -> None:
+    """No `timezone` key → None forwarded (brain keeps its UTC default; the
+    dream-cycle nightly schedule relies on this unchanged behavior)."""
+    wf = _write_sibling(
+        tmp_path,
+        "nightly.json",
+        {"scheduleId": "dream-cycle-nightly", "cronExpr": "0 3 * * *", "enabled": True},
+    )
+    client = MagicMock()
+    _register_sibling_schedule(wf, "dream-cycle-nightly", {}, client)
+    assert client.schedule_add.call_args.kwargs["timezone"] is None
 
 
 # ── _apply_template_defaults ─────────────────────────────────────────────


### PR DESCRIPTION
## Why

Follow-up to [#31](https://github.com/Amyssjj/digital-me/pull/31), required before deploying the digest live.

`brain_client.schedule_add` never passed `timezone`, so the brain defaulted **every** registered schedule to UTC. A sibling `schedule.json` declaring `0 7 * * *` + `America/Los_Angeles` would silently re-register at **7am UTC (11pm PT)** on each install — so deploying the digest (which re-registers its schedule) would have drifted the live 7am-PT digest by 7 hours.

The brain's MCP `schedule_add` handler already *accepts* a `timezone` field (`router.ts:495`); only the Python client dropped it.

## What

- `brain_client.schedule_add`: new optional `timezone` param, forwarded to `tasks.schedule_add`.
- `_register_sibling_schedule`: reads `timezone` from the `schedule.json` and passes it; status line notes the tz.
- No `timezone` key → `None` → brain keeps its UTC default. dream-cycle's own `nightly.schedule.json` declares none, so **its behavior is unchanged**; the digest's `digest.schedule.json` declares `America/Los_Angeles` and now registers correctly.
- Tests: timezone forwarded when declared; `None` when absent.

## Verification
- 151 dream-cycle tests pass (2 new).
- This unblocks a safe digest deploy: re-registering `daily-activity-digest` now preserves `0 7 * * * America/Los_Angeles` instead of drifting to UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)