### PR TITLE
feat(digest): post-update smoke gate — catch publisher-contract desync at update time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,39 @@ jobs:
           path: packages/services/dream-cycle/dist/*
           if-no-files-found: error
           retention-days: 7
+
+  digest-python:
+    name: digest (pytest + sdist + wheel)
+    runs-on: ubuntu-latest
+    needs: sanitize
+    defaults:
+      run:
+        working-directory: packages/services/digest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: python -m pip install --upgrade pip build
+      - run: pip install -e ".[dev]"
+      - name: pytest
+        run: pytest -q
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Install built wheel, smoke-test console script + the digest smoke gate
+        run: |
+          python -m venv /tmp/digest-wheel-venv
+          /tmp/digest-wheel-venv/bin/pip install dist/digital_me_digest-*-py3-none-any.whl
+          /tmp/digest-wheel-venv/bin/digital-me-digest --help > /dev/null
+          /tmp/digest-wheel-venv/bin/python -c "import digest.daily_digest"
+          # The smoke gate must pass from a clean wheel install — this also
+          # proves presentation.schema.json actually ships in the wheel.
+          /tmp/digest-wheel-venv/bin/python -m digest.smoke
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: digest-dist
+          path: packages/services/digest/dist/*
+          if-no-files-found: error
+          retention-days: 7

--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -759,6 +759,20 @@ function installDreamCycle(home: string, wikiRoot?: string): number {
 }
 
 /**
+ * Run the digest's hermetic smoke gate via the given venv python. Verifies the
+ * publisher contract still holds (schema present, validator agrees, fail-open
+ * floor postable, `content`-keyed blocks accepted) — the invariants whose
+ * silent violation caused the recurring 7am outages. Best-effort + non-fatal:
+ * returns the exit code and prints the smoke's own diagnostics; callers decide
+ * how loudly to react. Skips (returns 0) when the digest isn't installed.
+ */
+function runDigestSmoke(venvPython: string): number {
+  if (!existsSync(venvPython)) return 0; // digest not installed — nothing to check
+  const r = spawnSync(venvPython, ["-m", "digest.smoke"], { stdio: "inherit" });
+  return r.status ?? 1;
+}
+
+/**
  * Install the daily-digest Python sibling package.
  *
  * The digest SHARES the dream-cycle venv (~/.venvs/dream-cycle): it reuses
@@ -850,6 +864,10 @@ function installDigest(home: string, wikiRoot?: string): number {
         `Re-run later with: ${venvPython} -m digest.install_workflows`,
     );
   }
+
+  // Self-verify the publisher contract is intact (hermetic — no brain/LLM/post).
+  // A failure here means the digest can't reliably publish; surface it loudly.
+  runDigestSmoke(venvPython);
 
   console.log(
     `\n[OK] installed digest:\n` +
@@ -1464,6 +1482,30 @@ async function update(
 
   if (result.status === "failed" && result.blockers.length > 0) {
     console.error(`update failed:\n  - ${result.blockers.join("\n  - ")}`);
+  }
+
+  // Post-update smoke gate. An openclaw update re-materializes the worker/
+  // overlay layer, which historically desynced the digest's summarizer→
+  // publisher contract and silently broke the 7am cron. Catch a regression
+  // HERE, at update time, instead of at 7am. Best-effort + non-fatal: the
+  // digest may not be installed, and a digest issue must never fail an openclaw
+  // update — but it must be LOUD when it happens.
+  if (result.status !== "failed" && !opts.dryRun) {
+    const digestVenvPython = path.join(
+      home,
+      ".venvs",
+      DREAM_CYCLE_VENV_DIRNAME,
+      "bin",
+      "python3",
+    );
+    if (runDigestSmoke(digestVenvPython) !== 0) {
+      console.error(
+        "\n[WARN] post-update digest smoke FAILED — the daily digest may not " +
+          "publish (see [digest-smoke] lines above). The openclaw update itself " +
+          "succeeded. Repair with `digital-me install --runtime digest`, then " +
+          "confirm with `python -m digest.smoke`.",
+      );
+    }
   }
   return result.exitCode;
 }

--- a/packages/services/digest/README.md
+++ b/packages/services/digest/README.md
@@ -70,6 +70,20 @@ digest:
 Whether a given platform actually delivers depends on openclaw supporting that
 transport — the digest just hands it the platform + target.
 
+## Smoke gate
+
+`python -m digest.smoke` is a hermetic check (no brain, LLM, or chat transport)
+that asserts the digest can still publish: the schema ships, the validator
+agrees with it, the fail-open floor renders visible text, and the publisher
+still accepts `content`-keyed summarizer blocks (the exact shape that caused the
+2026-06-28 outage). Exit 0 = postable.
+
+It runs automatically at the end of `digital-me install --runtime digest`, and —
+crucially — after `digital-me update --runtime openclaw`, since an openclaw
+update re-materializes the worker layer that historically desynced the
+contract. A regression is caught at update time and flagged loudly, instead of
+surfacing as a silent 7am no-post.
+
 ## Install
 
 ```bash

--- a/packages/services/digest/src/digest/smoke.py
+++ b/packages/services/digest/src/digest/smoke.py
@@ -1,0 +1,173 @@
+"""Post-update / post-install smoke gate for the daily digest.
+
+The recurring digest outage was structural: an openclaw update (or any
+re-materialize of the worker/overlay layer) silently desynced the
+summarizer→publisher contract, and nobody noticed until the 7am cron failed
+closed. This smoke gate moves that detection EARLIER — it runs at update/install
+time and fails loudly if the digest can no longer produce a postable artifact.
+
+It is deliberately HERMETIC: no brain, no LLM, no chat transport, no network.
+It asserts the invariants whose violation caused real outages:
+
+  1. The installed package imports and ships its schema file (catches a wheel
+     that dropped presentation.schema.json).
+  2. The in-code validator still agrees with that schema (catches drift between
+     the prompt's declared contract and what the publisher enforces).
+  3. The fail-open floor (`_minimal_presentation`) satisfies the schema and
+     renders visible text — so a missing/garbage handoff still yields a digest.
+  4. The publisher still accepts a `content`-keyed summarizer block — the exact
+     shape that caused the 2026-06-28 "no visible text blocks" outage.
+
+A best-effort live check (5) also confirms the registered workflow still
+dispatches this package, when the brain DB is readable.
+
+Exit 0 = the digest can still publish. Non-zero = a regression caught here
+instead of at 7am.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def _check_contract() -> list[str]:
+    """Hermetic invariant checks (1–4). Returns a list of failure messages."""
+    failures: list[str] = []
+
+    from digest import daily_digest as dd
+
+    # 1. package ships its schema file
+    schema_path = Path(dd.__file__).parent / "presentation.schema.json"
+    if not schema_path.exists():
+        failures.append(
+            "presentation.schema.json missing from the installed package "
+            "(wheel/packaging regression)"
+        )
+        # Without the schema we can't run check 2, but 3 + 4 still apply.
+        schema = None
+    else:
+        try:
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            failures.append(f"presentation.schema.json unreadable/invalid: {e}")
+            schema = None
+
+    # 2. validator agrees with the schema file (no prompt↔validator drift)
+    if schema is not None:
+        try:
+            schema_tones = set(schema["properties"]["tone"]["enum"])
+            schema_types = set(
+                schema["properties"]["blocks"]["items"]["properties"]["type"]["enum"]
+            )
+            if dd._VALID_TONES != schema_tones:
+                failures.append(
+                    f"validator tones {dd._VALID_TONES} drifted from schema {schema_tones}"
+                )
+            if dd._VALID_BLOCK_TYPES != schema_types:
+                failures.append(
+                    f"validator block types {dd._VALID_BLOCK_TYPES} drifted from "
+                    f"schema {schema_types}"
+                )
+        except (KeyError, TypeError) as e:
+            failures.append(f"schema shape unexpected (cannot compare to validator): {e}")
+
+    # 3. fail-open floor is schema-valid AND renders visible text
+    floor = dd._minimal_presentation("2026-01-01")
+    floor_errors = dd.validate_presentation(floor)
+    if floor_errors:
+        failures.append(f"fail-open floor violates the schema: {floor_errors}")
+    floor_norm = dd._normalize_presentation(floor)
+    if not _has_visible_text(dd, floor_norm):
+        failures.append("fail-open floor produces no visible text after normalize")
+
+    # 4. the 2026-06-28 outage shape: a `content`-keyed block must survive
+    content_block = {
+        "title": "smoke",
+        "tone": "info",
+        "blocks": [{"type": "text", "content": "digest smoke probe"}],
+    }
+    content_norm = dd._normalize_presentation(content_block)
+    if "digest smoke probe" not in _joined_text(dd, content_norm):
+        failures.append(
+            "publisher no longer accepts `content`-keyed summarizer blocks "
+            "(the 2026-06-28 'no visible text blocks' outage shape)"
+        )
+
+    return failures
+
+
+def _has_visible_text(dd, presentation: dict) -> bool:
+    return any(
+        dd._block_text(b).strip()
+        for b in presentation.get("blocks") or []
+        if isinstance(b, dict) and b.get("type") == "text"
+    )
+
+
+def _joined_text(dd, presentation: dict) -> str:
+    return " ".join(
+        dd._block_text(b) for b in presentation.get("blocks") or [] if isinstance(b, dict)
+    )
+
+
+def _check_live_dispatch() -> Optional[str]:
+    """Best-effort (5): confirm the registered workflow still dispatches THIS
+    package. Returns a warning string, or None when OK/unknown. Never fails the
+    gate on its own — the brain may legitimately be absent at update time."""
+    from digest import daily_digest as dd
+
+    brain_db = dd.BRAIN_DB
+    if not brain_db.exists():
+        return None  # no brain to check against — not a regression
+    try:
+        con = sqlite3.connect(f"file:{brain_db}?mode=ro", uri=True)
+        try:
+            rows = con.execute(
+                "SELECT dispatch FROM workflow_step_templates "
+                "WHERE workflow_id='daily-activity-digest' AND step_key='publish'"
+            ).fetchall()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return None  # unreadable (locked/old schema) — don't fail the gate
+    if not rows:
+        return "no 'daily-activity-digest' workflow registered in the brain"
+    if "digest.daily_digest" not in (rows[0][0] or ""):
+        return (
+            "registered digest workflow does NOT dispatch this package "
+            "(publish step points elsewhere) — re-run "
+            "`python -m digest.install_workflows`"
+        )
+    return None
+
+
+def run_smoke() -> int:
+    failures = _check_contract()
+    for f in failures:
+        print(f"[digest-smoke] FAIL: {f}", file=sys.stderr)
+
+    warning = _check_live_dispatch()
+    if warning:
+        print(f"[digest-smoke] WARN: {warning}", file=sys.stderr)
+
+    if failures:
+        print(
+            f"[digest-smoke] {len(failures)} regression(s) — the digest may not "
+            "publish. See above.",
+            file=sys.stderr,
+        )
+        return 1
+    print("[digest-smoke] OK: publisher contract intact, fail-open floor postable.")
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    return run_smoke()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/services/digest/tests/test_smoke.py
+++ b/packages/services/digest/tests/test_smoke.py
@@ -1,0 +1,46 @@
+"""Tests for the post-update/install smoke gate."""
+
+from __future__ import annotations
+
+from digest import daily_digest as dd
+from digest import smoke
+
+
+def test_smoke_passes_on_healthy_package():
+    """The shipped package must pass its own smoke gate."""
+    assert smoke.run_smoke() == 0
+    assert smoke._check_contract() == []
+
+
+def test_smoke_catches_validator_schema_drift(monkeypatch):
+    """If the validator's tones drift from the schema file (the prompt↔validator
+    desync class), the gate must flag it."""
+    monkeypatch.setattr(dd, "_VALID_TONES", {"totally-bogus-tone"})
+    failures = smoke._check_contract()
+    assert any("tones" in f for f in failures)
+
+
+def test_smoke_catches_content_key_regression(monkeypatch):
+    """Reproduce the 2026-06-28 outage: a publisher that only sees `text` and
+    ignores `content` must be caught by the gate."""
+    def _text_only(presentation):
+        # Simulate the pre-fix normalizer that dropped `content`-keyed blocks.
+        blocks = []
+        for raw in presentation.get("blocks") or []:
+            if isinstance(raw, dict) and raw.get("type") == "text" and raw.get("text"):
+                blocks.append({"type": "text", "text": raw["text"]})
+        return {**presentation, "blocks": blocks}
+
+    monkeypatch.setattr(dd, "_normalize_presentation", _text_only)
+    failures = smoke._check_contract()
+    assert any("content`-keyed" in f or "content-keyed" in f for f in failures)
+
+
+def test_smoke_catches_broken_floor(monkeypatch):
+    """If the fail-open floor stops producing visible text, the digest could
+    silently publish nothing — the gate must catch it."""
+    monkeypatch.setattr(
+        dd, "_minimal_presentation", lambda _date: {"title": "x", "tone": "info", "blocks": []}
+    )
+    failures = smoke._check_contract()
+    assert failures  # empty-blocks floor violates schema (minItems) and/or visibility


### PR DESCRIPTION
## Why

The final piece to make the recurring digest outage **self-defending**. The outages were a silent contract desync — the summarizer emits a block shape the publisher rejects — discovered only when the 7am cron failed closed (e.g. the 2026-06-28 `content`-vs-`text` break). [#31](https://github.com/Amyssjj/digital-me/pull/31) made the publisher fail-open and contract-pinned; this moves *detection* to **update/install time**.

## What

- **`digest/smoke.py`** (`python -m digest.smoke`) — hermetic: no brain, LLM, or chat transport. Asserts the invariants whose violation caused real outages:
  1. the package ships `presentation.schema.json` (catches a wheel that dropped it),
  2. the in-code validator still agrees with that schema (prompt↔validator drift),
  3. the fail-open floor renders visible text (a missing handoff still yields a digest),
  4. the publisher still accepts a `content`-keyed block (the exact 2026-06-28 shape).
  Plus a best-effort live check that the registered workflow still dispatches this package.
- **Wired into the CLI**: runs at the end of `installDigest`, and — the key hook — **after `updateOpenclaw`** in `update()`. An openclaw update re-materializes the worker/overlay layer that desyncs the contract, so the gate fires exactly there. **Non-fatal but loud**: a digest regression never fails an openclaw update, but the user is told immediately with the repair command.
- **Tests**: passes on a healthy package; catches validator↔schema drift, a `content`-key regression (reproduces the outage), and a broken fail-open floor.

## Verification
- `python -m digest.smoke` → exit 0 on the deployed package.
- CLI typechecks; 44 digest tests pass; lint/knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)