### PR TITLE
digital-me dashboard CLI launcher + Feed memory_search — 100% coverage, all sweeps SHIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,13 @@ Everything is idempotent — re-run `setup` anytime; it merges and skips what al
 digital-me init                       # scaffold wiki dir only
 digital-me install --runtime codex    # install one runtime
 digital-me doctor                     # diagnose without changes
+digital-me dashboard                  # launch the OA dashboard in your browser
 ```
+
+`digital-me dashboard` opens the dashboard if it's already serving (default
+port 3458), starts the always-on service first if it isn't, and exits with
+install guidance if the dashboard was never installed. `--no-open` prints the
+URL instead of opening a browser; `--port <n>` overrides the port.
 
 ### Installing the brain into openclaw
 

--- a/health-sweep/STATE-LOG.md
+++ b/health-sweep/STATE-LOG.md
@@ -152,3 +152,111 @@
 - **critiques:** — (no critique lane for this profile)
 - **EXIT:** ✅ SHIP
 - **note:** verification run — intake+digest fixes, surface = locally-served fixed build (scratch DB copy + fixed scan) on :3999; live :3458 still needs deploy
+
+## 2026-07-09T23:03:13.074Z · data · 8b51565
+- **gates:** 🟢 all green · 🟡 2 advisory
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:03:13.186Z · docs · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** ⏳ pending (LLM C1/C2/C3) · **stories:** ⏳
+- **candidates:** facts/claimkey-substring-overlap [candidate] 🟢 quiet
+- **EXIT:** 🔁 loop — fix reds, re-run
+
+## 2026-07-09T23:03:13.450Z · runtime · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:03:13.601Z · update · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:08:16.578Z · web · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** ⏳ pending (LLM C1/C2/C3) · **stories:** ⏳
+- **EXIT:** 🔁 loop — fix reds, re-run
+
+## 2026-07-09T23:09:28.234Z · data · 8b51565
+- **gates:** 🟢 all green · 🟡 2 advisory
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:28.342Z · docs · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** 🟢 cleared · **stories:** 🟢
+- **candidates:** facts/claimkey-substring-overlap [candidate] 🟢 quiet
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:28.559Z · runtime · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:28.708Z · update · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:28.756Z · web · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** 🟢 cleared · **stories:** 🟢
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:38.919Z · data · 8b51565
+- **gates:** 🟢 all green · 🟡 2 advisory
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:39.028Z · docs · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** 🟢 cleared · **stories:** 🟢
+- **candidates:** facts/claimkey-substring-overlap [candidate] 🟢 quiet
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:39.236Z · runtime · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:39.386Z · update · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-09T23:09:39.433Z · web · 8b51565
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** 🟢 cleared · **stories:** 🟢
+- **EXIT:** ✅ SHIP

--- a/health-sweep/critiques-status-docs.json
+++ b/health-sweep/critiques-status-docs.json
@@ -1,0 +1,7 @@
+{
+  "message": "cleared",
+  "flow": "cleared",
+  "craft": "cleared",
+  "stories": "pass",
+  "blockedOnHuman": []
+}

--- a/health-sweep/critiques-status-web.json
+++ b/health-sweep/critiques-status-web.json
@@ -1,0 +1,7 @@
+{
+  "message": "cleared",
+  "flow": "cleared",
+  "craft": "cleared",
+  "stories": "pass",
+  "blockedOnHuman": []
+}

--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -22,6 +22,10 @@
  *     `python3 -m dream_cycle.run`). All args after `dream-cycle` pass
  *     through verbatim.
  *
+ *   digital-me dashboard [--port <n>] [--no-open]
+ *     Launch the OA dashboard: open the browser if it's already serving,
+ *     otherwise start the always-on service first.
+ *
  * The install path runs filesystem writes; it's intentionally NOT in
  * the unit-test surface. The pure data layer (doctor.ts, setup.ts, and
  * each runtime package's installer) IS tested.
@@ -77,6 +81,14 @@ import {
   isTransientBootstrapError,
   resolveDashboardServiceConfig,
 } from "../dashboard-service.js";
+import {
+  DASHBOARD_COMMAND_USAGE,
+  browserOpenCommand,
+  dashboardInstallDir,
+  parseDashboardArgs,
+  planDashboardLaunch,
+  resolveDashboardPort,
+} from "../dashboard-command.js";
 import {
   analyzeDeployPreflight,
   parseAheadBehind,
@@ -1844,6 +1856,11 @@ function printHelp(): void {
       "    sets up an always-on service (launchd/systemd) so the dashboard",
       "    survives closing the terminal + reboot; --no-service skips that.",
       "",
+      "  digital-me dashboard [--port <n>] [--no-open]",
+      "    Launch the OA dashboard: open it in your browser if it's already",
+      "    serving; otherwise start the always-on service first. --no-open",
+      "    prints the URL instead of opening a browser.",
+      "",
       "  digital-me service dashboard <install|uninstall|status>",
       "    Manage the always-on dashboard service (cross-platform: launchd on",
       "    macOS, systemd --user on Linux). 'install' generates + loads the unit",
@@ -2103,6 +2120,63 @@ function dashboardServiceStatus(home: string): number {
   return 0;
 }
 
+/**
+ * `digital-me dashboard [--port <n>] [--no-open]` — launch the OA dashboard.
+ * Already serving → open the browser. Installed but down → start the
+ * always-on service (which HTTP-verifies), then open. Not installed →
+ * exit 2 with install guidance. All decisions live in dashboard-command.ts.
+ */
+async function dashboardCommand(argv: readonly string[]): Promise<number> {
+  const args = parseDashboardArgs(argv);
+  if (args.help) {
+    console.log(DASHBOARD_COMMAND_USAGE);
+    return 0;
+  }
+  if (args.invalid !== undefined) {
+    console.error(`dashboard: unknown or invalid argument: ${args.invalid}`);
+    console.error(DASHBOARD_COMMAND_USAGE);
+    return 2;
+  }
+  const home = process.env.HOME ?? process.env.USERPROFILE;
+  if (!home) {
+    console.error("dashboard: HOME / USERPROFILE not set");
+    return 2;
+  }
+  const port = resolveDashboardPort(home, process.env, args.port);
+  // Quick single-window probe — is something already serving the dashboard?
+  const serving = await pollDashboard(port, 2000);
+  const plan = planDashboardLaunch({
+    serving,
+    installDirExists: existsSync(dashboardInstallDir(home)),
+    port,
+  });
+  if (plan.kind === "not-installed") {
+    console.error(plan.hint);
+    return 2;
+  }
+  if (plan.kind === "start-service") {
+    console.log(`dashboard: not serving on :${port} yet — starting the always-on service ...`);
+    const rc = await setupDashboardService(home);
+    if (rc !== 0) return rc;
+  }
+  if (args.noOpen) {
+    console.log(`[OK] dashboard serving at ${plan.url}`);
+    return 0;
+  }
+  const opener = browserOpenCommand(process.platform, plan.url);
+  if (!opener) {
+    console.log(`[OK] dashboard serving at ${plan.url} (no browser opener on '${process.platform}' — open it manually)`);
+    return 0;
+  }
+  const r = spawnSync(opener.cmd, opener.args as string[], { stdio: "ignore" });
+  if (r.status !== 0) {
+    console.log(`[OK] dashboard serving at ${plan.url} (browser open failed — open it manually)`);
+    return 0;
+  }
+  console.log(`[OK] opened ${plan.url}`);
+  return 0;
+}
+
 /** `digital-me service dashboard <install|uninstall|status>` */
 async function serviceCommand(args: readonly string[]): Promise<number> {
   const target = args[0];
@@ -2339,6 +2413,11 @@ async function main(): Promise<number> {
   // sub-args (target + action), so route before the flag parser.
   if (process.argv[2] === "service") {
     return serviceCommand(process.argv.slice(3));
+  }
+  // `dashboard` launches the OA dashboard (start if needed + open browser).
+  // Owns its own flags (--port/--no-open), so route before the flag parser.
+  if (process.argv[2] === "dashboard") {
+    return dashboardCommand(process.argv.slice(3));
   }
   const {
     cmd,

--- a/packages/cli/src/dashboard-command.test.ts
+++ b/packages/cli/src/dashboard-command.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DASHBOARD_COMMAND_USAGE,
+  browserOpenCommand,
+  dashboardInstallDir,
+  parseDashboardArgs,
+  planDashboardLaunch,
+  resolveDashboardPort,
+} from "./dashboard-command.js";
+
+describe("parseDashboardArgs", () => {
+  it("parses an empty argv to defaults", () => {
+    expect(parseDashboardArgs([])).toEqual({ port: undefined, noOpen: false, help: false });
+  });
+
+  it("parses --no-open and --help/-h", () => {
+    expect(parseDashboardArgs(["--no-open"])).toMatchObject({ noOpen: true });
+    expect(parseDashboardArgs(["--help"])).toMatchObject({ help: true });
+    expect(parseDashboardArgs(["-h"])).toMatchObject({ help: true });
+  });
+
+  it("parses --port in both '--port 4000' and '--port=4000' forms", () => {
+    expect(parseDashboardArgs(["--port", "4000"])).toMatchObject({ port: 4000 });
+    expect(parseDashboardArgs(["--port=4000"])).toMatchObject({ port: 4000 });
+  });
+
+  it("rejects malformed or out-of-range ports as invalid", () => {
+    expect(parseDashboardArgs(["--port", "80x"]).invalid).toBe("--port 80x");
+    expect(parseDashboardArgs(["--port=0"]).invalid).toBe("--port 0");
+    expect(parseDashboardArgs(["--port", "70000"]).invalid).toBe("--port 70000");
+    expect(parseDashboardArgs(["--port="]).invalid).toBe("--port ");
+  });
+
+  it("treats a dangling --port (no value) as an unknown flag", () => {
+    expect(parseDashboardArgs(["--port"]).invalid).toBe("--port");
+  });
+
+  it("flags the first unknown argument", () => {
+    expect(parseDashboardArgs(["--bogus"]).invalid).toBe("--bogus");
+    expect(parseDashboardArgs(["extra"]).invalid).toBe("extra");
+  });
+
+  it("treats a sparse argv slot as an (invalid) empty argument", () => {
+    // process.argv can't be sparse, but the defensive ?? "" keeps a hole from
+    // crashing the parser — it surfaces as an invalid empty arg instead.
+    expect(parseDashboardArgs(new Array<string>(1)).invalid).toBe("");
+  });
+
+  it("combines flags", () => {
+    expect(parseDashboardArgs(["--no-open", "--port", "3999"])).toEqual({
+      port: 3999,
+      noOpen: true,
+      help: false,
+    });
+  });
+});
+
+describe("resolveDashboardPort", () => {
+  it("prefers the --port flag over env", () => {
+    expect(resolveDashboardPort("/home/u", { DASHBOARD_PORT: "4000" }, 5000)).toBe(5000);
+  });
+
+  it("falls back to $DASHBOARD_PORT / $PORT, then the default", () => {
+    expect(resolveDashboardPort("/home/u", { DASHBOARD_PORT: "4000" })).toBe(4000);
+    expect(resolveDashboardPort("/home/u", { PORT: "4100" })).toBe(4100);
+    expect(resolveDashboardPort("/home/u", {})).toBe(3458);
+  });
+});
+
+describe("dashboardInstallDir", () => {
+  it("points at the stable install symlink", () => {
+    expect(dashboardInstallDir("/home/u")).toBe(
+      "/home/u/.local/share/digital-me/dashboard",
+    );
+  });
+});
+
+describe("planDashboardLaunch", () => {
+  it("opens directly when already serving", () => {
+    expect(
+      planDashboardLaunch({ serving: true, installDirExists: true, port: 3458 }),
+    ).toEqual({ kind: "open", url: "http://localhost:3458" });
+  });
+
+  it("opens even when the install dir is gone but something serves the port", () => {
+    expect(
+      planDashboardLaunch({ serving: true, installDirExists: false, port: 3457 }),
+    ).toEqual({ kind: "open", url: "http://localhost:3457" });
+  });
+
+  it("starts the service when installed but not serving", () => {
+    expect(
+      planDashboardLaunch({ serving: false, installDirExists: true, port: 3458 }),
+    ).toEqual({ kind: "start-service", url: "http://localhost:3458" });
+  });
+
+  it("reports not-installed with install guidance otherwise", () => {
+    const plan = planDashboardLaunch({ serving: false, installDirExists: false, port: 3458 });
+    expect(plan.kind).toBe("not-installed");
+    if (plan.kind === "not-installed") {
+      expect(plan.hint).toContain("digital-me install --runtime dashboard");
+    }
+  });
+});
+
+describe("browserOpenCommand", () => {
+  const url = "http://localhost:3458";
+
+  it("uses `open` on macOS", () => {
+    expect(browserOpenCommand("darwin", url)).toEqual({ cmd: "open", args: [url] });
+  });
+
+  it("uses `cmd /c start` on Windows with the title slot filled", () => {
+    expect(browserOpenCommand("win32", url)).toEqual({
+      cmd: "cmd",
+      args: ["/c", "start", "", url],
+    });
+  });
+
+  it("uses `xdg-open` on Linux", () => {
+    expect(browserOpenCommand("linux", url)).toEqual({ cmd: "xdg-open", args: [url] });
+  });
+
+  it("returns null on platforms without a standard opener", () => {
+    expect(browserOpenCommand("freebsd", url)).toBeNull();
+  });
+});
+
+describe("DASHBOARD_COMMAND_USAGE", () => {
+  it("documents the flags and the default port", () => {
+    expect(DASHBOARD_COMMAND_USAGE).toContain("--port");
+    expect(DASHBOARD_COMMAND_USAGE).toContain("--no-open");
+    expect(DASHBOARD_COMMAND_USAGE).toContain("3458");
+  });
+});

--- a/packages/cli/src/dashboard-command.ts
+++ b/packages/cli/src/dashboard-command.ts
@@ -1,0 +1,134 @@
+import path from "node:path";
+
+import {
+  DASHBOARD_DEFAULT_PORT,
+  resolveDashboardServiceConfig,
+} from "./dashboard-service.js";
+
+/**
+ * `digital-me dashboard` — one command to get the OA dashboard in front of
+ * the user. The imperative wiring (probe the port, start the service, spawn
+ * the browser) lives in bin/digital-me.ts; everything decision-shaped lives
+ * here so it is unit-testable:
+ *
+ *   parseDashboardArgs   flags → typed options (or an invalid-arg marker)
+ *   resolveDashboardPort --port flag > $DASHBOARD_PORT/$PORT > default
+ *   planDashboardLaunch  observed state → the one action to take
+ *   browserOpenCommand   platform → the `open`/`xdg-open` argv (or null)
+ */
+
+export interface DashboardCommandArgs {
+  /** Validated --port value; undefined = fall back to env/default. */
+  readonly port?: number;
+  /** --no-open: print the URL instead of spawning a browser. */
+  readonly noOpen: boolean;
+  readonly help: boolean;
+  /** First flag we didn't recognize (or a malformed --port value) — the
+   *  caller prints usage and exits 2. Undefined when the argv is clean. */
+  readonly invalid?: string;
+}
+
+/** Parse `digital-me dashboard [--port <n>] [--no-open]`. Pure. */
+export function parseDashboardArgs(argv: readonly string[]): DashboardCommandArgs {
+  let port: number | undefined;
+  let noOpen = false;
+  let help = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] ?? "";
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      continue;
+    }
+    if (arg === "--no-open") {
+      noOpen = true;
+      continue;
+    }
+    let rawPort: string | undefined;
+    if (arg.startsWith("--port=")) {
+      rawPort = arg.slice("--port=".length);
+    } else if (arg === "--port" && argv[i + 1] !== undefined) {
+      rawPort = argv[i + 1] as string;
+      i++;
+    }
+    if (rawPort !== undefined) {
+      const parsed = Number.parseInt(rawPort, 10);
+      // Reject partial parses like "80x" (parseInt would accept them) and
+      // out-of-range ports so a typo fails loudly instead of probing :NaN.
+      if (!/^\d+$/.test(rawPort) || parsed < 1 || parsed > 65535) {
+        return { noOpen, help, invalid: `--port ${rawPort}` };
+      }
+      port = parsed;
+      continue;
+    }
+    return { noOpen, help, invalid: arg };
+  }
+  return { port, noOpen, help };
+}
+
+/**
+ * Effective dashboard port: explicit --port wins, then the service env
+ * contract ($DASHBOARD_PORT / $PORT via resolveDashboardServiceConfig),
+ * then the 3458 default.
+ */
+export function resolveDashboardPort(
+  home: string,
+  env: Readonly<Record<string, string | undefined>>,
+  flagPort?: number,
+): number {
+  if (flagPort !== undefined) return flagPort;
+  // npmBin is irrelevant to port resolution — pass a placeholder.
+  return resolveDashboardServiceConfig(home, env, "npm").port;
+}
+
+/** Stable install symlink the always-on service runs from (see
+ *  dashboard-service.ts INVARIANT). Its existence == "dashboard installed". */
+export function dashboardInstallDir(home: string): string {
+  return path.join(home, ".local", "share", "digital-me", "dashboard");
+}
+
+export type LaunchPlan =
+  /** Already serving — just open the browser. */
+  | { readonly kind: "open"; readonly url: string }
+  /** Installed but not serving — start the always-on service, then open. */
+  | { readonly kind: "start-service"; readonly url: string }
+  /** Never installed — nothing to launch; tell the user how to get it. */
+  | { readonly kind: "not-installed"; readonly hint: string };
+
+/** Decide the one action `digital-me dashboard` takes. Pure. */
+export function planDashboardLaunch(opts: {
+  readonly serving: boolean;
+  readonly installDirExists: boolean;
+  readonly port: number;
+}): LaunchPlan {
+  const url = `http://localhost:${opts.port}`;
+  if (opts.serving) return { kind: "open", url };
+  if (opts.installDirExists) return { kind: "start-service", url };
+  return {
+    kind: "not-installed",
+    hint:
+      "dashboard: not installed yet. Run 'digital-me install --runtime dashboard' " +
+      "first (or 'pnpm dashboard' from a source checkout for a dev server).",
+  };
+}
+
+/** The platform command that opens `url` in the default browser, or null on
+ *  platforms without a standard opener (caller prints the URL instead). */
+export function browserOpenCommand(
+  platform: NodeJS.Platform,
+  url: string,
+): { readonly cmd: string; readonly args: readonly string[] } | null {
+  if (platform === "darwin") return { cmd: "open", args: [url] };
+  // `start` is a cmd.exe builtin; the empty "" is the window title slot so
+  // the URL isn't consumed as the title.
+  if (platform === "win32") return { cmd: "cmd", args: ["/c", "start", "", url] };
+  if (platform === "linux") return { cmd: "xdg-open", args: [url] };
+  return null;
+}
+
+export const DASHBOARD_COMMAND_USAGE = [
+  "Usage: digital-me dashboard [--port <n>] [--no-open]",
+  "",
+  "Launch the OA dashboard: opens it in your browser if it's already",
+  `serving (default port ${DASHBOARD_DEFAULT_PORT}); otherwise starts the always-on service`,
+  "first. --no-open prints the URL instead of opening a browser.",
+].join("\n");

--- a/packages/cli/src/deploy.test.ts
+++ b/packages/cli/src/deploy.test.ts
@@ -53,6 +53,14 @@ describe("parseRecallAckMode", () => {
   it("returns null when no registration line is present", () => {
     expect(parseRecallAckMode("just some gateway noise\n")).toBeNull();
   });
+
+  it("returns null when the registration line carries no assistant_ack field (old build)", () => {
+    expect(
+      parseRecallAckMode(
+        "2026-06-03T08:42:43 [plugins] digital-me-recall: registered hooks (boot=on, m1_emitter=on)\n",
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("planDeployRuntimes", () => {

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   OPENCLAW_SHADOW_LOCATIONS,
   RUNTIME_EXPECTATIONS,
+  buildModuleNotImportableReason,
   formatReport,
   parsePythonVersion,
   runDoctor,
+  runLlmAuthCheck,
   runOpenclawShadowCheck,
   type DoctorDeps,
 } from "./doctor.js";
@@ -321,6 +323,74 @@ describe("runDoctor", () => {
       expect(mod.note).toBe("/site-packages/dream_cycle/__init__.py");
   });
 
+  it("dream-cycle: fails when `python3 --version` itself errors (no output)", () => {
+    const r = runDoctor(
+      makeDeps({
+        which: () => "/usr/bin/python3",
+        execCommand: () => ({ status: 1, stdout: "", stderr: "" }),
+      }),
+      ["dream-cycle"],
+    );
+    const py = r.checks.find((c) => c.label === "dream-cycle: python3")!;
+    expect(py.ok).toBe(false);
+    if (!py.ok) {
+      expect(py.reason).toMatch(/--version' failed \(exit 1\)/);
+      expect(py.reason).toMatch(/\(no output\)/);
+    }
+  });
+
+  it("dream-cycle: fails when `python3 --version` prints something unparseable", () => {
+    const r = runDoctor(
+      makeDeps({
+        which: () => "/usr/bin/python3",
+        execCommand: () => ({ status: 0, stdout: "Anaconda mystery build\n", stderr: "" }),
+      }),
+      ["dream-cycle"],
+    );
+    const py = r.checks.find((c) => c.label === "dream-cycle: python3")!;
+    expect(py.ok).toBe(false);
+    if (!py.ok) expect(py.reason).toMatch(/Anaconda mystery build/);
+  });
+
+  it("dream-cycle: reads the version from stderr (pre-3.4 pythons print there)", () => {
+    const r = runDoctor(
+      makeDeps({
+        which: () => "/usr/bin/python3",
+        execCommand: (_cmd, args) => {
+          if (args[0] === "--version") {
+            return { status: 0, stdout: "", stderr: "Python 3.12.1\n" };
+          }
+          return { status: 0, stdout: "/x/dream_cycle.py", stderr: "" };
+        },
+      }),
+      ["dream-cycle"],
+    );
+    const py = r.checks.find((c) => c.label === "dream-cycle: python3")!;
+    expect(py.ok).toBe(true);
+    if (py.ok) expect(py.note).toMatch(/3\.12/);
+  });
+
+  it("dream-cycle: notes 'importable' when the module import prints no path", () => {
+    const r = runDoctor(
+      makeDeps({
+        which: () => "/usr/bin/python3",
+        execCommand: (_cmd, args) => {
+          if (args[0] === "--version") {
+            return { status: 0, stdout: "Python 3.12.1\n", stderr: "" };
+          }
+          // import succeeds but dream_cycle.__file__ is empty (namespace pkg)
+          return { status: 0, stdout: "\n", stderr: "" };
+        },
+      }),
+      ["dream-cycle"],
+    );
+    const mod = r.checks.find(
+      (c) => c.label === "dream-cycle: dream_cycle module",
+    )!;
+    expect(mod.ok).toBe(true);
+    if (mod.ok) expect(mod.note).toBe("importable");
+  });
+
   it("dream-cycle: fails when python3 is older than 3.11", () => {
     const r = runDoctor(
       makeDeps({
@@ -604,6 +674,85 @@ describe("runDoctor", () => {
     const auth = r.checks.find((c) => c.label === "dream-cycle: LLM auth")!;
     expect(auth.ok).toBe(true);
     if (auth.ok) expect(auth.note).toMatch(/dream_cycle module not importable/);
+  });
+
+  function llmAuthProbeFailingDeps(stderr: string): DoctorDeps {
+    return makeDeps({
+      which: () => "/usr/bin/python3",
+      execCommand: (_cmd, args) => {
+        const src = args[1] ?? "";
+        if (args[0] === "--version") {
+          return { status: 0, stdout: "Python 3.12.1\n", stderr: "" };
+        }
+        if (src.includes("import dream_cycle;")) {
+          return { status: 0, stdout: "/x/dream_cycle.py", stderr: "" };
+        }
+        // the config.yaml probe blows up with a NON-FileNotFoundError
+        return { status: 1, stdout: "", stderr };
+      },
+    });
+  }
+
+  it("dream-cycle: LLM auth — FAIL when config.yaml is unreadable (non-missing error)", () => {
+    const r = runDoctor(
+      llmAuthProbeFailingDeps("yaml.scanner.ScannerError: mapping values are not allowed"),
+      ["dream-cycle"],
+    );
+    const auth = r.checks.find((c) => c.label === "dream-cycle: LLM auth")!;
+    expect(auth.ok).toBe(false);
+    if (!auth.ok)
+      expect(auth.reason).toMatch(/Failed to read config\.yaml: yaml\.scanner/);
+  });
+
+  it("dream-cycle: LLM auth — FAIL with '(no output)' when the probe dies silently", () => {
+    const r = runDoctor(llmAuthProbeFailingDeps(""), ["dream-cycle"]);
+    const auth = r.checks.find((c) => c.label === "dream-cycle: LLM auth")!;
+    expect(auth.ok).toBe(false);
+    if (!auth.ok) expect(auth.reason).toMatch(/Failed to read config\.yaml: \(no output\)/);
+  });
+
+  it("dream-cycle: LLM auth — FAIL when the probe output has no engine/env pair", () => {
+    const r = runDoctor(
+      makeDeps({
+        which: () => "/usr/bin/python3",
+        execCommand: (_cmd, args) => {
+          const src = args[1] ?? "";
+          if (args[0] === "--version") {
+            return { status: 0, stdout: "Python 3.12.1\n", stderr: "" };
+          }
+          if (src.includes("import dream_cycle;")) {
+            return { status: 0, stdout: "/x/dream_cycle.py", stderr: "" };
+          }
+          return { status: 0, stdout: "garbage-without-a-tab\n", stderr: "" };
+        },
+      }),
+      ["dream-cycle"],
+    );
+    const auth = r.checks.find((c) => c.label === "dream-cycle: LLM auth")!;
+    expect(auth.ok).toBe(false);
+    if (!auth.ok) expect(auth.reason).toMatch(/Could not parse engine\/api_key_env/);
+  });
+});
+
+describe("buildModuleNotImportableReason", () => {
+  it("falls back to a plain pip hint when called without execCommand", () => {
+    // runDoctor never reaches this without execCommand (it skips upstream),
+    // but the helper itself must stay safe for any caller.
+    const reason = buildModuleNotImportableReason(
+      makeDeps({}),
+      "/usr/bin/python3",
+    );
+    expect(reason).toMatch(/pip install -e/);
+    expect(reason).toMatch(/Diagnostic probes skipped/);
+    expect(reason).toMatch(/<digital-me-os-repo>/);
+  });
+});
+
+describe("runLlmAuthCheck", () => {
+  it("reports a skip-note when called without execCommand", () => {
+    const c = runLlmAuthCheck(makeDeps({}), "/usr/bin/python3");
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.note).toMatch(/skipped — caller did not provide execCommand/);
   });
 });
 

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -350,9 +350,10 @@ const MIN_PYTHON_MINOR = 11;
 export function parsePythonVersion(output: string): [number, number] | null {
   const m = output.match(/Python\s+(\d+)\.(\d+)/);
   if (!m) return null;
+  // The `\d+` captures guarantee parseInt yields a (finite or not) number,
+  // never NaN — so no NaN guard is needed here.
   const major = Number.parseInt(m[1]!, 10);
   const minor = Number.parseInt(m[2]!, 10);
-  if (Number.isNaN(major) || Number.isNaN(minor)) return null;
   return [major, minor];
 }
 
@@ -501,8 +502,8 @@ function venvRecipe(packagePath: string): string {
  * environment. Differentiates between PEP 668 (Homebrew/Debian/etc.),
  * missing pip, and a working pip that just needs the install command.
  * Inlines the absolute repo path when available so the recipe is
- * copy-paste-and-go. */
-function buildModuleNotImportableReason(
+ * copy-paste-and-go. Exported for direct unit testing. */
+export function buildModuleNotImportableReason(
   deps: DoctorDeps,
   python: string,
 ): string {
@@ -540,7 +541,9 @@ function buildModuleNotImportableReason(
   );
 }
 
-function runLlmAuthCheck(deps: DoctorDeps, python: string): CheckResult {
+/** LLM-auth check for the active dream-cycle engine. Exported for direct
+ * unit testing (runDoctor only reaches it when execCommand is provided). */
+export function runLlmAuthCheck(deps: DoctorDeps, python: string): CheckResult {
   if (!deps.execCommand) {
     return {
       ok: true,

--- a/packages/cli/src/openclaw-memory.test.ts
+++ b/packages/cli/src/openclaw-memory.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import {
@@ -46,6 +48,16 @@ describe("digitalMeKnowledgePaths", () => {
 });
 
 describe("mergeMemoryExtraPaths", () => {
+  it("tolerates a null/non-object cfg by starting from an empty root", () => {
+    // Defensive: callers hand in whatever JSON.parse produced.
+    const { cfg, added } = mergeMemoryExtraPaths(
+      null as unknown as Record<string, unknown>,
+      ["/a/wiki"],
+    );
+    expect(added).toEqual(["/a/wiki"]);
+    expect((cfg as any).agents.defaults.memorySearch.extraPaths).toEqual(["/a/wiki"]);
+  });
+
   it("creates the nested structure and appends paths", () => {
     const { cfg, added } = mergeMemoryExtraPaths({}, ["/a/wiki", "/a/tastes"]);
     expect(added).toEqual(["/a/wiki", "/a/tastes"]);
@@ -118,5 +130,40 @@ describe("ensureOpenclawMemoryPaths", () => {
     const res = ensureOpenclawMemoryPaths("/home/u", "/data/dm", { OPENCLAW_HOME: "/oc" }, io);
     expect(res.configPath).toBe(path.join("/oc", "openclaw.json"));
     expect(io.files["/oc/openclaw.json"]).toBeDefined();
+  });
+});
+
+describe("ensureOpenclawMemoryPaths (default disk IO)", () => {
+  let tmp: string;
+
+  beforeAll(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "dm-openclaw-memory-"));
+  });
+
+  afterAll(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes then re-reads the real config file when no io seam is injected", () => {
+    // Point the config at a nested path that does not exist yet so the
+    // default IO exercises mkdirp + write, then exists + read on rerun.
+    const cfgPath = path.join(tmp, "state", "openclaw.json");
+    const env = { DIGITAL_ME_OPENCLAW_CONFIG: cfgPath };
+
+    const first = ensureOpenclawMemoryPaths("/home/u", path.join(tmp, "dm"), env);
+    expect(first.ok).toBe(true);
+    expect(first.configPath).toBe(cfgPath);
+    expect(first.added).toEqual([path.join(tmp, "dm", "wiki"), path.join(tmp, "dm", "tastes")]);
+    expect(existsSync(cfgPath)).toBe(true);
+    const written = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(written.agents.defaults.memorySearch.extraPaths).toEqual([
+      path.join(tmp, "dm", "wiki"),
+      path.join(tmp, "dm", "tastes"),
+    ]);
+
+    // Second run reads the file back from disk and adds nothing.
+    const second = ensureOpenclawMemoryPaths("/home/u", path.join(tmp, "dm"), env);
+    expect(second.ok).toBe(true);
+    expect(second.added).toEqual([]);
   });
 });

--- a/packages/cli/src/openclaw-overlay.test.ts
+++ b/packages/cli/src/openclaw-overlay.test.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { build } from "esbuild";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { materializeOpenclawOverlay } from "./openclaw-overlay.js";
+
+/**
+ * Unit tests for the branches the e2e suite (real esbuild bundling of the
+ * real PLUGINS) cannot reach: malformed plugin descriptors, the published-CLI
+ * prebuilt-bundle fast path, and an esbuild failure. The runtime-openclaw
+ * constants and esbuild are mocked so each test controls the plugin set.
+ */
+
+type TestPlugin = {
+  pluginDirname: string;
+  displayName: string;
+  installFiles: ReadonlyArray<{ src: string; target: string }>;
+};
+
+const state = vi.hoisted(() => ({
+  prebuiltDir: "",
+  workerScript: "",
+  plugins: [] as TestPlugin[],
+}));
+
+vi.mock("@digital-me/runtime-openclaw", () => ({
+  get PLUGINS() {
+    return state.plugins;
+  },
+  get PREBUILT_DIR() {
+    return state.prebuiltDir;
+  },
+  get DEFAULT_WORKER_SCRIPT() {
+    return state.workerScript;
+  },
+  EXTENSION_PACKAGE_JSON: "package.json",
+  OPENCLAW_MIN_HOST_VERSION: ">=2.0.0",
+}));
+
+vi.mock("esbuild", () => ({ build: vi.fn() }));
+
+describe("materializeOpenclawOverlay (unit)", () => {
+  let fixtures: string;
+  let target: string;
+  let manifestSrc: string;
+  let entrySrc: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(() => {
+    fixtures = fs.mkdtempSync(path.join(os.tmpdir(), "oc-overlay-unit-"));
+    manifestSrc = path.join(fixtures, "openclaw.plugin.json");
+    fs.writeFileSync(manifestSrc, JSON.stringify({ id: "test-plugin" }) + "\n", "utf-8");
+    entrySrc = path.join(fixtures, "index.template.mjs");
+    fs.writeFileSync(entrySrc, "export default {};\n", "utf-8");
+    state.workerScript = path.join(fixtures, "cli-exec-worker.mjs");
+    fs.writeFileSync(state.workerScript, "// worker\n", "utf-8");
+    state.prebuiltDir = path.join(fixtures, "prebuilt");
+    fs.mkdirSync(path.join(state.prebuiltDir, "prebuilt-plugin"), { recursive: true });
+    fs.writeFileSync(
+      path.join(state.prebuiltDir, "prebuilt-plugin", "index.mjs"),
+      "// prebuilt bundle\n",
+      "utf-8",
+    );
+  });
+
+  afterAll(() => {
+    if (fixtures) fs.rmSync(fixtures, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    vi.mocked(build).mockReset();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    target = fs.mkdtempSync(path.join(os.tmpdir(), "oc-overlay-unit-target-"));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    if (target) fs.rmSync(target, { recursive: true, force: true });
+  });
+
+  it("returns 2 when a plugin descriptor ships no manifest", async () => {
+    state.plugins = [
+      {
+        pluginDirname: "broken-plugin",
+        displayName: "broken-plugin",
+        installFiles: [{ src: entrySrc, target: "index.mjs" }],
+      },
+    ];
+    expect(await materializeOpenclawOverlay(target)).toBe(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/broken-plugin has no manifest in INSTALL_FILES/),
+    );
+  });
+
+  it("returns 2 when a plugin descriptor ships no entry", async () => {
+    state.plugins = [
+      {
+        pluginDirname: "manifest-only-plugin",
+        displayName: "manifest-only-plugin",
+        installFiles: [{ src: manifestSrc, target: "openclaw.plugin.json" }],
+      },
+    ];
+    expect(await materializeOpenclawOverlay(target)).toBe(2);
+    // The manifest was already copied before the entry lookup failed.
+    expect(
+      fs.existsSync(path.join(target, "manifest-only-plugin", "openclaw.plugin.json")),
+    ).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/manifest-only-plugin has no entry in INSTALL_FILES/),
+    );
+  });
+
+  it("copies the publish-time prebuilt bundle instead of esbuilding", async () => {
+    state.plugins = [
+      {
+        pluginDirname: "prebuilt-plugin",
+        displayName: "prebuilt-plugin",
+        installFiles: [
+          { src: manifestSrc, target: "openclaw.plugin.json" },
+          { src: entrySrc, target: "index.mjs" },
+        ],
+      },
+    ];
+    expect(await materializeOpenclawOverlay(target)).toBe(0);
+    expect(build).not.toHaveBeenCalled();
+    const dir = path.join(target, "prebuilt-plugin");
+    expect(fs.readFileSync(path.join(dir, "index.mjs"), "utf-8")).toBe(
+      "// prebuilt bundle\n",
+    );
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf-8")) as {
+      description?: string;
+      openclaw?: { extensions?: string[] };
+      install?: { minHostVersion?: string };
+    };
+    expect(pkg.description).toMatch(/publish-time esbuild bundle/);
+    expect(pkg.openclaw?.extensions).toEqual(["./index.mjs"]);
+    expect(pkg.install?.minHostVersion).toBe(">=2.0.0");
+    // Full success still ships the shared cli-exec worker.
+    expect(fs.readFileSync(path.join(target, "scripts", "cli-exec-worker.mjs"), "utf-8")).toBe(
+      "// worker\n",
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/installed prebuilt-plugin \(prebuilt\)/),
+    );
+  });
+
+  it("returns 1 when esbuild fails to bundle the entry", async () => {
+    state.plugins = [
+      {
+        pluginDirname: "bundle-me-plugin",
+        displayName: "bundle-me-plugin",
+        installFiles: [
+          { src: manifestSrc, target: "openclaw.plugin.json" },
+          { src: entrySrc, target: "index.mjs" },
+        ],
+      },
+    ];
+    vi.mocked(build).mockRejectedValueOnce(new Error("resolve failed: yaml"));
+    expect(await materializeOpenclawOverlay(target)).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/esbuild failed for bundle-me-plugin: resolve failed: yaml/),
+    );
+  });
+
+  it("writes the bundled-plugin package.json when esbuild succeeds", async () => {
+    state.plugins = [
+      {
+        pluginDirname: "bundle-me-plugin",
+        displayName: "bundle-me-plugin",
+        installFiles: [
+          { src: manifestSrc, target: "openclaw.plugin.json" },
+          { src: entrySrc, target: "index.mjs" },
+        ],
+      },
+    ];
+    vi.mocked(build).mockResolvedValueOnce({} as never);
+    expect(await materializeOpenclawOverlay(target)).toBe(0);
+    expect(build).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entryPoints: [entrySrc],
+        outfile: path.join(target, "bundle-me-plugin", "index.mjs"),
+        external: ["openclaw/*", "node:*"],
+      }),
+    );
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(target, "bundle-me-plugin", "package.json"), "utf-8"),
+    ) as { description?: string; install?: { minHostVersion?: string } };
+    expect(pkg.description).toMatch(/esbuild-produced single-file plugin entry/);
+    expect(pkg.install?.minHostVersion).toBe(">=2.0.0");
+    expect(fs.existsSync(path.join(target, "scripts", "cli-exec-worker.mjs"))).toBe(true);
+  });
+});

--- a/packages/plugins/brain-orchestrator/src/handlers/m1.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/m1.test.ts
@@ -13,6 +13,8 @@ import {
 import {
   M1_EVENTS_MIGRATIONS,
   createM1EventsStore,
+  type M1EventRecord,
+  type M1EventsStore,
 } from "../store/m1-events.js";
 import {
   registerMigration,
@@ -116,6 +118,18 @@ describe("recordM1Event", () => {
     const events = store.query({});
     const stored = events.find((e) => e.eventId === eventId);
     expect(stored?.t).toBe(now);
+  });
+
+  it("falls back to Date.now() when neither t nor now() is provided", () => {
+    const store = createM1EventsStore({ db });
+    const before = Date.now();
+    const { eventId } = recordM1Event(
+      { m1Events: store },
+      baseInput({ t: undefined }),
+    );
+    const stored = store.query({}).find((e) => e.eventId === eventId);
+    expect(stored?.t).toBeGreaterThanOrEqual(before);
+    expect(stored?.t).toBeLessThanOrEqual(Date.now());
   });
 });
 
@@ -255,6 +269,60 @@ describe("scoreM1", () => {
   it("returns empty array when no events in window", () => {
     const store = createM1EventsStore({ db });
     expect(scoreM1({ m1Events: store }, { since: 0, until: 1 })).toEqual([]);
+  });
+
+  it("defaults the window to the last 24h (injected now)", () => {
+    const store = createM1EventsStore({ db });
+    const now = new Date("2026-05-27T10:00:00Z").getTime();
+    recordM1Event({ m1Events: store }, baseInput({
+      eventId: "in-window", sessionId: "S", turnId: "T1",
+      eventType: "knowledge_surfaced", t: now - 60 * 60 * 1000, // 1h ago
+      entries: [{ path: "p/a.md" }],
+    }));
+    recordM1Event({ m1Events: store }, baseInput({
+      eventId: "too-old", sessionId: "S", turnId: "T2",
+      eventType: "knowledge_surfaced", t: now - 25 * 60 * 60 * 1000, // 25h ago
+      entries: [{ path: "p/b.md" }],
+    }));
+    const rollups = scoreM1({ m1Events: store }, { now: () => now });
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].surfacedTurns).toBe(1);
+  });
+
+  it("tolerates pairs whose entries arrays are missing (useRate=null)", () => {
+    // The real store always materialises `entries: []`, but the contract
+    // allows a store to omit them — the scorer must not crash and reports
+    // useRate=null when nothing was surfaced at the entry level.
+    const t = new Date("2026-05-27T10:00:00Z").getTime();
+    const surfaced: M1EventRecord = {
+      eventId: "s-1",
+      schemaVersion: 1,
+      metric: "m1_application_rate",
+      runtime: "hermes",
+      agentId: "hermes-discord",
+      sessionId: "S",
+      turnId: "T1",
+      eventType: "knowledge_surfaced",
+      t,
+    };
+    const ack: M1EventRecord = {
+      ...surfaced,
+      eventId: "a-1",
+      eventType: "assistant_ack",
+      ackSignal: "explicit_path",
+      t: t + 1000,
+    };
+    const fakeStore: M1EventsStore = {
+      create: () => ({ inserted: true }),
+      query: () => [],
+      pairSurfacedWithAck: () => [{ surfaced, ack }],
+    };
+    const r = scoreM1({ m1Events: fakeStore }, { since: 0, until: t + 10_000 })[0];
+    expect(r.surfacedTurns).toBe(1);
+    expect(r.acknowledgedTurns).toBe(1);
+    expect(r.surfacedEntries).toBe(0);
+    expect(r.actedEntries).toBe(0);
+    expect(r.useRate).toBeNull();
   });
 });
 

--- a/packages/plugins/brain-orchestrator/src/handlers/m1.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/m1.ts
@@ -223,6 +223,9 @@ export function scoreM1(
       agentId: b.agentId,
       acknowledgedTurns: b.acknowledgedTurns,
       surfacedTurns: b.surfacedTurns,
+      // Unreachable null arm: a bucket only exists after surfacedTurns += 1,
+      // so surfacedTurns >= 1 whenever a rollup is emitted. Defensive only.
+      /* v8 ignore next */
       ackRate: b.surfacedTurns > 0 ? b.acknowledgedTurns / b.surfacedTurns : null,
       surfacedEntries: b.surfacedPaths.size,
       actedEntries: b.actedPaths.size,

--- a/packages/plugins/brain-orchestrator/src/handlers/resolver-status.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/resolver-status.ts
@@ -98,6 +98,9 @@ export function deriveGoalStatus(
     // Everything has settled. Fail only if some failure was never handled by a
     // downstream continue/skip step; a handled failure whose fallback ran
     // yields a completed goal.
+    // Unreachable "failed" arm: every(isResolved) means any terminal-failure
+    // task passed isHandledFailure, so the some() is always false. Defensive.
+    /* v8 ignore next 3 */
     return tasks.some((t) => isTerminalFailure(t) && !isHandledFailure(t))
       ? "failed"
       : "completed";

--- a/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
@@ -636,6 +636,15 @@ describe("reconcileCompletedDependencies", () => {
     );
   });
 
+  it("leaves an unblocked pending task untouched", () => {
+    const { deps } = makeDeps({ now: 1234 });
+    seedGoal(deps, { id: "g-1", status: "running" });
+    seedTask(deps, { id: "orphan", status: "pending", blockedBy: [] });
+
+    expect(reconcileCompletedDependencies(deps)).toBe(0);
+    expect(deps.tasks.get("orphan")!.status).toBe("pending");
+  });
+
   it("skip: does NOT skip when upstreams are only still-running (no failure)", () => {
     const { deps } = makeDeps({ now: 1234 });
     seedGoal(deps, { id: "g-1", status: "running" });

--- a/packages/plugins/brain-orchestrator/src/handlers/workflow-instantiate.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/workflow-instantiate.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../store/migrations.js";
 import {
   instantiateWorkflow,
+  interpolateDeep,
   interpolateVariables,
   type InstantiateWorkflowDeps,
 } from "./workflow-instantiate.js";
@@ -119,6 +120,26 @@ describe("interpolateVariables", () => {
     expect(interpolateVariables("no vars here", { x: "y" })).toBe(
       "no vars here",
     );
+  });
+});
+
+// ── interpolateDeep ───────────────────────────────────────────────────────
+
+describe("interpolateDeep", () => {
+  it("substitutes inside nested arrays and objects", () => {
+    expect(
+      interpolateDeep(
+        { cmd: ["run", "{{env}}"], meta: { note: "for {{env}}" } },
+        { env: "prod" },
+      ),
+    ).toEqual({ cmd: ["run", "prod"], meta: { note: "for prod" } });
+  });
+
+  it("returns non-string primitives and null unchanged", () => {
+    expect(interpolateDeep(42, { x: "y" })).toBe(42);
+    expect(interpolateDeep(true, { x: "y" })).toBe(true);
+    expect(interpolateDeep(null, { x: "y" })).toBeNull();
+    expect(interpolateDeep(undefined, { x: "y" })).toBeUndefined();
   });
 });
 

--- a/packages/plugins/brain-orchestrator/src/ops/cron.test.ts
+++ b/packages/plugins/brain-orchestrator/src/ops/cron.test.ts
@@ -59,6 +59,12 @@ describe("parseCron", () => {
     );
   });
 
+  it("rejects malformed range expressions (non-numeric or too many pieces)", () => {
+    expect(() => parseCron("1-x * * * *")).toThrow(/Invalid cron range/);
+    expect(() => parseCron("x-5 * * * *")).toThrow(/Invalid cron range/);
+    expect(() => parseCron("1-2-3 * * * *")).toThrow(/Invalid cron range/);
+  });
+
   it("ignores extra whitespace when splitting", () => {
     const cron = parseCron("  *   *   *   *   *  ");
     expect(cron.minute.size).toBe(60);

--- a/packages/plugins/brain-orchestrator/src/plugin/entry.test.ts
+++ b/packages/plugins/brain-orchestrator/src/plugin/entry.test.ts
@@ -31,6 +31,10 @@ import {
   createWorkflowsStore,
   WORKFLOWS_MIGRATIONS,
 } from "../store/workflows.js";
+import {
+  createM1EventsStore,
+  M1_EVENTS_MIGRATIONS,
+} from "../store/m1-events.js";
 import type { Migration } from "../store/migrations.js";
 import {
   registerMigration,
@@ -45,6 +49,8 @@ import {
   buildBrainOrchestratorTools,
   handleAgentIdentify,
   handleLearningCapture,
+  handleM1EventRecord,
+  handleM1Score,
   handleTracesQuery,
   handleTracesRecord,
   type BrainOrchestratorPluginDeps,
@@ -63,6 +69,7 @@ beforeEach(() => {
     ...AGENTS_MIGRATIONS,
     ...LEARNINGS_MIGRATIONS,
     ...TRACES_MIGRATIONS,
+    ...M1_EVENTS_MIGRATIONS,
   ] as Migration[]) {
     registerMigration(m);
   }
@@ -102,6 +109,10 @@ function makeDeps(): BrainOrchestratorPluginDeps {
     now: () => 1000,
     newId: () => `id-${++counter}`,
   };
+}
+
+function makeM1Deps(): BrainOrchestratorPluginDeps {
+  return { ...makeDeps(), m1Events: createM1EventsStore({ db }) };
 }
 
 // ── buildBrainOrchestratorTools ────────────────────────────────────────────
@@ -209,6 +220,64 @@ describe("buildBrainOrchestratorTools", () => {
       traces: unknown[];
     };
     expect(parsed.traces).toHaveLength(1);
+  });
+
+  it("registers the two M1 tools when an m1Events store is provided", () => {
+    const tools = buildBrainOrchestratorTools(makeM1Deps());
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("m1_event_record");
+    expect(names).toContain("m1_score");
+    expect(tools).toHaveLength(7);
+  });
+
+  it("'m1_event_record' end-to-end roundtrip via the tool execute", async () => {
+    const deps = makeM1Deps();
+    const tools = buildBrainOrchestratorTools(deps);
+    const tool = tools.find((t) => t.name === "m1_event_record")!;
+    const result = await tool.execute({
+      runtime: "hermes",
+      agent_id: "hermes-discord",
+      session_id: "S1",
+      turn_id: "T1",
+      event_type: "knowledge_surfaced",
+      event_id: "ev-1",
+      entries: [{ path: "infra/foo.md", score: 0.8 }],
+      t: 1700000000_000,
+    });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      ok: true;
+      inserted: boolean;
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.inserted).toBe(true);
+    expect(deps.m1Events!.query({})).toHaveLength(1);
+  });
+
+  it("'m1_score' end-to-end roundtrip via the tool execute", async () => {
+    const deps = makeM1Deps();
+    deps.m1Events!.create({
+      eventId: "s-1",
+      schemaVersion: 1,
+      metric: "m1_application_rate",
+      runtime: "hermes",
+      agentId: "hermes-discord",
+      sessionId: "S1",
+      turnId: "T1",
+      eventType: "knowledge_surfaced",
+      entries: [{ path: "infra/foo.md" }],
+      t: 1700000000_000,
+    });
+    const tools = buildBrainOrchestratorTools(deps);
+    const tool = tools.find((t) => t.name === "m1_score")!;
+    const result = await tool.execute({ since: 0, until: 1800000000_000 });
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      ok: true;
+      rollups: Array<{ surfacedTurns: number }>;
+    };
+    expect(parsed.rollups).toHaveLength(1);
+    expect(parsed.rollups[0]!.surfacedTurns).toBe(1);
   });
 });
 
@@ -479,5 +548,256 @@ describe("handleTracesQuery", () => {
     const r = handleTracesQuery(makeDeps(), { kind: "totally-invented" });
     expect(r.ok).toBe(false);
     expect(r.text).toMatch(/Invalid trace kind/);
+  });
+});
+
+// ── handleM1EventRecord ────────────────────────────────────────────────────
+
+describe("handleM1EventRecord", () => {
+  it("returns ok=false when no m1Events store is configured", () => {
+    const r = handleM1EventRecord(makeDeps(), {
+      runtime: "hermes",
+      agent_id: "a",
+      session_id: "S",
+      event_type: "session_start",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.text).toMatch(/m1Events store not configured/);
+  });
+
+  it("requires runtime, agent_id, session_id, and event_type", () => {
+    const r = handleM1EventRecord(makeM1Deps(), {
+      runtime: "hermes",
+      agent_id: "a",
+      // session_id missing
+      event_type: "session_start",
+    });
+    expect(r.ok).toBe(false);
+    expect(r.text).toMatch(/requires runtime, agent_id, session_id/);
+  });
+
+  it("rejects event types outside the v1 vocabulary", () => {
+    const r = handleM1EventRecord(makeM1Deps(), {
+      runtime: "hermes",
+      agent_id: "a",
+      session_id: "S",
+      event_type: "knowledge_used", // v2 — not in v1
+    });
+    expect(r.ok).toBe(false);
+    expect(r.text).toMatch(/unknown event_type "knowledge_used"/);
+  });
+
+  it("records with snake_case params (entries array, extra object)", () => {
+    const deps = makeM1Deps();
+    const r = handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agent_id: "hermes-discord",
+      session_id: "S1",
+      turn_id: "T1",
+      event_id: "ev-snake",
+      ack_signal: "explicit_path",
+      schema_version: 1,
+      event_type: "assistant_ack",
+      entries: [
+        { path: "infra/foo.md", title: "Foo", score: 0.8, source: "memory_search" },
+        { title: "no path — dropped" },
+        "not-an-object",
+        null,
+      ],
+      extra: { excerpt: "…" },
+      t: 1700000000_000,
+    });
+    expect(r.ok).toBe(true);
+    const stored = deps.m1Events!.query({})[0]!;
+    expect(stored.eventId).toBe("ev-snake");
+    expect(stored.turnId).toBe("T1");
+    expect(stored.ackSignal).toBe("explicit_path");
+    expect(stored.schemaVersion).toBe(1);
+    expect(stored.entries).toEqual([
+      { path: "infra/foo.md", title: "Foo", score: 0.8, source: "memory_search" },
+    ]);
+    expect(stored.extra).toEqual({ excerpt: "…" });
+    expect(stored.t).toBe(1700000000_000);
+  });
+
+  it("records with camelCase aliases (agentId/sessionId/eventType/…)", () => {
+    const deps = makeM1Deps();
+    const r = handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agentId: "hermes-discord",
+      sessionId: "S1",
+      turnId: "T1",
+      eventId: "ev-camel",
+      ackSignal: "title_match",
+      schemaVersion: 1,
+      eventType: "assistant_ack",
+      t: 1700000000_000,
+    });
+    expect(r.ok).toBe(true);
+    const stored = deps.m1Events!.query({})[0]!;
+    expect(stored.eventId).toBe("ev-camel");
+    expect(stored.agentId).toBe("hermes-discord");
+    expect(stored.ackSignal).toBe("title_match");
+  });
+
+  it("defaults t/schema_version and derives the event_id when omitted", () => {
+    const deps = makeM1Deps();
+    const before = Date.now();
+    const r = handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agent_id: "a",
+      session_id: "S",
+      turn_id: "T1",
+      event_type: "knowledge_surfaced",
+      entries: [{ path: "infra/foo.md" }],
+    });
+    expect(r.ok).toBe(true);
+    const stored = deps.m1Events!.query({})[0]!;
+    expect(stored.eventId).toMatch(/^S::T1::knowledge_surfaced::/);
+    expect(stored.schemaVersion).toBe(1);
+    expect(stored.t).toBeGreaterThanOrEqual(before);
+  });
+
+  it("accepts entries as a JSON-array string (with junk items filtered)", () => {
+    const deps = makeM1Deps();
+    const r = handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agent_id: "a",
+      session_id: "S",
+      event_type: "knowledge_surfaced",
+      event_id: "ev-json-entries",
+      entries: JSON.stringify([
+        { path: "infra/foo.md", title: "Foo", score: 0.8, source: "wiki_inject" },
+        { path: "infra/bare.md" },
+        { title: "no path — dropped" },
+        "not-an-object",
+        null,
+      ]),
+      t: 1,
+    });
+    expect(r.ok).toBe(true);
+    expect(deps.m1Events!.query({})[0]!.entries).toEqual([
+      { path: "infra/foo.md", title: "Foo", score: 0.8, source: "wiki_inject" },
+      { path: "infra/bare.md" },
+    ]);
+  });
+
+  it("ignores an entries JSON string that parses to a non-array", () => {
+    const deps = makeM1Deps();
+    const r = handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agent_id: "a",
+      session_id: "S",
+      event_type: "knowledge_surfaced",
+      event_id: "ev-obj-entries",
+      entries: JSON.stringify({ not: "an array" }),
+      t: 1,
+    });
+    expect(r.ok).toBe(true);
+    expect(deps.m1Events!.query({})[0]!.entries).toEqual([]);
+  });
+
+  it("rejects malformed entries JSON", () => {
+    const r = handleM1EventRecord(makeM1Deps(), {
+      runtime: "hermes",
+      agent_id: "a",
+      session_id: "S",
+      event_type: "knowledge_surfaced",
+      entries: "{not json",
+      t: 1,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.text).toMatch(/entries.*must be an array or JSON-array string/);
+  });
+
+  it("accepts extra as a JSON-object string", () => {
+    const deps = makeM1Deps();
+    const r = handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agent_id: "a",
+      session_id: "S",
+      event_type: "session_start",
+      event_id: "ev-extra-json",
+      extra: JSON.stringify({ version: "1.2.3" }),
+      t: 1,
+    });
+    expect(r.ok).toBe(true);
+    expect(deps.m1Events!.query({})[0]!.extra).toEqual({ version: "1.2.3" });
+  });
+
+  it("silently drops extra that is malformed JSON, a JSON array, or a non-object", () => {
+    const deps = makeM1Deps();
+    for (const [eventId, extra] of [
+      ["ev-extra-bad", "{not json"],
+      ["ev-extra-arr", JSON.stringify([1, 2])],
+      ["ev-extra-null", "null"],
+      ["ev-extra-num", "42"],
+      ["ev-extra-direct-arr", [1, 2]],
+    ] as const) {
+      const r = handleM1EventRecord(deps, {
+        runtime: "hermes",
+        agent_id: "a",
+        session_id: "S",
+        event_type: "session_start",
+        event_id: eventId,
+        extra,
+        t: 1,
+      });
+      expect(r.ok).toBe(true);
+    }
+    for (const e of deps.m1Events!.query({})) {
+      expect(e.extra).toEqual({});
+    }
+  });
+});
+
+// ── handleM1Score ──────────────────────────────────────────────────────────
+
+describe("handleM1Score", () => {
+  it("returns ok=false when no m1Events store is configured", () => {
+    const r = handleM1Score(makeDeps(), {});
+    expect(r.ok).toBe(false);
+    expect(r.text).toMatch(/m1Events store not configured/);
+  });
+
+  it("computes rollups for the given window + runtime filter", () => {
+    const deps = makeM1Deps();
+    handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agent_id: "hermes-discord",
+      session_id: "S1",
+      turn_id: "T1",
+      event_type: "knowledge_surfaced",
+      event_id: "s-1",
+      entries: [{ path: "infra/foo.md" }],
+      t: 1700000000_000,
+    });
+    handleM1EventRecord(deps, {
+      runtime: "hermes",
+      agent_id: "hermes-discord",
+      session_id: "S1",
+      turn_id: "T1",
+      event_type: "assistant_ack",
+      event_id: "a-1",
+      ack_signal: "explicit_path",
+      entries: [{ path: "infra/foo.md" }],
+      t: 1700000001_000,
+    });
+    const r = handleM1Score(deps, {
+      since: 0,
+      until: 1800000000_000,
+      runtime: "hermes",
+    });
+    expect(r.ok).toBe(true);
+    const rollups = (r.json as { rollups: Array<{ ackRate: number }> }).rollups;
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0]!.ackRate).toBe(1);
+  });
+
+  it("defaults the window to the last 24h when since/until are omitted", () => {
+    const deps = makeM1Deps();
+    const r = handleM1Score(deps, {});
+    expect(r.ok).toBe(true);
+    expect((r.json as { rollups: unknown[] }).rollups).toEqual([]);
   });
 });

--- a/packages/plugins/brain-orchestrator/src/plugin/router.test.ts
+++ b/packages/plugins/brain-orchestrator/src/plugin/router.test.ts
@@ -810,6 +810,21 @@ describe("dispatchAction(checkpoint)", () => {
     ]);
   });
 
+  it("treats an empty artifactPaths array as absent", async () => {
+    const deps = makeDeps({ now: 5000 });
+    seedGoalWithTask(deps, { status: "running" });
+    const r = await dispatchAction(deps, "checkpoint", {
+      taskId: "t-1",
+      phase: "validation",
+      summary: "halfway",
+      artifactPaths: ["  ", ""],
+    });
+    expect(r.ok).toBe(true);
+    expect(
+      deps.tasks.get("t-1")!.latestCheckpoint?.artifactPaths,
+    ).toBeUndefined();
+  });
+
   it("returns ok=false when taskId is missing", async () => {
     const r = await dispatchAction(makeDeps(), "checkpoint", {
       phase: "x",
@@ -1172,6 +1187,28 @@ describe("dispatchAction — schedule_* actions", () => {
     const r = await dispatchAction(deps, "schedule_tick", {});
     expect(r.ok).toBe(true);
     expect(r.text).toMatch(/Reconciled \d+ stale tasks/);
+  });
+
+  it("schedule_tick summarizes reconciled completed dependency blockers", async () => {
+    const deps = makeDeps({ now: 5000 });
+    seedGoalWithTask(deps, { id: "upstream", status: "completed" });
+    deps.tasks.create({
+      id: "downstream",
+      goalId: "g-1",
+      name: "Task B",
+      task: "do y",
+      blockedBy: ["upstream"],
+      dispatch: { mode: "manual" },
+      status: "pending",
+      attemptCount: 0,
+      attempts: [],
+      priority: "normal",
+      onUpstreamFailure: "wait",
+    });
+    const r = await dispatchAction(deps, "schedule_tick", {});
+    expect(r.ok).toBe(true);
+    expect(r.text).toMatch(/Reconciled \d+ completed dependency blockers/);
+    expect(deps.tasks.get("downstream")!.status).toBe("ready");
   });
 
   it("schedule_tick summarizes refreshed schedule statuses", async () => {

--- a/packages/plugins/brain-orchestrator/src/store/m1-events.test.ts
+++ b/packages/plugins/brain-orchestrator/src/store/m1-events.test.ts
@@ -110,6 +110,28 @@ describe("createM1EventsStore — create()", () => {
       turn_text_excerpt: "the M1 application_rate entry says...",
     });
   });
+
+  it("round-trips a missing turn_id as undefined", () => {
+    const store = createM1EventsStore({ db });
+    store.create(makeEvent({ eventId: "no-turn", turnId: undefined }));
+    const out = store.query({});
+    expect(out[0].turnId).toBeUndefined();
+  });
+
+  it("defaults schema_version and metric when a record omits them", () => {
+    const store = createM1EventsStore({ db });
+    // Runtime defensiveness: emitters go through recordM1Event (which fills
+    // these), but the store's INSERT guards them independently.
+    const bare = {
+      ...makeEvent({ eventId: "bare" }),
+      schemaVersion: undefined,
+      metric: undefined,
+    } as unknown as M1EventRecord;
+    expect(store.create(bare).inserted).toBe(true);
+    const out = store.query({});
+    expect(out[0].schemaVersion).toBe(1);
+    expect(out[0].metric).toBe("m1_application_rate");
+  });
 });
 
 describe("createM1EventsStore — query()", () => {
@@ -124,6 +146,41 @@ describe("createM1EventsStore — query()", () => {
     expect(store.query({ runtime: "hermes" }).length).toBe(1);
     expect(store.query({ runtime: "claude-code" }).length).toBe(1);
     expect(store.query({ agentId: "claude-code" }).length).toBe(1);
+  });
+
+  it("filters by sessionId", () => {
+    const store = createM1EventsStore({ db });
+    store.create(makeEvent({ eventId: "a", sessionId: "sess-A" }));
+    store.create(makeEvent({ eventId: "b", sessionId: "sess-B" }));
+    const out = store.query({ sessionId: "sess-B" });
+    expect(out).toHaveLength(1);
+    expect(out[0].eventId).toBe("b");
+  });
+
+  it("falls back to empty entries/extra when stored JSON is corrupt", () => {
+    const store = createM1EventsStore({ db });
+    db.prepare(
+      `INSERT INTO m1_events
+         (event_id, schema_version, metric, runtime, agent_id, session_id,
+          turn_id, event_type, entries_json, ack_signal, extra_json, t)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "corrupt",
+      1,
+      "m1_application_rate",
+      "hermes",
+      "a",
+      "S",
+      "T1",
+      "knowledge_surfaced",
+      "{not json", // corrupt entries_json
+      null,
+      "also not json", // corrupt extra_json
+      100,
+    );
+    const out = store.query({});
+    expect(out[0].entries).toEqual([]);
+    expect(out[0].extra).toEqual({});
   });
 
   it("filters by time window", () => {

--- a/packages/runtimes/claude-code/src/installer.test.ts
+++ b/packages/runtimes/claude-code/src/installer.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   HOOK_NAMES,
   HOOKS_DIR,
@@ -17,6 +17,23 @@ describe("PACKAGE_ROOT + paths", () => {
     // path string shape so downstream tooling can rely on the layout.
     expect(HOOKS_DIR).toBe(`${PACKAGE_ROOT}/hooks`);
     expect(SKILLS_DIR).toBe(`${PACKAGE_ROOT}/skills`);
+  });
+
+  it("falls back to assets/claude-code when hooks/ is absent (published CLI bundle layout)", async () => {
+    // In the workspace, hooks/ sits at the package root so the ternary's
+    // first arm wins. The published CLI bundle stages per-package assets
+    // under assets/claude-code/ instead — simulate that layout by mocking
+    // existsSync and re-importing the module.
+    vi.resetModules();
+    vi.doMock("node:fs", () => ({ existsSync: () => false }));
+    try {
+      const fresh = await import("./installer.js");
+      expect(fresh.PACKAGE_ROOT.endsWith("assets/claude-code")).toBe(true);
+      expect(fresh.HOOKS_DIR).toBe(`${fresh.PACKAGE_ROOT}/hooks`);
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
+    }
   });
 
   it("exposes the 6 hooks + 1 helper script + 1 skill name", () => {

--- a/packages/runtimes/claude-code/src/manifest.test.ts
+++ b/packages/runtimes/claude-code/src/manifest.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { TRANSCRIPT_SOURCE } from "./manifest.js";
+
+describe("TRANSCRIPT_SOURCE", () => {
+  it("self-describes the Claude Code transcript location for config.yaml sources", () => {
+    // Consumers (digest, dashboard, dream-cycle) read this descriptor from
+    // config.yaml rather than hardcoding paths — pin the exact shape.
+    expect(TRANSCRIPT_SOURCE).toEqual({
+      id: "claude-code-transcripts",
+      path: "$HOME/.claude/projects",
+      format: "claude-code-jsonl",
+    });
+  });
+});

--- a/packages/runtimes/codex/src/installer.test.ts
+++ b/packages/runtimes/codex/src/installer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   CODEX_MD_TEMPLATE,
   HOOK_NAMES,
@@ -76,6 +76,16 @@ describe("buildCodexMcpConfig", () => {
     expect(toml).not.toContain("codex\nBROKEN");
     expect(toml.split("\n")).toHaveLength(5);
   });
+
+  it("escapes backspace and form-feed control characters", () => {
+    // \b and \f have dedicated TOML short escapes — make sure they don't
+    // fall through to the generic \uXXXX arm.
+    const toml = buildCodexMcpConfig({
+      ...inputs,
+      agentId: "codex\b\f",
+    });
+    expect(toml).toContain(`OPENCLAW_AGENT_ID = "codex\\b\\f"`);
+  });
 });
 
 describe("paths", () => {
@@ -86,6 +96,23 @@ describe("paths", () => {
     expect(MCP_TOML_TEMPLATE.endsWith("templates/openclaw-brain.mcp.toml")).toBe(
       true,
     );
+  });
+
+  it("falls back to assets/codex when hooks/ is absent (published CLI bundle layout)", async () => {
+    // In the workspace, hooks/ sits at the package root so the ternary's
+    // first arm wins. The published CLI bundle stages per-package assets
+    // under assets/codex/ instead — simulate that layout by mocking
+    // existsSync and re-importing the module.
+    vi.resetModules();
+    vi.doMock("node:fs", () => ({ existsSync: () => false }));
+    try {
+      const fresh = await import("./installer.js");
+      expect(fresh.PACKAGE_ROOT.endsWith("assets/codex")).toBe(true);
+      expect(fresh.TEMPLATES_DIR).toBe(`${fresh.PACKAGE_ROOT}/templates`);
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
+    }
   });
 });
 

--- a/packages/runtimes/codex/src/manifest.test.ts
+++ b/packages/runtimes/codex/src/manifest.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { TRANSCRIPT_SOURCE } from "./manifest.js";
+
+describe("TRANSCRIPT_SOURCE", () => {
+  it("self-describes the Codex transcript location for config.yaml sources", () => {
+    // Consumers (digest, dashboard, dream-cycle) read this descriptor from
+    // config.yaml rather than hardcoding paths — pin the exact shape.
+    expect(TRANSCRIPT_SOURCE).toEqual({
+      id: "codex-transcripts",
+      path: "$HOME/.codex/sessions",
+      format: "codex-jsonl",
+    });
+  });
+});

--- a/packages/runtimes/hermes/src/installer.test.ts
+++ b/packages/runtimes/hermes/src/installer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   PACKAGE_ROOT,
   SECTION_BEGIN,
@@ -12,6 +12,23 @@ describe("paths", () => {
   it("TEMPLATES_DIR sits under PACKAGE_ROOT", () => {
     expect(TEMPLATES_DIR).toBe(`${PACKAGE_ROOT}/templates`);
     expect(SOUL_MD_TEMPLATE.endsWith("templates/SOUL.md")).toBe(true);
+  });
+
+  it("falls back to assets/hermes when templates/ is absent (published CLI bundle layout)", async () => {
+    // In the workspace, templates/ sits at the package root so the
+    // ternary's first arm wins. The published CLI bundle stages
+    // per-package assets under assets/hermes/ instead — simulate that
+    // layout by mocking existsSync and re-importing the module.
+    vi.resetModules();
+    vi.doMock("node:fs", () => ({ existsSync: () => false }));
+    try {
+      const fresh = await import("./installer.js");
+      expect(fresh.PACKAGE_ROOT.endsWith("assets/hermes")).toBe(true);
+      expect(fresh.TEMPLATES_DIR).toBe(`${fresh.PACKAGE_ROOT}/templates`);
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
+    }
   });
 });
 

--- a/packages/runtimes/hermes/src/manifest.test.ts
+++ b/packages/runtimes/hermes/src/manifest.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { TRANSCRIPT_SOURCE } from "./manifest.js";
+
+describe("TRANSCRIPT_SOURCE", () => {
+  it("self-describes the Hermes transcript location for config.yaml sources", () => {
+    // Consumers (digest, dashboard, dream-cycle) read this descriptor from
+    // config.yaml rather than hardcoding paths — pin the exact shape,
+    // including the glob (Hermes writes one session_*.json per session).
+    expect(TRANSCRIPT_SOURCE).toEqual({
+      id: "hermes-transcripts",
+      path: "$HOME/.hermes/sessions",
+      format: "hermes-session-json",
+      glob: "session_*.json",
+    });
+  });
+});

--- a/packages/runtimes/openclaw/src/alias-resolver.test.ts
+++ b/packages/runtimes/openclaw/src/alias-resolver.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -329,6 +329,32 @@ describe("createOpenClawAliasResolver", () => {
     expect(resolver("unknown", makeCtx())).toBeUndefined();
   });
 
+  it("proceeds best-effort when chmod is unsupported (network mounts ignoring mode bits)", () => {
+    // Both tighten-up chmods (artifact dir 0700 + spec.json 0600) are
+    // best-effort: a filesystem that rejects chmod must not break dispatch.
+    const chmodSpy = vi.spyOn(fs, "chmodSync").mockImplementation(() => {
+      throw new Error("EPERM: operation not permitted");
+    });
+    try {
+      const resolver = createOpenClawAliasResolver({
+        aliases: { "claude-code-cli": claudeAlias },
+        artifactRoot,
+        workerScript: "/abs/worker.mjs",
+        nodeBinary: "/abs/node",
+      });
+      const result = resolver("claude-code-cli", makeCtx()) as TaskDispatch;
+      expect(result.mode).toBe("exec");
+      // Dir + spec chmod were both attempted (and both swallowed).
+      expect(chmodSpy).toHaveBeenCalledTimes(2);
+      // spec.json was still written despite the chmod failures.
+      expect(
+        fs.existsSync(path.join(artifactRoot, "g-1", "t-1", "spec.json")),
+      ).toBe(true);
+    } finally {
+      chmodSpy.mockRestore();
+    }
+  });
+
   it("works with a non-exec originalDispatch (still resolves the alias)", () => {
     const resolver = createOpenClawAliasResolver({
       aliases: { "claude-code-cli": claudeAlias },
@@ -348,5 +374,33 @@ describe("createOpenClawAliasResolver", () => {
       }),
     ) as TaskDispatch;
     expect(result.mode).toBe("exec");
+  });
+});
+
+describe("PACKAGE_ROOT resolution — published CLI bundle layout", () => {
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+  });
+
+  it("resolves DEFAULT_WORKER_SCRIPT under assets/openclaw when scripts/ is absent", async () => {
+    // In the published CLI bundle, esbuild inlines this module into
+    // <npm-pkg>/bin/*.js — MODULE_ROOT then has no scripts/ dir and the
+    // per-package assets are staged under assets/openclaw/ instead.
+    vi.resetModules();
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        existsSync: () => false,
+        default: { ...actual, existsSync: () => false },
+      };
+    });
+    const bundled = await import("./alias-resolver.js");
+    expect(
+      bundled.DEFAULT_WORKER_SCRIPT.endsWith(
+        "/assets/openclaw/scripts/cli-exec-worker.mjs",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/runtimes/openclaw/src/compat.test.ts
+++ b/packages/runtimes/openclaw/src/compat.test.ts
@@ -90,4 +90,46 @@ describe("compat", () => {
   it("never throws on a missing api", () => {
     expect(() => warnIfUntestedHost(undefined, "digital-me-brain")).not.toThrow();
   });
+
+  it("warns when the host is newer by YEAR (not just month/patch)", () => {
+    const { api, warnings } = makeApi("2027.1.0");
+    warnIfUntestedHost(api, "digital-me-brain");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("2027.1.0");
+  });
+
+  it("does not warn when the host is older by YEAR", () => {
+    const { api, warnings } = makeApi("2025.12.99");
+    warnIfUntestedHost(api, "digital-me-brain");
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does not warn (and does not throw) on an unparseable host version", () => {
+    const { api, warnings } = makeApi("beta");
+    expect(() => warnIfUntestedHost(api, "digital-me-brain")).not.toThrow();
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("resolveHostOpenclawVersion returns undefined when the api throws on access", () => {
+    // Defensive contract: a hostile/buggy api object (throwing config getter)
+    // must resolve to "unknown version", never propagate.
+    const throwingApi = {
+      get config(): never {
+        throw new Error("boom");
+      },
+    } as unknown as Parameters<typeof resolveHostOpenclawVersion>[0];
+    expect(resolveHostOpenclawVersion(throwingApi)).toBeUndefined();
+  });
+
+  it("warnIfUntestedHost swallows a throwing logger (compat check must never block load)", () => {
+    const api = {
+      config: { meta: { lastTouchedVersion: "2027.1.0" } },
+      logger: {
+        warn: () => {
+          throw new Error("logger exploded");
+        },
+      },
+    };
+    expect(() => warnIfUntestedHost(api, "digital-me-brain")).not.toThrow();
+  });
 });

--- a/packages/runtimes/openclaw/src/installer.test.ts
+++ b/packages/runtimes/openclaw/src/installer.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BRAIN_ENTRY_TEMPLATE,
   BRAIN_INSTALL_FILES,
@@ -233,6 +233,33 @@ describe("PLUGINS catalog", () => {
         expect(fs.existsSync(f.src)).toBe(true);
       }
     }
+  });
+});
+
+describe("PACKAGE_ROOT resolution — published CLI bundle layout", () => {
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+  });
+
+  it("falls back to <MODULE_ROOT>/assets/openclaw when templates/ is absent", async () => {
+    // In the published CLI bundle, esbuild inlines this module into
+    // <npm-pkg>/bin/*.js — MODULE_ROOT then has no templates/ dir and the
+    // per-package assets live under assets/openclaw/ instead.
+    vi.resetModules();
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        existsSync: () => false,
+        default: { ...actual, existsSync: () => false },
+      };
+    });
+    const bundled = await import("./installer.js");
+    expect(bundled.PACKAGE_ROOT.endsWith("/assets/openclaw")).toBe(true);
+    expect(bundled.TEMPLATES_DIR.endsWith("/assets/openclaw/templates")).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/runtimes/openclaw/src/manifest.test.ts
+++ b/packages/runtimes/openclaw/src/manifest.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { TRANSCRIPT_SOURCE } from "./manifest.js";
+
+describe("TRANSCRIPT_SOURCE", () => {
+  it("identifies the openclaw agent transcript store", () => {
+    expect(TRANSCRIPT_SOURCE.id).toBe("openclaw-agent-transcripts");
+    expect(TRANSCRIPT_SOURCE.format).toBe("openclaw-agent-jsonl");
+  });
+
+  it("points at the per-agent dir under the openclaw state home", () => {
+    // $HOME is expanded by the consumer at read time, not here.
+    expect(TRANSCRIPT_SOURCE.path).toBe("$HOME/.openclaw/agents");
+    expect(TRANSCRIPT_SOURCE.path.startsWith("$HOME/")).toBe(true);
+  });
+});

--- a/packages/runtimes/openclaw/src/recall-hooks.test.ts
+++ b/packages/runtimes/openclaw/src/recall-hooks.test.ts
@@ -14,6 +14,7 @@ import {
   readWikiBody,
   type AckEntry,
   type BootContextFsAccess,
+  type RecallHit,
   type WikiBodyReader,
 } from "./recall-hooks.js";
 
@@ -114,6 +115,22 @@ describe("loadBootContext", () => {
     expect(out).toContain("Protocol B body");
     expect(out).not.toContain("ignored");
   });
+
+  it("skips shared-protocols when the dir vanishes between exists check and read", () => {
+    const racyFs: BootContextFsAccess = {
+      readFile: () => null,
+      existsSync: () => true,
+      readdirSync: () => {
+        throw new Error("ENOENT: no such file or directory");
+      },
+    };
+    const out = loadBootContext(
+      { digitalMeProtocol: "P", protocolsDir: "/gone" },
+      racyFs,
+    );
+    expect(out).toContain("<digital-me-protocol>");
+    expect(out).not.toContain("<shared-protocols>");
+  });
 });
 
 // ─── Hook B ─────────────────────────────────────────────────────────────
@@ -151,6 +168,14 @@ describe("formatRecallInjection", () => {
     expect(out).toContain("E0");
     expect(out).not.toContain("E19");
   });
+
+  it("returns empty string when even the first hit exceeds maxChars", () => {
+    const out = formatRecallInjection(
+      [{ path: "big.md", body: "x".repeat(500) }],
+      100,
+    );
+    expect(out).toBe("");
+  });
 });
 
 // ─── Hook C ─────────────────────────────────────────────────────────────
@@ -176,6 +201,13 @@ describe("parseRouteFrontmatter", () => {
     expect(parseRouteFrontmatter(fm)).toEqual({
       toolName: "exec",
       conditions: 'params.command contains "ffmpeg"',
+    });
+  });
+
+  it("strips surrounding double quotes (YAML scalar form)", () => {
+    expect(parseRouteFrontmatter('route: "tool=tasks"')).toEqual({
+      toolName: "tasks",
+      conditions: "",
     });
   });
 
@@ -233,6 +265,25 @@ describe("buildRouteIndex", () => {
     expect(rec.rule).toBe("Be careful");
     expect(rec.filePath).toBe("a.md");
   });
+
+  it("skips entries with no frontmatter block", () => {
+    const idx = buildRouteIndex([
+      { filePath: "x.md", text: "# no fences here\nroute: tool=exec\n" },
+    ]);
+    expect(idx.size).toBe(0);
+  });
+
+  it("leaves title undefined when the frontmatter has no title:", () => {
+    const idx = buildRouteIndex([
+      {
+        filePath: "untitled.md",
+        text: "---\nroute: tool=tasks\n---\n\n## Rule\nBe safe\n",
+      },
+    ]);
+    const rec = idx.get("tasks")![0];
+    expect(rec.title).toBeUndefined();
+    expect(rec.rule).toBe("Be safe");
+  });
 });
 
 describe("matchRouteConditions", () => {
@@ -274,6 +325,20 @@ describe("matchRouteConditions", () => {
   it("returns false for unknown condition shapes (fail-closed)", () => {
     expect(matchRouteConditions("magic stuff here", { command: "x" })).toBe(false);
   });
+
+  it("returns false when the named param is not a string", () => {
+    expect(
+      matchRouteConditions('params.command contains "x"', { command: 42 }),
+    ).toBe(false);
+  });
+
+  it("returns false for a contains condition with no quoted patterns", () => {
+    expect(
+      matchRouteConditions("params.command contains ffmpeg", {
+        command: "ffmpeg -i in.mp4",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("formatRouteInjection", () => {
@@ -295,6 +360,44 @@ describe("formatRouteInjection", () => {
     expect(out).toContain("### ffmpeg flag");
     expect(out).toContain("-loglevel error");
     expect(out).toContain("</routed-learnings>");
+  });
+
+  it("labels rules without a title as (untitled)", () => {
+    const out = formatRouteInjection([
+      { toolName: "exec", conditions: "", rule: "R", filePath: "x.md" },
+    ]);
+    expect(out).toContain("### (untitled)");
+  });
+
+  it("caps total length, dropping rules that would overflow", () => {
+    const small = {
+      toolName: "exec",
+      conditions: "",
+      rule: "tiny rule",
+      filePath: "a.md",
+      title: "A",
+    };
+    const huge = {
+      toolName: "exec",
+      conditions: "",
+      rule: "x".repeat(5000),
+      filePath: "b.md",
+      title: "B",
+    };
+    const out = formatRouteInjection([small, huge], 200);
+    expect(out).toContain("### A");
+    expect(out).not.toContain("### B");
+  });
+
+  it("returns empty string when even the first rule exceeds maxChars", () => {
+    const huge = {
+      toolName: "exec",
+      conditions: "",
+      rule: "x".repeat(5000),
+      filePath: "b.md",
+      title: "B",
+    };
+    expect(formatRouteInjection([huge], 100)).toBe("");
   });
 });
 
@@ -405,6 +508,45 @@ describe("readWikiBody", () => {
     const reader = fakeReader({ "/wiki/x.md": "body" });
     expect(readWikiBody("/etc/passwd", "/wiki", reader)).toBeNull();
   });
+
+  it("resolves /tastes/ hits to the tastes tree next to the wiki root", () => {
+    const reader = fakeReader({
+      "/dm/tastes/food/x.md": "---\ntitle: X\n---\ntaste body",
+    });
+    expect(
+      readWikiBody("../../home/digital-me/tastes/food/x.md", "/dm/wiki", reader),
+    ).toBe("taste body");
+  });
+
+  it("resolves a bare wiki/-prefixed hit under the wiki root", () => {
+    const reader = fakeReader({ "/dm/wiki/infra/x.md": "---\n---\nbody" });
+    expect(readWikiBody("wiki/infra/x.md", "/dm/wiki", reader)).toBe("body");
+  });
+
+  it("resolves a bare tastes/-prefixed hit when wikiRoot is not */wiki", () => {
+    // Backcompat shape: a caller passing the digital-me parent dir directly.
+    const reader = fakeReader({
+      "/knowledge/tastes/food/x.md": "---\n---\ntaste",
+    });
+    expect(readWikiBody("tastes/food/x.md", "/knowledge", reader)).toBe("taste");
+  });
+
+  it("returns null when the file exists but reads empty", () => {
+    const reader = fakeReader({ "/wiki/foo.md": "" });
+    expect(readWikiBody("foo.md", "/wiki", reader)).toBeNull();
+  });
+
+  it("returns null when the body is empty after stripping frontmatter", () => {
+    const reader = fakeReader({ "/wiki/foo.md": "---\ntitle: x\n---\n   \n" });
+    expect(readWikiBody("foo.md", "/wiki", reader)).toBeNull();
+  });
+
+  it("returns the whole text when there is no frontmatter to strip", () => {
+    const reader = fakeReader({ "/wiki/foo.md": "just a body, no fences" });
+    expect(readWikiBody("foo.md", "/wiki", reader)).toBe(
+      "just a body, no fences",
+    );
+  });
 });
 
 describe("applyRecallHygiene", () => {
@@ -500,6 +642,22 @@ describe("applyRecallHygiene", () => {
     });
     expect(out).toEqual([]);
   });
+
+  it("skips null-ish hits and hits without a path", () => {
+    // Upstream search payloads are untrusted — a malformed element must not
+    // break hygiene for the well-formed hits around it.
+    const seen = new Set<string>();
+    const out = applyRecallHygiene({
+      hits: [
+        null as unknown as RecallHit,
+        { path: "", body: "no-path" },
+        { path: "ok.md", body: "OK", score: 0.9 },
+      ],
+      seen,
+    });
+    expect(out.map((h) => h.path)).toEqual(["ok.md"]);
+    expect(seen.has("")).toBe(false);
+  });
 });
 
 describe("formatRecallInjection — [Digital Me] attribution + directive", () => {
@@ -578,5 +736,73 @@ describe("parseDigitalMeAck — [Digital Me] application-start marker", () => {
   it("returns no_acknowledgement when nothing was surfaced", () => {
     const { ackSignal } = parseDigitalMeAck("[Digital Me] applying x", []);
     expect(ackSignal).toBe("no_acknowledgement");
+  });
+
+  it("returns no_acknowledgement for an empty or whitespace-only reply", () => {
+    expect(parseDigitalMeAck("", surfaced).ackSignal).toBe(
+      "no_acknowledgement",
+    );
+    expect(parseDigitalMeAck("   \n\t ", surfaced).ackSignal).toBe(
+      "no_acknowledgement",
+    );
+  });
+
+  it("counts explicit_path for a slug hit without an .md extension", () => {
+    const entries: AckEntry[] = [
+      { path: "infrastructure/deploy-runbook-notes", title: "Deploy Runbook Notes" },
+    ];
+    const { ackSignal, actedEntries } = parseDigitalMeAck(
+      "[Digital Me] applying deploy-runbook-notes as instructed.",
+      entries,
+    );
+    expect(ackSignal).toBe("explicit_path");
+    expect(actedEntries).toHaveLength(1);
+  });
+
+  it("matches by path when the surfaced entry has no title", () => {
+    const entries: AckEntry[] = [{ path: "youtube/thumbnail-rules.md" }];
+    const { ackSignal, actedEntries } = parseDigitalMeAck(
+      "[Digital Me] applying thumbnail-rules here.",
+      entries,
+    );
+    expect(ackSignal).toBe("explicit_path");
+    expect(actedEntries.map((e) => e.path)).toEqual([
+      "youtube/thumbnail-rules.md",
+    ]);
+  });
+
+  it("tolerates entries with an empty path (title-only match)", () => {
+    const entries: AckEntry[] = [
+      { path: "", title: "Deployment Runbook Checklist" },
+    ];
+    const { ackSignal, actedEntries } = parseDigitalMeAck(
+      "[Digital Me] applying Deployment Runbook Checklist.",
+      entries,
+    );
+    expect(ackSignal).toBe("title_match");
+    expect(actedEntries).toHaveLength(1);
+  });
+
+  it("matches a title stem, ignoring trailing decorations like ' (2026 edition)'", () => {
+    const entries: AckEntry[] = [
+      { path: "a.md", title: "Thumbnail Rules (2026 edition)" },
+    ];
+    const { ackSignal } = parseDigitalMeAck(
+      "[Digital Me] applying Thumbnail Rules.",
+      entries,
+    );
+    expect(ackSignal).toBe("title_match");
+  });
+
+  it("refuses to title-match a stem shorter than 5 chars (falls back to top-1 attribution)", () => {
+    // "Git" stems to < 5 chars — too short to be a confident title match, so
+    // the bare prefix falls back to top-1 attribution instead.
+    const entries: AckEntry[] = [{ path: "a.md", title: "Git" }];
+    const { ackSignal, actedEntries } = parseDigitalMeAck(
+      "[Digital Me] applying Git",
+      entries,
+    );
+    expect(ackSignal).toBe("title_match");
+    expect(actedEntries).toEqual([entries[0]]);
   });
 });

--- a/packages/runtimes/openclaw/src/recall-hooks.ts
+++ b/packages/runtimes/openclaw/src/recall-hooks.ts
@@ -314,9 +314,14 @@ export function readWikiBody(
   let rel: string;
   let treePrefix: "wiki" | "tastes" | null = null;
   if (hitPath.includes("/wiki/")) {
+    // `?? hitPath` only narrows TS's index type — split() after a successful
+    // includes() always yields ≥2 parts, so [1] is never undefined at runtime.
+    /* v8 ignore next */
     rel = hitPath.split("/wiki/")[1] ?? hitPath;
     treePrefix = "wiki";
   } else if (hitPath.includes("/tastes/")) {
+    // Same TS-narrowing-only fallback as the /wiki/ arm above.
+    /* v8 ignore next */
     rel = hitPath.split("/tastes/")[1] ?? hitPath;
     treePrefix = "tastes";
   } else if (hitPath.startsWith("wiki/")) {
@@ -500,6 +505,9 @@ export function matchRouteConditions(
   // `params.X OR params.Y` — existence check
   const orExistMatch = c.match(/^params\.(\w+)(?:\s+OR\s+params\.(\w+))+\s*$/);
   if (orExistMatch) {
+    // `|| []` only narrows TS's null type — the anchored orExistMatch above
+    // guarantees the global scan finds at least two params.X occurrences.
+    /* v8 ignore next */
     const fields = c.match(/params\.(\w+)/g) || [];
     return fields.some((f) => {
       const name = f.slice("params.".length);

--- a/packages/runtimes/openclaw/src/updater.test.ts
+++ b/packages/runtimes/openclaw/src/updater.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PNPM_SPEC,
   OVERLAY_DIRNAMES,
+  defaultExec,
   pnpmSpecFromPackageManager,
   resolvePnpmSpec,
   selectMatureStableTag,
@@ -145,6 +146,24 @@ function scriptedExec(cfg: ScriptConfig): ExecFn & { calls: { cmd: string; args:
     return ok("");
   }) as ExecFn & { calls: { cmd: string; args: string[] }[] };
   (exec as { calls: typeof calls }).calls = calls;
+  return exec;
+}
+
+/** Wrap a scripted exec, letting `override` intercept specific commands while
+ *  keeping the underlying call recording intact. */
+function withOverride(
+  inner: ReturnType<typeof scriptedExec>,
+  override: (cmd: string, args: readonly string[]) => ExecResult | undefined,
+): ExecFn & { calls: { cmd: string; args: string[] }[] } {
+  const exec = ((cmd, args, opts) => {
+    const hit = override(cmd, args);
+    if (hit) {
+      inner.calls.push({ cmd, args: [...args] });
+      return hit;
+    }
+    return inner(cmd, args, opts);
+  }) as ExecFn & { calls: { cmd: string; args: string[] }[] };
+  exec.calls = inner.calls;
   return exec;
 }
 
@@ -353,6 +372,10 @@ describe("updateOpenclaw", () => {
   async function runWithOpenclawHome(opts: {
     cfg: ScriptConfig;
     withSentinel: boolean;
+    /** Optional log collector (defaults to a silent logger). */
+    log?: (line: string) => void;
+    /** Optional exec override (defaults to scriptedExec(cfg)). */
+    exec?: ExecFn & { calls: { cmd: string; args: string[] }[] };
   }) {
     const prevHome = process.env.OPENCLAW_HOME;
     const openclawHome = fs.mkdtempSync(path.join(os.tmpdir(), "oc-home-"));
@@ -361,7 +384,7 @@ describe("updateOpenclaw", () => {
     if (opts.withSentinel) {
       fs.writeFileSync(path.join(openclawHome, "disable-launchagent"), "");
     }
-    const exec = scriptedExec(opts.cfg);
+    const exec = opts.exec ?? scriptedExec(opts.cfg);
     const { repoDir, extensionsDir } = makeRepo();
     try {
       const res = await updateOpenclaw({
@@ -369,7 +392,7 @@ describe("updateOpenclaw", () => {
         repoDir,
         extensionsDir,
         exec,
-        log: () => {},
+        log: opts.log ?? (() => {}),
         rematerializeOverlay: writingRematerialize(extensionsDir),
       });
       return { res, exec };
@@ -529,6 +552,575 @@ describe("updateOpenclaw", () => {
         c.cmd === "pnpm" && c.args.some((a) => /^pnpm@\d/.test(a)),
     );
     expect(leakedSpec).toBeUndefined();
+  });
+
+  // ── preflight failures + path resolution ─────────────────────────────
+
+  it("fails when the repo dir is missing, via the default exec and console logger", async () => {
+    // No exec/log injected: exercises the defaultExec + console.log defaults.
+    // Nothing is spawned — the existsSync preflight fails first.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const prevRepo = process.env.OPENCLAW_REPO;
+    delete process.env.OPENCLAW_REPO;
+    try {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "oc-nohome-"));
+      tmpDirs.push(home);
+      const res = await updateOpenclaw({
+        home,
+        rematerializeOverlay: async () => 0,
+      });
+      expect(res.status).toBe("failed");
+      expect(res.exitCode).toBe(1);
+      expect(res.blockers.join(" ")).toMatch(/openclaw repo not found/);
+      // Default repo resolution: <home>/openclaw.
+      expect(res.blockers.join(" ")).toContain(path.join(home, "openclaw"));
+      expect(logSpy).toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+      if (prevRepo !== undefined) process.env.OPENCLAW_REPO = prevRepo;
+    }
+  });
+
+  it("resolves the repo from $OPENCLAW_REPO when --repo-dir is not given", async () => {
+    const prevRepo = process.env.OPENCLAW_REPO;
+    process.env.OPENCLAW_REPO = "/nonexistent/openclaw-env-repo";
+    try {
+      const res = await updateOpenclaw({
+        home: os.tmpdir(),
+        exec: scriptedExec(base()),
+        log: () => {},
+        rematerializeOverlay: async () => 0,
+      });
+      expect(res.status).toBe("failed");
+      expect(res.blockers.join(" ")).toContain("/nonexistent/openclaw-env-repo");
+    } finally {
+      if (prevRepo === undefined) delete process.env.OPENCLAW_REPO;
+      else process.env.OPENCLAW_REPO = prevRepo;
+    }
+  });
+
+  it("fails when the dir is not a git work tree", async () => {
+    const exec = withOverride(scriptedExec(base()), (cmd, args) =>
+      cmd === "git" && args.includes("--is-inside-work-tree")
+        ? { status: 0, stdout: "false", stderr: "" }
+        : undefined,
+    );
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      exec,
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/not a git work tree/);
+  });
+
+  it("fails on a stale .git/index.lock", async () => {
+    const { repoDir, extensionsDir } = makeRepo();
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(repoDir, ".git", "index.lock"), "");
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      exec: scriptedExec(base()),
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/index\.lock/);
+  });
+
+  it("counts in-tree overlay-like paths as dirt when extensionsDir is outside the repo", async () => {
+    // With the overlay outside repoDir, git-status entries can never belong
+    // to it — an in-tree extensions/ path is real dirt, not overlay.
+    const { repoDir } = makeRepo();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "oc-ext-"));
+    tmpDirs.push(outside);
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir: outside,
+      exec: scriptedExec({
+        ...base(),
+        porcelain: "?? extensions/digital-me-brain/index.mjs",
+      }),
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/uncommitted changes/);
+  });
+
+  it("updates cleanly with an extensionsDir outside the repo", async () => {
+    const cfg = base();
+    const { repoDir } = makeRepo();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "oc-ext-"));
+    tmpDirs.push(outside);
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir: outside,
+      skipRestart: true,
+      exec: scriptedExec(cfg),
+      log: () => {},
+      rematerializeOverlay: writingRematerialize(outside),
+    });
+    expect(res.status).toBe("updated");
+  });
+
+  it("treats overlay dirs at the repo root as overlay when extensionsDir IS the repo dir", async () => {
+    const { repoDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir: repoDir,
+      dryRun: true,
+      exec: scriptedExec({
+        ...base(),
+        porcelain: "?? digital-me-brain/index.mjs",
+      }),
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    // The root-level overlay dir is ignored by the clean check.
+    expect(res.status).toBe("dry-run");
+  });
+
+  it("logs a NOTE when the overlay is git-tracked (legacy fork model)", async () => {
+    const cfg = base();
+    cfg.tracked = "extensions/digital-me-brain/index.mjs";
+    const { repoDir, extensionsDir } = makeRepo();
+    const lines: string[] = [];
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      dryRun: true,
+      exec: scriptedExec(cfg),
+      log: (l) => lines.push(l),
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("dry-run");
+    expect(lines.join("\n")).toMatch(/\[NOTE\] Plugin overlay is git-tracked/);
+  });
+
+  // ── fetch / tag selection / resolution failures ──────────────────────
+
+  it("fails with a blocker when git fetch fails", async () => {
+    const cfg = base();
+    cfg.fetchStatus = 1;
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      exec: scriptedExec(cfg),
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/git fetch failed/);
+  });
+
+  it("falls back to origin/main (with a WARN) when no mature stable tag exists", async () => {
+    const cfg = base();
+    cfg.tagsOutput = "";
+    cfg.targetRef = "origin/main";
+    const { repoDir, extensionsDir } = makeRepo();
+    const lines: string[] = [];
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      dryRun: true,
+      exec: scriptedExec(cfg),
+      log: (l) => lines.push(l),
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("dry-run");
+    expect(res.toRef).toBe("origin/main");
+    expect(lines.join("\n")).toMatch(/no stable tag/);
+  });
+
+  it("fails when the target ref cannot be resolved to a commit", async () => {
+    const exec = withOverride(scriptedExec(base()), (cmd, args) =>
+      cmd === "git" && args.some((a) => a.endsWith("^{commit}"))
+        ? { status: 1, stdout: "", stderr: "" }
+        : undefined,
+    );
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      exec,
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/could not resolve target ref/);
+  });
+
+  it("logs --pnpm-spec as the pnpm source when explicitly overridden", async () => {
+    const { repoDir, extensionsDir } = makeRepo();
+    const lines: string[] = [];
+    await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      dryRun: true,
+      pnpmSpec: "pnpm@9.9.9",
+      exec: scriptedExec(base()),
+      log: (l) => lines.push(l),
+      rematerializeOverlay: async () => 0,
+    });
+    expect(lines.join("\n")).toMatch(/pnpm@9\.9\.9 \(--pnpm-spec\)/);
+  });
+
+  it("noop reports 'unknown' when package.json cannot be parsed at either ref", async () => {
+    const cfg = base();
+    cfg.targetSha = cfg.headSha; // already current
+    const exec = withOverride(scriptedExec(cfg), (cmd, args) =>
+      cmd === "git" && args.includes("show")
+        ? { status: 0, stdout: "not-json{", stderr: "" }
+        : undefined,
+    );
+    const { repoDir, extensionsDir } = makeRepo();
+    const lines: string[] = [];
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      exec,
+      log: (l) => lines.push(l),
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("noop");
+    expect(lines.join("\n")).toMatch(/\(unknown\)/);
+  });
+
+  it("plans with sha/'?' fallbacks when git show fails at both refs (dry-run, skipRestart)", async () => {
+    const cfg = base();
+    const exec = withOverride(scriptedExec(cfg), (cmd, args) =>
+      cmd === "git" && args.includes("show")
+        ? { status: 1, stdout: "", stderr: "fatal: bad object" }
+        : undefined,
+    );
+    const { repoDir, extensionsDir } = makeRepo();
+    const lines: string[] = [];
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      dryRun: true,
+      skipRestart: true,
+      exec,
+      log: (l) => lines.push(l),
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("dry-run");
+    expect(res.fromVersion).toBeUndefined();
+    expect(res.toVersion).toBeUndefined();
+    const all = lines.join("\n");
+    // Plan header falls back to the abbreviated sha and "?".
+    expect(all).toMatch(/aaaaaaaaaa → \?/);
+    // skipRestart drops the re-stamp/restart step from the dry-run plan.
+    expect(all).not.toMatch(/re-stamp service \+ restart gateway/);
+  });
+
+  // ── checkout / build / overlay / smoke failures ──────────────────────
+
+  it("fails with a blocker when git checkout fails", async () => {
+    const cfg = base();
+    cfg.checkoutStatus = 1;
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      skipRestart: true,
+      exec: scriptedExec(cfg),
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/git checkout failed/);
+  });
+
+  it("fails when post-checkout HEAD does not land on the target sha", async () => {
+    const cfg = base();
+    // rev-parse HEAD keeps answering the OLD sha even after checkout.
+    const exec = withOverride(scriptedExec(cfg), (cmd, args) =>
+      cmd === "git" && args.includes("rev-parse") && args.includes("HEAD")
+        ? { status: 0, stdout: cfg.headSha, stderr: "" }
+        : undefined,
+    );
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      skipRestart: true,
+      exec,
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/post-checkout HEAD/);
+  });
+
+  it("fails with a blocker when pnpm build fails", async () => {
+    const cfg = base();
+    cfg.buildStatus = 1;
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      skipRestart: true,
+      exec: scriptedExec(cfg),
+      log: () => {},
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/pnpm build failed/);
+  });
+
+  it("fails when overlay materialization returns a non-zero exit", async () => {
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      skipRestart: true,
+      exec: scriptedExec(base()),
+      log: () => {},
+      rematerializeOverlay: async () => 3,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/overlay materialization failed \(exit 3\)/);
+  });
+
+  it("fails when a built overlay entry is missing on disk", async () => {
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      skipRestart: true,
+      exec: scriptedExec(base()),
+      log: () => {},
+      // Claims success but writes nothing.
+      rematerializeOverlay: async () => 0,
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/missing built overlay entry/);
+  });
+
+  it("fails when an overlay bundle flunks the node --check syntax smoke", async () => {
+    const cfg = base();
+    cfg.smokeStatus = 1;
+    const { repoDir, extensionsDir } = makeRepo();
+    const res = await updateOpenclaw({
+      home: os.tmpdir(),
+      repoDir,
+      extensionsDir,
+      skipRestart: true,
+      exec: scriptedExec(cfg),
+      log: () => {},
+      rematerializeOverlay: writingRematerialize(extensionsDir),
+    });
+    expect(res.status).toBe("failed");
+    expect(res.blockers.join(" ")).toMatch(/failed syntax smoke/);
+  });
+
+  // ── restart / audit edge cases ───────────────────────────────────────
+
+  it("warns (non-fatal) when gateway restart fails", async () => {
+    const cfg = base();
+    cfg.hasOpenclaw = true;
+    cfg.restartStatus = 1;
+    const lines: string[] = [];
+    const { res } = await runWithOpenclawHome({
+      cfg,
+      withSentinel: true, // restart-only path
+      log: (l) => lines.push(l),
+    });
+    // Non-fatal: the update itself is applied.
+    expect(res.status).toBe("updated");
+    expect(lines.join("\n")).toMatch(/gateway restart returned 1/);
+  });
+
+  it("warns and skips the restart when 'openclaw' is not on PATH", async () => {
+    const cfg = base(); // hasOpenclaw defaults to falsy → `which` fails
+    const lines: string[] = [];
+    const { res, exec } = await runWithOpenclawHome({
+      cfg,
+      withSentinel: false,
+      log: (l) => lines.push(l),
+    });
+    expect(res.status).toBe("updated");
+    expect(lines.join("\n")).toMatch(/'openclaw' not on PATH/);
+    expect(exec.calls.some((c) => c.cmd === "openclaw")).toBe(false);
+  });
+
+  it("audit warns when the live version/probe don't reflect the update yet", async () => {
+    const cfg = base();
+    cfg.hasOpenclaw = true;
+    const exec = withOverride(scriptedExec(cfg), (cmd, args) => {
+      if (cmd === "openclaw" && args.includes("--version")) {
+        return { status: 0, stdout: "OpenClaw 0.0.0", stderr: "" };
+      }
+      if (cmd === "openclaw" && args.includes("status")) {
+        return { status: 0, stdout: "still starting", stderr: "" };
+      }
+      return undefined;
+    });
+    const lines: string[] = [];
+    const { res } = await runWithOpenclawHome({
+      cfg,
+      withSentinel: true, // restart-only path runs the audit directly
+      log: (l) => lines.push(l),
+      exec,
+    });
+    expect(res.status).toBe("updated");
+    const all = lines.join("\n");
+    expect(all).toMatch(/does not include 2026\.5\.27/);
+    expect(all).toMatch(/did not report 'Connectivity probe: ok'/);
+  });
+
+  it("falls back to ref names in logs when versions are unknown (full update + re-stamp)", async () => {
+    const cfg = base();
+    cfg.hasOpenclaw = true;
+    const exec = withOverride(scriptedExec(cfg), (cmd, args) =>
+      cmd === "git" && args.includes("show")
+        ? { status: 0, stdout: "{invalid", stderr: "" }
+        : undefined,
+    );
+    const lines: string[] = [];
+    const { res } = await runWithOpenclawHome({
+      cfg,
+      withSentinel: false, // re-stamp + restart path
+      log: (l) => lines.push(l),
+      exec,
+    });
+    expect(res.status).toBe("updated");
+    const all = lines.join("\n");
+    // toVersion unknown → both stamps fall back to the tag ref…
+    expect(all).toMatch(/service files re-stamped to v2026\.5\.27/);
+    // …and the final OK line falls back to the abbreviated sha + tag ref.
+    expect(all).toMatch(/openclaw updated aaaaaaaaaa → v2026\.5\.27/);
+  });
+
+  // ── env-var extensionsDir resolution ─────────────────────────────────
+
+  it("resolves extensionsDir from $OPENCLAW_EXTENSIONS_DIR when not given", async () => {
+    const prevExt = process.env.OPENCLAW_EXTENSIONS_DIR;
+    const envExt = fs.mkdtempSync(path.join(os.tmpdir(), "oc-envext-"));
+    tmpDirs.push(envExt);
+    process.env.OPENCLAW_EXTENSIONS_DIR = envExt;
+    try {
+      const { repoDir } = makeRepo();
+      let got: string | undefined;
+      const res = await updateOpenclaw({
+        home: os.tmpdir(),
+        repoDir,
+        skipRestart: true,
+        exec: scriptedExec(base()),
+        log: () => {},
+        rematerializeOverlay: async ({ extensionsDir }) => {
+          got = extensionsDir;
+          await writingRematerialize(extensionsDir)();
+          return 0;
+        },
+      });
+      expect(res.status).toBe("updated");
+      expect(got).toBe(envExt);
+    } finally {
+      if (prevExt === undefined) delete process.env.OPENCLAW_EXTENSIONS_DIR;
+      else process.env.OPENCLAW_EXTENSIONS_DIR = prevExt;
+    }
+  });
+
+  it("defaults extensionsDir to <OPENCLAW_HOME>/extensions when nothing else is set", async () => {
+    const prevExt = process.env.OPENCLAW_EXTENSIONS_DIR;
+    const prevHome = process.env.OPENCLAW_HOME;
+    delete process.env.OPENCLAW_EXTENSIONS_DIR;
+    const openclawHome = fs.mkdtempSync(path.join(os.tmpdir(), "oc-statehome-"));
+    tmpDirs.push(openclawHome);
+    process.env.OPENCLAW_HOME = openclawHome;
+    try {
+      const { repoDir } = makeRepo();
+      let got: string | undefined;
+      const res = await updateOpenclaw({
+        home: os.tmpdir(),
+        repoDir,
+        skipRestart: true,
+        exec: scriptedExec(base()),
+        log: () => {},
+        rematerializeOverlay: async ({ extensionsDir }) => {
+          got = extensionsDir;
+          await writingRematerialize(extensionsDir)();
+          return 0;
+        },
+      });
+      expect(res.status).toBe("updated");
+      expect(got).toBe(path.join(openclawHome, "extensions"));
+    } finally {
+      if (prevExt === undefined) delete process.env.OPENCLAW_EXTENSIONS_DIR;
+      else process.env.OPENCLAW_EXTENSIONS_DIR = prevExt;
+      if (prevHome === undefined) delete process.env.OPENCLAW_HOME;
+      else process.env.OPENCLAW_HOME = prevHome;
+    }
+  });
+});
+
+describe("defaultExec", () => {
+  it("runs a real process, forwarding cwd/env/input/timeout", () => {
+    const res = defaultExec(
+      process.execPath,
+      [
+        "-e",
+        "process.stdout.write(require('node:fs').readFileSync(0,'utf8') + process.env.DM_TEST_MARK)",
+      ],
+      {
+        cwd: os.tmpdir(),
+        env: { ...process.env, DM_TEST_MARK: "-mark" },
+        input: "echoed",
+        timeoutMs: 30_000,
+      },
+    );
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe("echoed-mark");
+  });
+
+  it("uses the built-in defaults (no opts) and captures stderr + exit code", () => {
+    const res = defaultExec(process.execPath, [
+      "-e",
+      "process.stderr.write('warn'); process.exit(3)",
+    ]);
+    expect(res.status).toBe(3);
+    expect(res.stderr).toBe("warn");
+    expect(res.stdout).toBe("");
+  });
+
+  it("maps a spawn error (missing binary) to status 1 with empty output", () => {
+    const res = defaultExec("/definitely/not/a/binary-dm-test", []);
+    expect(res.status).toBe(1);
+    expect(res.stdout).toBe("");
+    expect(res.stderr).toBe("");
+  });
+
+  it("maps a signal-killed process (null status, no spawn error) to status 0", () => {
+    const res = defaultExec(process.execPath, [
+      "-e",
+      "process.kill(process.pid, 'SIGKILL')",
+    ]);
+    expect(res.status).toBe(0);
   });
 });
 

--- a/packages/runtimes/openclaw/src/updater.ts
+++ b/packages/runtimes/openclaw/src/updater.ts
@@ -93,7 +93,10 @@ export interface UpdateResult {
 
 const MINUTE = 60_000;
 
-function defaultExec(
+/** Default {@link ExecFn}: a spawnSync wrapper. Exported for direct unit
+ * testing of the process-runner edge cases (missing binary, signal kill);
+ * production callers go through {@link updateOpenclaw}'s `opts.exec` default. */
+export function defaultExec(
   cmd: string,
   args: readonly string[],
   opts: {

--- a/packages/runtimes/openclaw/src/wiki-graph.test.ts
+++ b/packages/runtimes/openclaw/src/wiki-graph.test.ts
@@ -137,4 +137,12 @@ describe("expandViaGraph", () => {
     const out = expandViaGraph([graph["a.md"]], (p) => graph[p] ?? null, 5);
     expect(out.map((e) => e.relPath).sort()).toEqual(["a.md", "b.md"]);
   });
+
+  it("treats a node without a related: field as having no neighbors", () => {
+    // frontmatter.related is optional — entries parsed from files with no
+    // related: line arrive as {} and must not blow up the walk.
+    const bare: WikiEntry = { relPath: "bare.md", frontmatter: {} };
+    const out = expandViaGraph([bare], () => null, 2);
+    expect(out.map((e) => e.relPath)).toEqual(["bare.md"]);
+  });
 });

--- a/packages/services/dashboard/src/frontend/components/ActivityFeed.tsx
+++ b/packages/services/dashboard/src/frontend/components/ActivityFeed.tsx
@@ -16,8 +16,11 @@ import remarkGfm from "remark-gfm";
  * (see server/activity-feed.ts).
  */
 
-type ActivityKind = "captured" | "applied" | "workflow" | "taste";
-type ActivityFilter = "all" | ActivityKind;
+/** `knowledge` is frontend-only: it badges search results (wiki entries and
+ *  memory leaves surfaced by /api/search) in the same post design the four
+ *  live streams use. The feed API itself never emits it. */
+type ActivityKind = "captured" | "applied" | "workflow" | "taste" | "knowledge";
+type ActivityFilter = "all" | Exclude<ActivityKind, "knowledge">;
 
 const FILTERS: { key: ActivityFilter; label: string }[] = [
   { key: "all", label: "All" },
@@ -92,6 +95,8 @@ function agentMeta(agent: string): AgentMeta {
   const id = (agent || "").toLowerCase();
   // The dream-cycle distills taste principles — it gets the brain avatar.
   if (id === "dream-cycle") return { name: "Dream Cycle", handle: "dreamcycle", brain: true, accent: "#DB2777" };
+  // Search results are authored by the knowledge base itself, not a runtime.
+  if (id === "wiki") return { name: "Living Knowledge", handle: "wiki", brain: true, accent: "#0F766E" };
   for (const r of RUNTIMES) if (r.match.test(id)) return r.meta;
   // Everything else (coo, podcast, youtube, orchestrator, …) is an
   // OpenClaw-runtime agent: keep its readable name, give it the OpenClaw logo.
@@ -134,6 +139,7 @@ const ACTIVITY_VERB: Record<ActivityKind, string> = {
   applied: "applied knowledge",
   workflow: "started a workflow",
   taste: "distilled a taste",
+  knowledge: "matched your search",
 };
 
 const ACTIVITY_BADGE: Record<ActivityKind, { label: string; cls: string; icon: string }> = {
@@ -141,7 +147,52 @@ const ACTIVITY_BADGE: Record<ActivityKind, { label: string; cls: string; icon: s
   applied: { label: "Applied learning", cls: "bg-cyan-50 text-cyan-700 border-cyan-200", icon: "↻" },
   workflow: { label: "Workflow", cls: "bg-violet-50 text-violet-700 border-violet-200", icon: "▸" },
   taste: { label: "Taste principle", cls: "bg-rose-50 text-rose-700 border-rose-200", icon: "◆" },
+  knowledge: { label: "Knowledge", cls: "bg-emerald-50 text-emerald-700 border-emerald-200", icon: "◈" },
 };
+
+// ── Search (ranked memory_search over the knowledge base) ──────────────────
+
+interface SearchResult {
+  id: string;
+  rank: number;
+  title: string;
+  path: string;
+  score: number | null;
+  snippet: string;
+  markdown: string | null;
+}
+
+interface SearchResponse {
+  query: string;
+  results: SearchResult[];
+}
+
+const SEARCH_DEBOUNCE_MS = 300;
+const SEARCH_LIMIT = 20;
+
+/** Present a ranked search hit in the feed's own vocabulary: a post authored
+ *  by the knowledge base, carrying the entry as a previewable attachment. */
+function searchResultToItem(r: SearchResult): ActivityItem {
+  return {
+    id: r.id,
+    ts: "", // rank replaces recency in search mode; the preview hides it
+    agent_id: "wiki",
+    activity: "knowledge",
+    title: r.title,
+    description: snippetTeaser(r.snippet),
+    meta: r.path,
+    attachments: [{ title: r.title, path: r.path, markdown: r.markdown }],
+  };
+}
+
+/** Body teaser from a raw snippet: drop the frontmatter block, the tool's
+ *  trailing "Source: <path>#Lx-Ly" citation line, and markdown noise so the
+ *  post preview reads as prose. */
+function snippetTeaser(snippet: string): string | null {
+  const body = stripFrontmatter(snippet ?? "").replace(/^Source:\s.*$/gm, " ");
+  const teaser = headline(body);
+  return teaser.length > 0 ? teaser : null;
+}
 
 export function ActivityFeed() {
   const [items, setItems] = useState<ActivityItem[]>([]);
@@ -151,7 +202,16 @@ export function ActivityFeed() {
   const [preview, setPreview] = useState<PreviewTarget | null>(null);
   const newIdsRef = useRef<Set<string>>(new Set());
 
+  // Search mode: a non-empty query pauses the live feed poll and shows
+  // ranked memory_search results in the same post design instead.
+  const [query, setQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[] | null>(null);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const searching = query.trim().length > 0;
+
   useEffect(() => {
+    if (searching) return; // paused while a search is active
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     // Reset to the loading state when the filter changes so the feed doesn't
@@ -188,7 +248,44 @@ export function ActivityFeed() {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-  }, [filter]);
+  }, [filter, searching]);
+
+  // Debounced ranked search. Results arrive pre-ranked from the brain's
+  // memory_search; stale responses are dropped via the cancelled flag.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length === 0) {
+      setSearchResults(null);
+      setSearchError(null);
+      setIsSearching(false);
+      return;
+    }
+    let cancelled = false;
+    setIsSearching(true);
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(q)}&limit=${SEARCH_LIMIT}`);
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(body?.error ?? `HTTP ${res.status}`);
+        }
+        const json = (await res.json()) as SearchResponse;
+        if (cancelled) return;
+        setSearchResults(json.results);
+        setSearchError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setSearchResults(null);
+        setSearchError(e instanceof Error ? e.message : "Unknown error");
+      } finally {
+        if (!cancelled) setIsSearching(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
 
   return (
     <div className="space-y-5">
@@ -207,29 +304,70 @@ export function ActivityFeed() {
             </p>
           </div>
           <span className="text-[10px] font-mono uppercase tracking-wider text-gray-300 whitespace-nowrap">
-            live · {POLL_INTERVAL_MS / 1000}s · {items.length} post{items.length === 1 ? "" : "s"}
+            {searching
+              ? `search · ${searchResults?.length ?? 0} result${(searchResults?.length ?? 0) === 1 ? "" : "s"}`
+              : `live · ${POLL_INTERVAL_MS / 1000}s · ${items.length} post${items.length === 1 ? "" : "s"}`}
           </span>
         </div>
 
-        {/* Filter chips */}
-        <div className="flex gap-2 mt-4">
-          {FILTERS.map((f) => (
-            <button
-              key={f.key}
-              onClick={() => setFilter(f.key)}
-              className={`text-xs px-3 py-1 rounded-full border transition-colors ${
-                filter === f.key
-                  ? "bg-gray-900 text-white border-gray-900"
-                  : "bg-white text-gray-500 border-gray-200 hover:border-gray-300"
-              }`}
-            >
-              {f.label}
-            </button>
-          ))}
+        {/* Search + filter chips */}
+        <div className="flex flex-wrap items-center gap-3 mt-4">
+          <div className="relative">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-300" aria-hidden>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <circle cx="11" cy="11" r="7" />
+                <path d="m20 20-3.5-3.5" />
+              </svg>
+            </span>
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search knowledge…"
+              aria-label="Search knowledge"
+              className="w-56 rounded-full border border-gray-200 bg-white pl-8 pr-8 py-1 text-xs text-gray-700 placeholder:text-gray-300 outline-none transition-colors focus:border-gray-400 [&::-webkit-search-cancel-button]:hidden"
+            />
+            {searching ? (
+              <button
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 flex h-4 w-4 items-center justify-center rounded-full text-gray-300 transition-colors hover:text-gray-600"
+              >
+                ✕
+              </button>
+            ) : null}
+          </div>
+          {!searching
+            ? FILTERS.map((f) => (
+                <button
+                  key={f.key}
+                  onClick={() => setFilter(f.key)}
+                  className={`text-xs px-3 py-1 rounded-full border transition-colors ${
+                    filter === f.key
+                      ? "bg-gray-900 text-white border-gray-900"
+                      : "bg-white text-gray-500 border-gray-200 hover:border-gray-300"
+                  }`}
+                >
+                  {f.label}
+                </button>
+              ))
+            : (
+                <span className="text-xs text-gray-400">
+                  ranked by relevance · memory_search
+                </span>
+              )}
         </div>
       </motion.div>
 
-      {isLoading && items.length === 0 ? (
+      {searching ? (
+        <SearchResults
+          results={searchResults}
+          isSearching={isSearching}
+          error={searchError}
+          query={query.trim()}
+          onOpen={(item, attachment) => setPreview({ item, attachment })}
+        />
+      ) : isLoading && items.length === 0 ? (
         <div className="flex items-center justify-center py-24">
           <p className="text-[10px] text-gray-400 uppercase tracking-[0.3em] font-mono">Loading feed</p>
         </div>
@@ -263,6 +401,110 @@ export function ActivityFeed() {
 
       <PreviewPanel target={preview} onClose={() => setPreview(null)} />
     </div>
+  );
+}
+
+/** Ranked search results, rendered with the feed's own post design: each hit
+ *  is a post authored by the knowledge base, its entry a previewable
+ *  attachment card that opens the right-side panel. */
+function SearchResults({
+  results,
+  isSearching,
+  error,
+  query,
+  onOpen,
+}: {
+  results: SearchResult[] | null;
+  isSearching: boolean;
+  error: string | null;
+  query: string;
+  onOpen: (item: ActivityItem, attachment: Attachment) => void;
+}) {
+  if (isSearching && results === null) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-[10px] text-gray-400 uppercase tracking-[0.3em] font-mono">Searching knowledge</p>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        Search failed: {error}
+      </div>
+    );
+  }
+  if (!results || results.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white py-16 text-center">
+        <p className="text-sm text-gray-500">No knowledge matches “{query}”.</p>
+        <p className="text-xs text-gray-400 mt-1">
+          Results are ranked by the brain's memory_search across the wiki and captured learnings.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white overflow-hidden">
+      <ol>
+        {results.map((r, i) => (
+          <SearchPost key={r.id} result={r} isFirst={i === 0} onOpen={onOpen} />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+/** One ranked hit in the FeedPost layout — the byline carries rank + match
+ *  strength where a live post shows its relative timestamp. */
+function SearchPost({
+  result,
+  isFirst,
+  onOpen,
+}: {
+  result: SearchResult;
+  isFirst: boolean;
+  onOpen: (item: ActivityItem, attachment: Attachment) => void;
+}) {
+  const item = searchResultToItem(result);
+  const m = agentMeta(item.agent_id);
+  const attachment = item.attachments![0]!;
+  return (
+    <li className={`px-5 py-5 ${isFirst ? "" : "border-t border-gray-100"}`}>
+      <div className="flex items-start gap-3">
+        <Avatar agent={item.agent_id} />
+        <div className="min-w-0 flex-1">
+          {/* Byline — rank + match strength instead of recency */}
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-[15px] font-semibold text-gray-900">{m.name}</span>
+            <VerifiedCheck color={m.accent} />
+            <span className="text-xs text-gray-300">·</span>
+            <span className="text-xs text-gray-400 font-mono">
+              #{result.rank}
+              {result.score !== null ? ` · ${Math.round(result.score * 100)}% match` : ""}
+            </span>
+          </div>
+          <p className="text-xs text-gray-400 -mt-0.5">
+            @{m.handle} · {ACTIVITY_VERB[item.activity]}
+          </p>
+
+          <p className="font-serif text-lg leading-snug text-gray-900 mt-2 line-clamp-3">{headline(item.title)}</p>
+
+          {item.description ? (
+            <p className="text-sm text-gray-500 mt-1.5 leading-relaxed line-clamp-2">{item.description}</p>
+          ) : null}
+
+          <div className="mt-3">
+            <AttachmentCard
+              activity={item.activity}
+              attachment={attachment}
+              accent={m.accent}
+              onOpen={() => onOpen(item, attachment)}
+            />
+          </div>
+        </div>
+      </div>
+    </li>
   );
 }
 
@@ -525,9 +767,15 @@ function RenderedLearning({ target, onClose }: { target: PreviewTarget; onClose:
               <span className="text-sm font-semibold text-gray-900">{m.name}</span>
               <VerifiedCheck color={m.accent} />
             </div>
-            <p className="text-xs text-gray-400" title={new Date(item.ts).toLocaleString()}>
-              {new Date(item.ts).toLocaleString()}
-            </p>
+            {/* Search results carry no event timestamp — show their source
+                verb instead of an "Invalid Date". */}
+            {Number.isNaN(new Date(item.ts).getTime()) ? (
+              <p className="text-xs text-gray-400">{ACTIVITY_VERB[item.activity]}</p>
+            ) : (
+              <p className="text-xs text-gray-400" title={new Date(item.ts).toLocaleString()}>
+                {new Date(item.ts).toLocaleString()}
+              </p>
+            )}
           </div>
         </div>
 

--- a/packages/services/dashboard/src/server/activity-feed.test.ts
+++ b/packages/services/dashboard/src/server/activity-feed.test.ts
@@ -1,10 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import type { AddressInfo } from "node:net";
 import Database from "better-sqlite3";
 
-import { coerceFilter, queryActivityFeed } from "./activity-feed.js";
+import { buildActivityFeedRouter, coerceFilter, queryActivityFeed } from "./activity-feed.js";
 import { migrate } from "./migrate.js";
 
 let tmpDir: string;
@@ -154,6 +157,31 @@ describe("queryActivityFeed", () => {
     expect(item.attachments![1]!.markdown).toContain("body b");
   });
 
+  it("filters non-object attachment entries and defaults missing fields", () => {
+    seed([
+      {
+        id: "mixed",
+        ts: "2026-06-04T03:00:00.000Z",
+        agent_id: "cc",
+        activity: "applied",
+        title: "x",
+        // Non-object entries drop; object entries default non-string fields.
+        attachments: JSON.stringify([null, "str", 42, {}, { title: 7, path: 3, markdown: 9 }]),
+      },
+      // Valid JSON but not an array → null.
+      { id: "obj", ts: "2026-06-04T02:00:00.000Z", agent_id: "cc", activity: "applied", title: "y", attachments: `{"not":"array"}` },
+      // Array whose every entry is filtered out → null, not [].
+      { id: "allbad", ts: "2026-06-04T01:00:00.000Z", agent_id: "cc", activity: "applied", title: "z", attachments: "[42]" },
+    ]);
+    const byId = Object.fromEntries(queryActivityFeed(db).items.map((i) => [i.id, i]));
+    expect(byId["mixed"]!.attachments).toEqual([
+      { title: "", path: null, markdown: null },
+      { title: "", path: null, markdown: null },
+    ]);
+    expect(byId["obj"]!.attachments).toBeNull();
+    expect(byId["allbad"]!.attachments).toBeNull();
+  });
+
   it("degrades malformed/absent attachments to null", () => {
     seed([
       { id: "bad", ts: "2026-06-04T02:00:00.000Z", agent_id: "cc", activity: "applied", title: "x", attachments: "{not json" },
@@ -193,5 +221,102 @@ describe("queryActivityFeed", () => {
     expect(coerceFilter("all")).toBe("all");
     expect(coerceFilter("bogus")).toBe("all");
     expect(coerceFilter(undefined)).toBe("all");
+  });
+});
+
+describe("buildActivityFeedRouter (HTTP)", () => {
+  let server: http.Server;
+  let base: string;
+
+  /** Mount the router against `dbFile` and start listening on an ephemeral
+   *  port. Same pattern as search.test.ts "buildSearchRouter (HTTP)". */
+  async function listen(dbFile: string): Promise<void> {
+    const app = express();
+    app.use("/api/activity-feed", buildActivityFeedRouter(dbFile));
+    server = http.createServer(app);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  }
+
+  afterEach(async () => {
+    await new Promise((r) => server.close(r));
+  });
+
+  interface FeedJson {
+    items: Array<{ id: string; activity: string }>;
+    latest_ts: string | null;
+  }
+
+  it("serves the feed with the default limit when none is given", async () => {
+    seed([
+      { id: "c1", ts: "2026-06-03T16:00:00.000Z", agent_id: "podcast", activity: "captured", title: "T" },
+      { id: "a1", ts: "2026-06-04T01:00:00.000Z", agent_id: "cc", activity: "applied", title: "A" },
+    ]);
+    await listen(dbPath);
+    const res = await fetch(`${base}/api/activity-feed`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as FeedJson;
+    expect(json.items.map((i) => i.id)).toEqual(["a1", "c1"]);
+    expect(json.latest_ts).toBe("2026-06-04T01:00:00.000Z");
+  });
+
+  it("respects an explicit valid limit", async () => {
+    seed(
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `x${i}`,
+        ts: `2026-06-04T0${i}:00:00.000Z`,
+        agent_id: "cc",
+        activity: "applied" as const,
+        title: `t${i}`,
+      })),
+    );
+    await listen(dbPath);
+    const json = (await (await fetch(`${base}/api/activity-feed?limit=2`)).json()) as FeedJson;
+    expect(json.items).toHaveLength(2);
+  });
+
+  it("falls back to the default limit of 100 on bogus/out-of-range limits", async () => {
+    seed(
+      Array.from({ length: 3 }, (_, i) => ({
+        id: `x${i}`,
+        ts: `2026-06-04T0${i}:00:00.000Z`,
+        agent_id: "cc",
+        activity: "applied" as const,
+        title: `t${i}`,
+      })),
+    );
+    await listen(dbPath);
+    for (const bad of ["abc", "0", "-5", "501"]) {
+      const json = (await (await fetch(`${base}/api/activity-feed?limit=${bad}`)).json()) as FeedJson;
+      // Default 100 > seeded 3 → everything comes back.
+      expect(json.items).toHaveLength(3);
+    }
+  });
+
+  it("coerces the kind filter (valid scopes, bogus falls back to all)", async () => {
+    seed([
+      { id: "c1", ts: "2026-06-03T16:00:00.000Z", agent_id: "podcast", activity: "captured", title: "T" },
+      { id: "a1", ts: "2026-06-04T01:00:00.000Z", agent_id: "cc", activity: "applied", title: "A" },
+    ]);
+    await listen(dbPath);
+    const captured = (await (await fetch(`${base}/api/activity-feed?kind=captured`)).json()) as FeedJson;
+    expect(captured.items.map((i) => i.activity)).toEqual(["captured"]);
+    const bogus = (await (await fetch(`${base}/api/activity-feed?kind=bogus`)).json()) as FeedJson;
+    expect(bogus.items).toHaveLength(2);
+  });
+
+  it("500s when the DB path is not a usable database", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // A directory path is unopenable as a sqlite file → the handler's catch.
+      await listen(path.join(tmpDir, "missing-dir", "nope.db"));
+      const res = await fetch(`${base}/api/activity-feed`);
+      expect(res.status).toBe(500);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toBe("Failed to fetch activity feed");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/services/dashboard/src/server/activity-feed.ts
+++ b/packages/services/dashboard/src/server/activity-feed.ts
@@ -144,7 +144,9 @@ export function queryActivityFeed(
 
   return {
     items: rows.map(toItem),
-    latest_ts: rows.length > 0 ? (rows[0]?.ts ?? null) : null,
+    // rows[0] is undefined on an empty feed → null; identical to the
+    // length-guarded form but without an unreachable fallback arm.
+    latest_ts: rows[0]?.ts ?? null,
   };
 }
 

--- a/packages/services/dashboard/src/server/brain-client.mc.ts
+++ b/packages/services/dashboard/src/server/brain-client.mc.ts
@@ -355,6 +355,22 @@ export async function brainWikiStatus(): Promise<BrainWikiStatus> {
   return result;
 }
 
+// ── Public API: Memory search ─────────────────────────────────────
+
+/** Ranked knowledge search via the brain's memory_search tool. Returns the
+ *  raw (parsed) payload — normalization lives in search.ts. Uncached: search
+ *  is user-initiated, not polled. */
+export async function brainMemorySearch(
+  query: string,
+  opts: { corpus?: "wiki" | "memory" | "all"; limit?: number } = {},
+): Promise<unknown> {
+  return callTool("memory_search", {
+    query,
+    corpus: opts.corpus ?? "all",
+    limit: opts.limit ?? 20,
+  });
+}
+
 // ── Connection Lifecycle ───────��───────────────────────────���──────
 
 export async function initBrainClient(): Promise<void> {

--- a/packages/services/dashboard/src/server/brain-client.test.ts
+++ b/packages/services/dashboard/src/server/brain-client.test.ts
@@ -276,6 +276,26 @@ describe("createBrainClient — public tool wrappers", () => {
     expect(out.freshness).toEqual({});
   });
 
+  it("memorySearch forwards the query with corpus/limit defaults and returns the raw payload", async () => {
+    const handler = vi.fn(async (args: Record<string, unknown>) => ({
+      results: [{ path: "wiki/a.md", score: 0.9 }],
+      echoed: args,
+    }));
+    const fake = fakeClient({ memory_search: handler });
+    const client = createBrainClient({ clientFactory: async () => fake });
+    const out = (await client.memorySearch("feed design")) as Record<string, unknown>;
+    expect(handler).toHaveBeenCalledWith({ query: "feed design", corpus: "all", limit: 20 });
+    expect(out.results).toEqual([{ path: "wiki/a.md", score: 0.9 }]);
+  });
+
+  it("memorySearch honors explicit corpus and limit", async () => {
+    const handler = vi.fn(async () => ({ results: [] }));
+    const fake = fakeClient({ memory_search: handler });
+    const client = createBrainClient({ clientFactory: async () => fake });
+    await client.memorySearch("q", { corpus: "wiki", limit: 3 });
+    expect(handler).toHaveBeenCalledWith({ query: "q", corpus: "wiki", limit: 3 });
+  });
+
   it("each wrapper auto-connects on first call", async () => {
     const factory = vi.fn(async () =>
       fakeClient({ tasks: async () => ({ goals: [], stats: {} }) }),

--- a/packages/services/dashboard/src/server/brain-client.ts
+++ b/packages/services/dashboard/src/server/brain-client.ts
@@ -96,6 +96,11 @@ function errorMessage(err: unknown): string {
 
 // ── Public factory ─────────────────────────────────────────────────────────
 
+export type MemorySearchOpts = {
+  corpus?: "wiki" | "memory" | "all";
+  limit?: number;
+};
+
 export type BrainClient = {
   connect(): Promise<MinimalMcpClient>;
   init(): Promise<InitResult>;
@@ -106,6 +111,7 @@ export type BrainClient = {
   scheduleList(): Promise<Array<Record<string, unknown>>>;
   tracesQuery(opts: TracesQueryOpts): Promise<TracesQueryResult>;
   wikiStatus(): Promise<BrainWikiStatus>;
+  memorySearch(query: string, opts?: MemorySearchOpts): Promise<unknown>;
 };
 
 export function createBrainClient(deps: {
@@ -270,6 +276,20 @@ export function createBrainClient(deps: {
     return result;
   }
 
+  /** Ranked knowledge search. Returns the tool's raw (parsed) payload —
+   *  shaping lives in search.ts so the router owns one normalizer. Uncached:
+   *  searches are user-initiated, not polled. */
+  async function memorySearch(
+    query: string,
+    opts: MemorySearchOpts = {},
+  ): Promise<unknown> {
+    return callTool("memory_search", {
+      query,
+      corpus: opts.corpus ?? "all",
+      limit: opts.limit ?? 20,
+    });
+  }
+
   return {
     connect,
     init,
@@ -280,5 +300,6 @@ export function createBrainClient(deps: {
     scheduleList,
     tracesQuery,
     wikiStatus,
+    memorySearch,
   };
 }

--- a/packages/services/dashboard/src/server/mechanism-routes.test.ts
+++ b/packages/services/dashboard/src/server/mechanism-routes.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { buildKanbanRouter, buildMechanismRouter } from "./mechanism-routes.js";
+import { brainBoard, brainWorkflowList } from "./brain-client.mc.js";
+
+// The routers import module-level singletons from the legacy brain client —
+// mock the whole module so tests control what the brain "returns" without a
+// live proxy (the .mc module itself is migration-window code, excluded from
+// coverage; these tests target mechanism-routes.ts only).
+vi.mock("./brain-client.mc.js", () => ({
+  brainBoard: vi.fn(),
+  brainWorkflowList: vi.fn(),
+}));
+
+const mockBoard = vi.mocked(brainBoard);
+const mockWorkflowList = vi.mocked(brainWorkflowList);
+
+let server: http.Server;
+let base: string;
+
+async function listen(): Promise<void> {
+  const app = express();
+  app.use("/api/mechanism", buildMechanismRouter());
+  app.use("/api/kanban", buildKanbanRouter());
+  server = http.createServer(app);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await listen();
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+});
+
+type Awaitable<T> = T | Promise<T>;
+type WorkflowListResult = Awaited<ReturnType<typeof brainWorkflowList>>;
+type BoardResult = Awaited<ReturnType<typeof brainBoard>>;
+
+/** Loosely-shaped brain payloads: the routes normalize snake_case/camelCase
+ *  variants at runtime, so mocks are authored untyped and cast once here. */
+function givenWorkflows(templates: unknown[]): void {
+  mockWorkflowList.mockResolvedValue(templates as Awaitable<never> & WorkflowListResult);
+}
+function givenBoard(board: unknown): void {
+  mockBoard.mockResolvedValue(board as Awaitable<never> & BoardResult);
+}
+
+interface WorkflowRow {
+  id: string;
+  name: string;
+  description: string | null;
+  version: number | null;
+  steps: Array<{ stepKey: string; name: string; blockedByKeys: string[]; sortOrder: number }>;
+  latestRun: unknown;
+  totalRuns: number;
+  successRate: number | null;
+  mechanismVisibility: { explicit: boolean; enabled: boolean | null; autoIncluded: boolean };
+}
+
+describe("buildMechanismRouter (HTTP)", () => {
+  it("includes explicit-true and >=3-step workflows; hides explicit-false and short ones", async () => {
+    givenWorkflows([
+      // Explicitly opted in despite having no steps.
+      { id: "wf-explicit", name: "Explicit", display: { mechanism_view: true } },
+      // Explicitly hidden despite having plenty of steps.
+      {
+        id: "wf-hidden",
+        name: "Hidden",
+        display: { mechanism_view: false },
+        steps: [{ name: "a" }, { name: "b" }, { name: "c" }],
+      },
+      // No flag, >=3 steps → auto-included.
+      {
+        id: "wf-auto",
+        name: "Auto",
+        description: "three steps",
+        version: 2,
+        steps: [
+          { stepKey: "one", name: "One", blockedByKeys: ["zero"], sortOrder: 10 },
+          { step_key: "two", name: "Two", blocked_by_keys: ["one"], sort_order: 20 },
+          { name: "Three", blocked_by_keys: "one, two, ,three" },
+          { name: "Four", blocked_by_keys: "" },
+          { name: "Five" },
+        ],
+        latestRun: { goalId: "g1", status: "done", startedAt: "2026-06-01T00:00:00Z" },
+        totalRuns: 7,
+        successRate: 0.85,
+      },
+      // No flag, <3 steps → hidden by default.
+      { id: "wf-short", name: "Short", steps: [{ name: "only" }] },
+      // No flag, no steps at all → hidden.
+      { id: "wf-empty", name: "Empty" },
+    ]);
+
+    const res = await fetch(`${base}/api/mechanism/workflows`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { workflows: WorkflowRow[]; rule: string };
+    expect(json.rule).toBe("display.mechanism_view ?? (steps.length >= 3)");
+    expect(json.workflows.map((w) => w.id)).toEqual(["wf-explicit", "wf-auto"]);
+
+    // Explicit opt-in: missing optional fields default; no steps → [].
+    const explicit = json.workflows[0]!;
+    expect(explicit).toMatchObject({
+      description: null,
+      version: null,
+      steps: [],
+      latestRun: null,
+      totalRuns: 0,
+      successRate: null,
+      mechanismVisibility: { explicit: true, enabled: true, autoIncluded: false },
+    });
+
+    // Auto-included: step key/blockedByKeys/sortOrder normalization.
+    const auto = json.workflows[1]!;
+    expect(auto).toMatchObject({
+      description: "three steps",
+      version: 2,
+      totalRuns: 7,
+      successRate: 0.85,
+      mechanismVisibility: { explicit: false, enabled: null, autoIncluded: true },
+    });
+    expect(auto.latestRun).toMatchObject({ goalId: "g1" });
+    expect(auto.steps).toEqual([
+      { stepKey: "one", name: "One", blockedByKeys: ["zero"], sortOrder: 10 },
+      { stepKey: "two", name: "Two", blockedByKeys: ["one"], sortOrder: 20 },
+      // Comma-separated string arm: trimmed, empties filtered out.
+      { stepKey: "step-2", name: "Three", blockedByKeys: ["one", "two", "three"], sortOrder: 2 },
+      // Empty-string arm degrades to no blockers.
+      { stepKey: "step-3", name: "Four", blockedByKeys: [], sortOrder: 3 },
+      // No blocker field at all.
+      { stepKey: "step-4", name: "Five", blockedByKeys: [], sortOrder: 4 },
+    ]);
+  });
+
+  it("500s when the brain workflow list is unavailable", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mockWorkflowList.mockRejectedValue(new Error("brain down"));
+      const res = await fetch(`${base}/api/mechanism/workflows`);
+      expect(res.status).toBe(500);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toBe("Failed to fetch mechanism workflows");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("buildKanbanRouter (HTTP)", () => {
+  const eligibleTemplates = [
+    {
+      id: "wf-auto",
+      name: "Auto",
+      steps: [{ name: "a" }, { name: "b" }, { name: "c" }],
+    },
+    { id: "wf-short", name: "Short", steps: [{ name: "only" }] }, // ineligible
+  ];
+
+  it("flattens tasks of mechanism-eligible workflows only, normalizing field variants", async () => {
+    givenWorkflows(eligibleTemplates);
+    givenBoard({
+      goals: [
+        {
+          id: "g1",
+          sourceWorkflowId: "wf-auto", // camelCase variant
+          tasks: [
+            { id: "t1", name: "Task 1", status: "done", updated_at: "2026-06-01T00:00:00Z" },
+            { id: "t2", name: "Task 2", status: "running", updatedAt: "2026-06-02T00:00:00Z" },
+            { id: "t3", name: "Task 3", status: "queued" }, // no timestamp variant
+          ],
+        },
+        {
+          id: "g2",
+          source_workflow_id: "wf-auto", // snake_case variant, no tasks array
+        },
+        {
+          id: "g3",
+          source_workflow_id: "wf-short", // ineligible workflow → skipped
+          tasks: [{ id: "tx", name: "X", status: "done" }],
+        },
+        { id: "g4" }, // no workflow id at all → skipped
+      ],
+    });
+
+    const res = await fetch(`${base}/api/kanban`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { tasks: Array<Record<string, unknown>> };
+    expect(json.tasks).toEqual([
+      {
+        id: "t1",
+        workflow_id: "wf-auto",
+        workflow_name: "Auto",
+        status: "done",
+        name: "Task 1",
+        last_update_ts: "2026-06-01T00:00:00Z",
+      },
+      {
+        id: "t2",
+        workflow_id: "wf-auto",
+        workflow_name: "Auto",
+        status: "running",
+        name: "Task 2",
+        last_update_ts: "2026-06-02T00:00:00Z",
+      },
+      {
+        id: "t3",
+        workflow_id: "wf-auto",
+        workflow_name: "Auto",
+        status: "queued",
+        name: "Task 3",
+        last_update_ts: null,
+      },
+    ]);
+  });
+
+  it("falls back to the workflow id when the template has no name, and to [] without goals", async () => {
+    // A brain payload may omit `name`; the route echoes the id instead.
+    givenWorkflows([{ id: "wf-anon", steps: [{ name: "a" }, { name: "b" }, { name: "c" }] }]);
+    givenBoard({
+      goals: [
+        {
+          id: "g1",
+          sourceWorkflowId: "wf-anon",
+          tasks: [{ id: "t1", name: "Task 1", status: "done" }],
+        },
+      ],
+    });
+    const withAnon = (await (await fetch(`${base}/api/kanban`)).json()) as {
+      tasks: Array<{ workflow_name: string }>;
+    };
+    expect(withAnon.tasks[0]!.workflow_name).toBe("wf-anon");
+
+    // A board without a goals array degrades to an empty task list.
+    givenWorkflows(eligibleTemplates);
+    givenBoard({});
+    const empty = (await (await fetch(`${base}/api/kanban`)).json()) as { tasks: unknown[] };
+    expect(empty.tasks).toEqual([]);
+  });
+
+  it("500s when the brain board is unavailable", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      givenWorkflows(eligibleTemplates);
+      mockBoard.mockRejectedValue(new Error("brain down"));
+      const res = await fetch(`${base}/api/kanban`);
+      expect(res.status).toBe(500);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toBe("Failed to fetch kanban tasks");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/services/dashboard/src/server/mechanism-routes.ts
+++ b/packages/services/dashboard/src/server/mechanism-routes.ts
@@ -55,34 +55,36 @@ export function buildMechanismRouter(): Router {
       const eligible = templates.filter(isMechanismEligible);
       // Surface the rule so the UI can render a tooltip/badge explaining
       // why each workflow shows.
-      const rows = eligible.map((w) => ({
-        id: w.id,
-        name: w.name,
-        description: w.description ?? null,
-        version: w.version ?? null,
-        steps: (w.steps ?? []).map((s, i) => ({
-          stepKey: s.stepKey ?? s.step_key ?? `step-${i}`,
-          name: s.name,
-          blockedByKeys:
-            Array.isArray(s.blockedByKeys) ? s.blockedByKeys
-            : Array.isArray(s.blocked_by_keys) ? s.blocked_by_keys
-            : typeof s.blocked_by_keys === "string" && s.blocked_by_keys.length > 0
-              ? s.blocked_by_keys.split(",").map((k) => k.trim()).filter(Boolean)
-              : [],
-          sortOrder: s.sortOrder ?? s.sort_order ?? i,
-        })),
-        latestRun: w.latestRun ?? null,
-        totalRuns: w.totalRuns ?? 0,
-        successRate: w.successRate ?? null,
-        // Echo the inclusion reason — explicit flag vs auto-default.
-        mechanismVisibility: {
-          explicit: typeof w.display?.mechanism_view === "boolean",
-          enabled: w.display?.mechanism_view ?? null,
-          autoIncluded:
-            typeof w.display?.mechanism_view !== "boolean" &&
-            (w.steps ?? []).length >= 3,
-        },
-      }));
+      const rows = eligible.map((w) => {
+        const steps = w.steps ?? [];
+        return {
+          id: w.id,
+          name: w.name,
+          description: w.description ?? null,
+          version: w.version ?? null,
+          steps: steps.map((s, i) => ({
+            stepKey: s.stepKey ?? s.step_key ?? `step-${i}`,
+            name: s.name,
+            blockedByKeys:
+              Array.isArray(s.blockedByKeys) ? s.blockedByKeys
+              : Array.isArray(s.blocked_by_keys) ? s.blocked_by_keys
+              : typeof s.blocked_by_keys === "string" && s.blocked_by_keys.length > 0
+                ? s.blocked_by_keys.split(",").map((k) => k.trim()).filter(Boolean)
+                : [],
+            sortOrder: s.sortOrder ?? s.sort_order ?? i,
+          })),
+          latestRun: w.latestRun ?? null,
+          totalRuns: w.totalRuns ?? 0,
+          successRate: w.successRate ?? null,
+          // Echo the inclusion reason — explicit flag vs auto-default.
+          mechanismVisibility: {
+            explicit: typeof w.display?.mechanism_view === "boolean",
+            enabled: w.display?.mechanism_view ?? null,
+            autoIncluded:
+              typeof w.display?.mechanism_view !== "boolean" && steps.length >= 3,
+          },
+        };
+      });
       res.json({ workflows: rows, rule: "display.mechanism_view ?? (steps.length >= 3)" });
     } catch (err) {
       console.error("[/api/mechanism/workflows]", err);

--- a/packages/services/dashboard/src/server/metrics-queries.test.ts
+++ b/packages/services/dashboard/src/server/metrics-queries.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+
+import {
+  queryApplicationRate,
+  queryDistribution,
+  queryKnowledgeTasteChanges,
+  querySessionsByAgent,
+} from "./metrics-queries.js";
+import { migrate } from "./migrate.js";
+
+let tmpDir: string;
+let dbPath: string;
+let db: Database.Database;
+
+/** ISO date `offset` days before today — the queries filter on
+ *  `date >= date('now', '-N days')`, so seeds must be relative to now. */
+function daysAgo(offset: number): string {
+  const d = new Date(Date.now() - offset * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "metrics-queries-"));
+  dbPath = path.join(tmpDir, "dashboard.db");
+  // Use the real migration so the tests exercise the actual 7-table schema.
+  migrate(dbPath);
+  db = new Database(dbPath);
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("querySessionsByAgent", () => {
+  it("returns empty rows and agents on an empty DB", () => {
+    const res = querySessionsByAgent(db, 30);
+    expect(res.rows).toEqual([]);
+    expect(res.agents).toEqual([]);
+  });
+
+  it("returns rows in the window, sorted, with a distinct sorted agent list", () => {
+    const stmt = db.prepare(
+      `INSERT INTO daa (agent_id, date, sessions, is_active) VALUES (?, ?, ?, ?)`,
+    );
+    stmt.run("zeta", daysAgo(1), 3, 1);
+    stmt.run("alpha", daysAgo(1), 1, 0);
+    stmt.run("alpha", daysAgo(2), 2, 1);
+    stmt.run("old", daysAgo(90), 9, 1); // outside the 30-day window
+    const res = querySessionsByAgent(db, 30);
+    expect(res.rows).toEqual([
+      { date: daysAgo(2), agent_id: "alpha", sessions: 2, is_active: 1 },
+      { date: daysAgo(1), agent_id: "alpha", sessions: 1, is_active: 0 },
+      { date: daysAgo(1), agent_id: "zeta", sessions: 3, is_active: 1 },
+    ]);
+    expect(res.agents).toEqual(["alpha", "zeta"]);
+  });
+});
+
+describe("queryKnowledgeTasteChanges", () => {
+  it("returns empty rows and domains on an empty DB", () => {
+    const res = queryKnowledgeTasteChanges(db, 30);
+    expect(res.rows).toEqual([]);
+    expect(res.domains).toEqual([]);
+  });
+
+  it("scopes to the window and derives a distinct sorted domain list", () => {
+    const stmt = db.prepare(
+      `INSERT INTO knowledge_taste_changes (date, tree, domain, created, updated)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    stmt.run(daysAgo(1), "wiki", "youtube", 2, 1);
+    stmt.run(daysAgo(1), "tastes", "design", 1, 0);
+    stmt.run(daysAgo(3), "wiki", "design", 0, 4);
+    stmt.run(daysAgo(120), "wiki", "ancient", 5, 5); // outside the window
+    const res = queryKnowledgeTasteChanges(db, 30);
+    expect(res.rows.map((r) => [r.date, r.tree, r.domain])).toEqual([
+      [daysAgo(3), "wiki", "design"],
+      [daysAgo(1), "tastes", "design"],
+      [daysAgo(1), "wiki", "youtube"],
+    ]);
+    expect(res.domains).toEqual(["design", "youtube"]);
+  });
+});
+
+describe("queryApplicationRate", () => {
+  it("returns three empty series on an empty DB", () => {
+    const res = queryApplicationRate(db, 30);
+    expect(res.daily).toEqual([]);
+    expect(res.by_domain).toEqual([]);
+    expect(res.by_agent).toEqual([]);
+  });
+
+  it("returns daily rows plus per-domain/per-agent drilldowns with computed rates", () => {
+    db.prepare(
+      `INSERT INTO application_rate (date, tree, surfaced_unique, acted_unique, rate)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(daysAgo(1), "wiki", 4, 2, 0.5);
+    db.prepare(
+      `INSERT INTO application_rate (date, tree, surfaced_unique, acted_unique, rate)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(daysAgo(90), "wiki", 8, 8, 1); // outside the window
+    const byDomain = db.prepare(
+      `INSERT INTO application_rate_by_domain (date, tree, domain, surfaced_unique, acted_unique)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    byDomain.run(daysAgo(1), "wiki", "youtube", 4, 1);
+    byDomain.run(daysAgo(1), "wiki", "exec", 0, 0); // surfaced 0 → NULL rate
+    const byAgent = db.prepare(
+      `INSERT INTO application_rate_by_agent (date, tree, agent_id, surfaced_unique, acted_unique)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    byAgent.run(daysAgo(1), "wiki", "claude-code", 2, 1);
+    byAgent.run(daysAgo(1), "wiki", "podcast", 0, 0); // surfaced 0 → NULL rate
+
+    const res = queryApplicationRate(db, 30);
+    expect(res.daily).toEqual([
+      { date: daysAgo(1), tree: "wiki", surfaced_unique: 4, acted_unique: 2, rate: 0.5 },
+    ]);
+    expect(res.by_domain).toEqual([
+      { date: daysAgo(1), tree: "wiki", domain: "exec", surfaced_unique: 0, acted_unique: 0, rate: null },
+      { date: daysAgo(1), tree: "wiki", domain: "youtube", surfaced_unique: 4, acted_unique: 1, rate: 0.25 },
+    ]);
+    expect(res.by_agent).toEqual([
+      { date: daysAgo(1), tree: "wiki", agent_id: "claude-code", surfaced_unique: 2, acted_unique: 1, rate: 0.5 },
+      { date: daysAgo(1), tree: "wiki", agent_id: "podcast", surfaced_unique: 0, acted_unique: 0, rate: null },
+    ]);
+  });
+});
+
+describe("queryDistribution", () => {
+  function seedDistribution(rows: Array<[string, string, number]>): void {
+    const stmt = db.prepare(
+      `INSERT INTO knowledge_taste_distribution (tree, domain, total, as_of)
+       VALUES (?, ?, ?, ?)`,
+    );
+    for (const [tree, domain, total] of rows) stmt.run(tree, domain, total, daysAgo(0));
+  }
+
+  it("returns empty rows and top_domains on an empty DB", () => {
+    const res = queryDistribution(db);
+    expect(res.rows).toEqual([]);
+    expect(res.top_domains).toEqual([]);
+  });
+
+  it("unions top-N-per-tree so taste-only domains keep an axis", () => {
+    // Wiki dwarfs tastes: with a combined ranking, the taste-only domain
+    // would be starved out of a small top-N. Per-tree ranking keeps it.
+    seedDistribution([
+      ["wiki", "youtube", 100],
+      ["wiki", "exec", 90],
+      ["wiki", "agents", 80],
+      ["tastes", "storytelling", 3],
+    ]);
+    const res = queryDistribution(db, 2);
+    // Top-2 wiki (youtube, exec) ∪ top-2 tastes (storytelling), ordered by
+    // max(wiki, tastes) descending.
+    expect(res.top_domains).toEqual(["youtube", "exec", "storytelling"]);
+    expect(res.rows).toHaveLength(4);
+  });
+
+  it("accumulates totals per (tree, domain) and orders axes by max across trees", () => {
+    seedDistribution([
+      ["wiki", "design", 10],
+      ["tastes", "design", 50], // max(design) = 50 → leads
+      ["wiki", "youtube", 30],
+    ]);
+    const res = queryDistribution(db);
+    expect(res.top_domains).toEqual(["design", "youtube"]);
+    // Raw rows come back ordered by domain then tree.
+    expect(res.rows.map((r) => [r.tree, r.domain, r.total])).toEqual([
+      ["tastes", "design", 50],
+      ["wiki", "design", 10],
+      ["wiki", "youtube", 30],
+    ]);
+  });
+
+  it("orders taste-only domains when the wiki tree is empty", () => {
+    // Both comparator positions must handle a domain absent from a tree's
+    // totals map (missing wiki entry → 0).
+    seedDistribution([
+      ["tastes", "storytelling", 5],
+      ["tastes", "design", 9],
+    ]);
+    const res = queryDistribution(db);
+    expect(res.top_domains).toEqual(["design", "storytelling"]);
+  });
+
+  it("defaults topN to 8 and truncates beyond it per tree", () => {
+    seedDistribution(
+      Array.from({ length: 10 }, (_, i): [string, string, number] => [
+        "wiki",
+        `domain-${String(i).padStart(2, "0")}`,
+        100 - i,
+      ]),
+    );
+    const res = queryDistribution(db);
+    expect(res.top_domains).toHaveLength(8);
+    expect(res.top_domains[0]).toBe("domain-00");
+    expect(res.top_domains).not.toContain("domain-08");
+    expect(res.top_domains).not.toContain("domain-09");
+  });
+});

--- a/packages/services/dashboard/src/server/metrics-routes.test.ts
+++ b/packages/services/dashboard/src/server/metrics-routes.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import type { AddressInfo } from "node:net";
+import Database from "better-sqlite3";
+
+import { buildMetricsRouter } from "./metrics-routes.js";
+import { migrate } from "./migrate.js";
+
+let tmpDir: string;
+let dbPath: string;
+let server: http.Server;
+let base: string;
+
+/** ISO date `offset` days before today (the routes' queries filter on
+ *  `date >= date('now', '-N days')`). */
+function daysAgo(offset: number): string {
+  const d = new Date(Date.now() - offset * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Mount the router against `dbFile` and listen on an ephemeral port.
+ *  Same pattern as search.test.ts "buildSearchRouter (HTTP)". */
+async function listen(dbFile: string): Promise<void> {
+  const app = express();
+  app.use("/api/metrics", buildMetricsRouter(dbFile));
+  server = http.createServer(app);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "metrics-routes-"));
+  dbPath = path.join(tmpDir, "dashboard.db");
+  migrate(dbPath);
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function seedAll(): void {
+  const db = new Database(dbPath);
+  db.prepare(
+    `INSERT INTO daa (agent_id, date, sessions, is_active) VALUES (?, ?, ?, ?)`,
+  ).run("claude-code", daysAgo(1), 2, 1);
+  db.prepare(
+    `INSERT INTO daa (agent_id, date, sessions, is_active) VALUES (?, ?, ?, ?)`,
+  ).run("ancient", daysAgo(120), 9, 1); // outside every default window
+  db.prepare(
+    `INSERT INTO knowledge_taste_changes (date, tree, domain, created, updated)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(daysAgo(1), "wiki", "youtube", 2, 1);
+  db.prepare(
+    `INSERT INTO application_rate (date, tree, surfaced_unique, acted_unique, rate)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(daysAgo(1), "wiki", 4, 2, 0.5);
+  const dist = db.prepare(
+    `INSERT INTO knowledge_taste_distribution (tree, domain, total, as_of)
+     VALUES (?, ?, ?, ?)`,
+  );
+  dist.run("wiki", "youtube", 10, daysAgo(0));
+  dist.run("wiki", "exec", 5, daysAgo(0));
+  db.close();
+}
+
+describe("buildMetricsRouter (HTTP)", () => {
+  it("GET /sessions-by-agent returns windowed rows with the agent list", async () => {
+    seedAll();
+    await listen(dbPath);
+    const res = await fetch(`${base}/api/metrics/sessions-by-agent`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { rows: Array<{ agent_id: string }>; agents: string[] };
+    expect(json.rows).toEqual([
+      { date: daysAgo(1), agent_id: "claude-code", sessions: 2, is_active: 1 },
+    ]);
+    expect(json.agents).toEqual(["claude-code"]);
+  });
+
+  it("GET /sessions-by-agent honors an explicit valid days window", async () => {
+    seedAll();
+    await listen(dbPath);
+    const res = await fetch(`${base}/api/metrics/sessions-by-agent?days=365`);
+    const json = (await res.json()) as { agents: string[] };
+    // 365-day window now reaches the 120-day-old row too.
+    expect(json.agents).toEqual(["ancient", "claude-code"]);
+  });
+
+  it("falls back to the default days on bogus/out-of-range values", async () => {
+    seedAll();
+    await listen(dbPath);
+    for (const bad of ["abc", "0", "-3", "366"]) {
+      const res = await fetch(`${base}/api/metrics/sessions-by-agent?days=${bad}`);
+      const json = (await res.json()) as { agents: string[] };
+      // Default 60-day window excludes the 120-day-old row.
+      expect(json.agents).toEqual(["claude-code"]);
+    }
+  });
+
+  it("GET /knowledge-taste-changes returns rows with the domain list", async () => {
+    seedAll();
+    await listen(dbPath);
+    const res = await fetch(`${base}/api/metrics/knowledge-taste-changes`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { rows: unknown[]; domains: string[] };
+    expect(json.rows).toEqual([
+      { date: daysAgo(1), tree: "wiki", domain: "youtube", created: 2, updated: 1 },
+    ]);
+    expect(json.domains).toEqual(["youtube"]);
+  });
+
+  it("GET /application-rate returns the three series", async () => {
+    seedAll();
+    await listen(dbPath);
+    const res = await fetch(`${base}/api/metrics/application-rate`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { daily: unknown[]; by_domain: unknown[]; by_agent: unknown[] };
+    expect(json.daily).toEqual([
+      { date: daysAgo(1), tree: "wiki", surfaced_unique: 4, acted_unique: 2, rate: 0.5 },
+    ]);
+    expect(json.by_domain).toEqual([]);
+    expect(json.by_agent).toEqual([]);
+  });
+
+  it("GET /distribution returns rows with top_domains, honoring topN", async () => {
+    seedAll();
+    await listen(dbPath);
+    const all = (await (await fetch(`${base}/api/metrics/distribution`)).json()) as {
+      rows: unknown[];
+      top_domains: string[];
+    };
+    expect(all.top_domains).toEqual(["youtube", "exec"]);
+    const top1 = (await (await fetch(`${base}/api/metrics/distribution?topN=1`)).json()) as {
+      top_domains: string[];
+    };
+    expect(top1.top_domains).toEqual(["youtube"]);
+    // Bogus topN falls back to the default of 8.
+    const bogus = (await (await fetch(`${base}/api/metrics/distribution?topN=zzz`)).json()) as {
+      top_domains: string[];
+    };
+    expect(bogus.top_domains).toEqual(["youtube", "exec"]);
+  });
+
+  it("500s on every endpoint when the DB path is unopenable", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // A path under a nonexistent directory can't be opened read-only.
+      await listen(path.join(tmpDir, "missing-dir", "nope.db"));
+      for (const ep of [
+        "sessions-by-agent",
+        "knowledge-taste-changes",
+        "application-rate",
+        "distribution",
+      ]) {
+        const res = await fetch(`${base}/api/metrics/${ep}`);
+        expect(res.status).toBe(500);
+        const json = (await res.json()) as { error: string };
+        expect(json.error).toBe(`Failed to fetch ${ep}`);
+      }
+      expect(spy).toHaveBeenCalledTimes(4);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/services/dashboard/src/server/migrate.test.ts
+++ b/packages/services/dashboard/src/server/migrate.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+
+import { main, migrate } from "./migrate.js";
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "migrate-"));
+  dbPath = path.join(tmpDir, "dashboard.db");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Create a DB that still carries a legacy (pre-NUX) table, so migrate()
+ *  treats it as a real destructive cutover and snapshots first. */
+function createLegacyDb(p: string): void {
+  const db = new Database(p);
+  db.exec(`CREATE TABLE issues (id TEXT PRIMARY KEY)`);
+  db.exec(`INSERT INTO issues (id) VALUES ('i1')`);
+  db.close();
+}
+
+describe("migrate — pre-cutover backup", () => {
+  it("takes no backup on a fresh DB (no legacy tables present)", () => {
+    const result = migrate(dbPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(fs.existsSync(`${dbPath}.pre-cutover.bak`)).toBe(false);
+  });
+
+  it("snapshots a populated legacy DB before dropping (VACUUM INTO arm)", () => {
+    createLegacyDb(dbPath);
+    const result = migrate(dbPath);
+    expect(result.backupPath).toBe(`${dbPath}.pre-cutover.bak`);
+    expect(fs.existsSync(result.backupPath!)).toBe(true);
+    // The snapshot preserves the legacy table the migration dropped.
+    const bak = new Database(result.backupPath!, { readonly: true });
+    const rows = bak.prepare(`SELECT id FROM issues`).all() as Array<{ id: string }>;
+    bak.close();
+    expect(rows).toEqual([{ id: "i1" }]);
+    const migrated = new Database(dbPath, { readonly: true });
+    const tables = new Set(
+      (migrated.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as Array<{
+        name: string;
+      }>).map((r) => r.name),
+    );
+    migrated.close();
+    expect(tables.has("issues")).toBe(false);
+    expect(tables.has("activity")).toBe(true);
+  });
+
+  it("keeps an earlier snapshot instead of overwriting it (already-exists arm)", () => {
+    createLegacyDb(dbPath);
+    const candidate = `${dbPath}.pre-cutover.bak`;
+    fs.writeFileSync(candidate, "earlier snapshot", "utf-8");
+    // Re-introduce a legacy table so this run is again a destructive cutover.
+    const result = migrate(dbPath);
+    expect(result.backupPath).toBe(candidate);
+    // The pre-existing file is preserved, not clobbered by VACUUM INTO.
+    expect(fs.readFileSync(candidate, "utf-8")).toBe("earlier snapshot");
+  });
+
+  it("skips the backup probe entirely with keepLegacy", () => {
+    createLegacyDb(dbPath);
+    const result = migrate(dbPath, { keepLegacy: true });
+    expect(result.backupPath).toBeUndefined();
+    // Legacy table survives (DROP_LEGACY skipped).
+    const db = new Database(dbPath, { readonly: true });
+    const rows = db.prepare(`SELECT id FROM issues`).all();
+    db.close();
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("main (CLI entry)", () => {
+  it("prints usage and exits 2 when the db-path argument is missing", async () => {
+    const log = vi.fn();
+    const error = vi.fn();
+    const exit = vi.fn();
+    await main(["node", "migrate.ts"], log, error, exit);
+    expect(error).toHaveBeenCalledWith("usage: tsx migrate.ts <db-path>");
+    expect(exit).toHaveBeenCalledWith(2);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("migrates the given path and reports drop/create counts", async () => {
+    const log = vi.fn();
+    const error = vi.fn();
+    const exit = vi.fn();
+    await main(["node", "migrate.ts", dbPath], log, error, exit);
+    expect(error).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+    const lines = log.mock.calls.map((c) => c[0] as string);
+    expect(lines[0]).toBe(`migrate: ${dbPath}`);
+    // Fresh DB → no backup line.
+    expect(lines.some((l) => l.includes("backup:"))).toBe(false);
+    expect(lines.some((l) => l.includes("dropped:"))).toBe(true);
+    expect(lines.some((l) => l.includes("created:"))).toBe(true);
+  });
+
+  it("reports the backupPath line when a cutover snapshot was taken", async () => {
+    createLegacyDb(dbPath);
+    const log = vi.fn();
+    await main(["node", "migrate.ts", dbPath], log, vi.fn(), vi.fn());
+    const lines = log.mock.calls.map((c) => c[0] as string);
+    expect(lines.some((l) => l.includes(`backup:  ${dbPath}.pre-cutover.bak`))).toBe(true);
+  });
+});

--- a/packages/services/dashboard/src/server/migrate.ts
+++ b/packages/services/dashboard/src/server/migrate.ts
@@ -226,23 +226,32 @@ export function migrate(
   return { dbPath, droppedLegacy: dropped, createdNew: created, backupPath };
 }
 
-/** CLI entry: `tsx migrate.ts <dbPath>` */
-async function main(): Promise<void> {
-  const dbPath = process.argv[2];
+/** CLI entry: `tsx migrate.ts <dbPath>`. The process seams (argv/log/error/
+ *  exit) are injectable so tests can drive it as a plain function; the
+ *  defaults keep the CLI behavior identical. */
+export async function main(
+  argv: readonly string[] = process.argv,
+  log: (msg: string) => void = console.log,
+  error: (msg: string) => void = console.error,
+  exit: (code: number) => void = process.exit,
+): Promise<void> {
+  const dbPath = argv[2];
   if (!dbPath) {
-    console.error("usage: tsx migrate.ts <db-path>");
-    process.exit(2);
+    error("usage: tsx migrate.ts <db-path>");
+    exit(2);
+    return; // unreachable in production (process.exit never returns)
   }
   const result = migrate(dbPath);
-  console.log(`migrate: ${result.dbPath}`);
+  log(`migrate: ${result.dbPath}`);
   if (result.backupPath) {
-    console.log(`  backup:  ${result.backupPath} (pre-cutover snapshot — restore with 'cp' to roll back)`);
+    log(`  backup:  ${result.backupPath} (pre-cutover snapshot — restore with 'cp' to roll back)`);
   }
-  console.log(`  dropped: ${result.droppedLegacy} legacy table(s)`);
-  console.log(`  created: ${result.createdNew} statement(s) ` +
-              `(7 tables + 2 indexes)`);
+  log(`  dropped: ${result.droppedLegacy} legacy table(s)`);
+  log(`  created: ${result.createdNew} statement(s) ` +
+      `(7 tables + 2 indexes)`);
 }
 
+/* v8 ignore next 3 -- CLI entry guard; never true when imported by tests. */
 if (import.meta.url === `file://${process.argv[1]}`) {
   void main();
 }

--- a/packages/services/dashboard/src/server/search.test.ts
+++ b/packages/services/dashboard/src/server/search.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import type { AddressInfo } from "node:net";
+
+import {
+  buildSearchResponse,
+  buildSearchRouter,
+  coerceCorpus,
+  coerceLimit,
+  displayPath,
+  loadMarkdown,
+  normalizeSearchResults,
+  resolveContentPath,
+  titleForHit,
+} from "./search.js";
+
+describe("coerceCorpus / coerceLimit", () => {
+  it("accepts the three corpora and falls back to 'all'", () => {
+    expect(coerceCorpus("wiki")).toBe("wiki");
+    expect(coerceCorpus("memory")).toBe("memory");
+    expect(coerceCorpus("all")).toBe("all");
+    expect(coerceCorpus("bogus")).toBe("all");
+    expect(coerceCorpus(undefined)).toBe("all");
+  });
+
+  it("bounds the limit to 1..50 with a default of 20", () => {
+    expect(coerceLimit("5")).toBe(5);
+    expect(coerceLimit("50")).toBe(50);
+    expect(coerceLimit("51")).toBe(20);
+    expect(coerceLimit("0")).toBe(20);
+    expect(coerceLimit("abc")).toBe(20);
+    expect(coerceLimit(undefined)).toBe(20);
+  });
+});
+
+describe("normalizeSearchResults", () => {
+  it("extracts path/snippet/score from a well-formed payload", () => {
+    const hits = normalizeSearchResults({
+      results: [{ path: "wiki/a.md", snippet: "## Rule\nDo X", score: 0.91 }],
+    });
+    expect(hits).toEqual([{ path: "wiki/a.md", snippet: "## Rule\nDo X", score: 0.91 }]);
+  });
+
+  it("degrades malformed payloads to an empty list", () => {
+    expect(normalizeSearchResults(null)).toEqual([]);
+    expect(normalizeSearchResults("nope")).toEqual([]);
+    expect(normalizeSearchResults({})).toEqual([]);
+    expect(normalizeSearchResults({ results: "nope" })).toEqual([]);
+  });
+
+  it("skips entries without a usable path and defaults missing fields", () => {
+    const hits = normalizeSearchResults({
+      results: [
+        null,
+        "string-entry",
+        { snippet: "no path" },
+        { path: "" },
+        { path: "ok.md", snippet: 42, score: "high" },
+      ],
+    });
+    expect(hits).toEqual([{ path: "ok.md", snippet: "", score: null }]);
+  });
+});
+
+describe("titleForHit", () => {
+  it("prefers the frontmatter title line, unquoting it", () => {
+    expect(titleForHit("---\ntitle: Plain Title\n---\nbody", "x.md")).toBe("Plain Title");
+    expect(titleForHit("---\ntitle: 'Quoted Title'\n---", "x.md")).toBe("Quoted Title");
+  });
+
+  it("falls back to a de-kebabed filename when there is no title", () => {
+    expect(titleForHit("no frontmatter", "wiki/dash/feed-intake-location.md")).toBe(
+      "Feed intake location",
+    );
+  });
+
+  it("ignores an empty frontmatter title and survives odd paths", () => {
+    expect(titleForHit("title: ''\n", "wiki/some_entry.md")).toBe("Some entry");
+    expect(titleForHit("", ".md")).toBe(".md");
+  });
+});
+
+describe("displayPath", () => {
+  it("cuts to the wiki/tastes/memory/inbox tree marker", () => {
+    expect(displayPath("../../../someone/digital-me/wiki/dash/a.md")).toBe("wiki/dash/a.md");
+    expect(displayPath("/abs/digital-me/tastes/design/b.md")).toBe("tastes/design/b.md");
+    expect(displayPath("memory/2026-05-15.md")).toBe("memory/2026-05-15.md");
+    expect(displayPath("../inbox/c.md")).toBe("inbox/c.md");
+  });
+
+  it("strips ../ churn and collapses foreign absolute paths to a basename", () => {
+    expect(displayPath("../../notes/d.md")).toBe("notes/d.md");
+    expect(displayPath("/etc/passwd")).toBe("passwd");
+    expect(displayPath("plain.md")).toBe("plain.md");
+  });
+
+  it("normalizes backslashes", () => {
+    expect(displayPath("..\\..\\digital-me\\wiki\\a.md")).toBe("wiki/a.md");
+  });
+});
+
+describe("resolveContentPath", () => {
+  const root = "/home/u/digital-me";
+  const exists = (present: string[]) => (p: string) => present.includes(p);
+
+  it("resolves a root-relative path", () => {
+    expect(
+      resolveContentPath("wiki/a.md", [root], exists(["/home/u/digital-me/wiki/a.md"])),
+    ).toBe("/home/u/digital-me/wiki/a.md");
+  });
+
+  it("accepts an absolute path inside a root", () => {
+    expect(
+      resolveContentPath(
+        "/home/u/digital-me/wiki/a.md",
+        [root],
+        exists(["/home/u/digital-me/wiki/a.md"]),
+      ),
+    ).toBe("/home/u/digital-me/wiki/a.md");
+  });
+
+  it("recovers a deep ../-relative path via the root-basename marker", () => {
+    expect(
+      resolveContentPath(
+        "../../../../../someone/digital-me/wiki/dash/a.md",
+        [root],
+        exists(["/home/u/digital-me/wiki/dash/a.md"]),
+      ),
+    ).toBe("/home/u/digital-me/wiki/dash/a.md");
+  });
+
+  it("tries roots in order and falls through to the next", () => {
+    const workspace = "/home/u/.openclaw/workspace";
+    expect(
+      resolveContentPath(
+        "memory/2026.md",
+        [root, workspace],
+        exists(["/home/u/.openclaw/workspace/memory/2026.md"]),
+      ),
+    ).toBe("/home/u/.openclaw/workspace/memory/2026.md");
+  });
+
+  it("refuses traversal escapes and absolute paths outside every root", () => {
+    const anything = () => true; // even if the file exists, containment must fail
+    expect(resolveContentPath("../../etc/passwd", [root], anything)).toBeNull();
+    expect(resolveContentPath("/etc/passwd", [root], anything)).toBeNull();
+    expect(resolveContentPath("wiki/../../escape.md", [root], anything)).toBeNull();
+  });
+
+  it("returns null when nothing exists", () => {
+    expect(resolveContentPath("wiki/a.md", [root], () => false)).toBeNull();
+  });
+
+  it("uses the real filesystem by default", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "search-root-"));
+    try {
+      fs.mkdirSync(path.join(tmp, "wiki"));
+      fs.writeFileSync(path.join(tmp, "wiki", "real.md"), "# hi", "utf-8");
+      expect(resolveContentPath("wiki/real.md", [tmp])).toBe(path.join(tmp, "wiki", "real.md"));
+      expect(resolveContentPath("wiki/missing.md", [tmp])).toBeNull();
+      // A directory is not a previewable file.
+      expect(resolveContentPath("wiki", [tmp])).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadMarkdown", () => {
+  it("reads content and caps oversized files", () => {
+    expect(loadMarkdown("/x.md", () => "# body")).toBe("# body");
+    const huge = "x".repeat(256 * 1024 + 10);
+    expect(loadMarkdown("/x.md", () => huge)).toHaveLength(256 * 1024);
+  });
+
+  it("degrades a read failure to null", () => {
+    expect(
+      loadMarkdown("/x.md", () => {
+        throw new Error("EACCES");
+      }),
+    ).toBeNull();
+  });
+
+  it("uses the real filesystem by default", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "search-md-"));
+    try {
+      const p = path.join(tmp, "a.md");
+      fs.writeFileSync(p, "# real", "utf-8");
+      expect(loadMarkdown(p)).toBe("# real");
+      expect(loadMarkdown(path.join(tmp, "missing.md"))).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildSearchResponse", () => {
+  const root = "/home/u/digital-me";
+  const deps = {
+    contentRoots: [root],
+    fileExists: (p: string) => p === "/home/u/digital-me/wiki/a.md",
+    readFile: (p: string) => `content of ${p}`,
+  };
+
+  it("ranks hits in payload order and hydrates resolvable previews", () => {
+    const raw = {
+      results: [
+        { path: "wiki/a.md", snippet: "---\ntitle: Entry A\n---\nRule", score: 0.9 },
+        { path: "wiki/gone.md", snippet: "", score: 0.5 },
+      ],
+    };
+    const res = buildSearchResponse("feed", "wiki", raw, deps);
+    expect(res.query).toBe("feed");
+    expect(res.corpus).toBe("wiki");
+    expect(res.results).toHaveLength(2);
+    expect(res.results[0]).toMatchObject({
+      rank: 1,
+      title: "Entry A",
+      path: "wiki/a.md",
+      score: 0.9,
+      markdown: "content of /home/u/digital-me/wiki/a.md",
+    });
+    // Unresolvable hit still ranks — snippet-only preview.
+    expect(res.results[1]).toMatchObject({ rank: 2, markdown: null });
+    expect(res.results.map((r) => r.id)).toEqual(["wiki/a.md#1", "wiki/gone.md#2"]);
+  });
+
+  it("passes default fs seams through when none are injected", () => {
+    const res = buildSearchResponse("q", "all", { results: [{ path: "nope/x.md" }] }, {
+      contentRoots: ["/definitely/not/a/real/root"],
+    });
+    expect(res.results[0]!.markdown).toBeNull();
+  });
+});
+
+describe("buildSearchRouter (HTTP)", () => {
+  let server: http.Server;
+  let base: string;
+  let memorySearch: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    memorySearch = vi.fn();
+    const app = express();
+    app.use(
+      "/api/search",
+      buildSearchRouter({
+        memorySearch,
+        contentRoots: ["/home/u/digital-me"],
+        fileExists: () => false,
+        readFile: () => "",
+      }),
+    );
+    server = http.createServer(app);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise((r) => server.close(r));
+  });
+
+  it("400s without a query (missing or blank)", async () => {
+    expect((await fetch(`${base}/api/search`)).status).toBe(400);
+    expect((await fetch(`${base}/api/search?q=%20`)).status).toBe(400);
+    expect(memorySearch).not.toHaveBeenCalled();
+  });
+
+  it("forwards query/corpus/limit to memory_search and returns ranked results", async () => {
+    memorySearch.mockResolvedValue({
+      results: [{ path: "wiki/a.md", snippet: "title: A\n", score: 0.8 }],
+    });
+    const res = await fetch(`${base}/api/search?q=feed+design&corpus=wiki&limit=5`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { query: string; results: Array<{ title: string }> };
+    expect(memorySearch).toHaveBeenCalledWith("feed design", { corpus: "wiki", limit: 5 });
+    expect(json.query).toBe("feed design");
+    expect(json.results[0]!.title).toBe("A");
+  });
+
+  it("coerces a bogus corpus/limit to the defaults", async () => {
+    memorySearch.mockResolvedValue({ results: [] });
+    const res = await fetch(`${base}/api/search?q=x&corpus=bogus&limit=999`);
+    expect(res.status).toBe(200);
+    expect(memorySearch).toHaveBeenCalledWith("x", { corpus: "all", limit: 20 });
+  });
+
+  it("502s when the brain is unreachable", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      memorySearch.mockRejectedValue(new Error("proxy down"));
+      const res = await fetch(`${base}/api/search?q=x`);
+      expect(res.status).toBe(502);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toContain("memory_search unavailable");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/services/dashboard/src/server/search.ts
+++ b/packages/services/dashboard/src/server/search.ts
@@ -1,0 +1,232 @@
+/**
+ * Feed search — ranked knowledge search over the brain's memory_search tool.
+ *
+ * GET /api/search?q=<query>[&corpus=wiki|memory|all][&limit=N]
+ *
+ * The brain does the ranking (hybrid vector + text score); this module owns
+ * everything around it:
+ *
+ *   • normalizing the tool's loose result shape into typed hits
+ *   • deriving a human title (frontmatter `title:` > filename slug)
+ *   • resolving each hit's raw path — often a `../../..`-relative artifact of
+ *     the brain's index root — back to a real file INSIDE an allow-listed
+ *     content root, so the preview panel can render the full markdown
+ *   • never reading outside those roots (the resolver is containment-checked;
+ *     a hostile `../../etc/passwd` path degrades to a null preview, not a read)
+ *
+ * The response items mirror the Feed's attachment shape (title/path/markdown)
+ * so the frontend renders results with the exact same post + preview design.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { Router } from "express";
+
+export type SearchCorpus = "wiki" | "memory" | "all";
+
+const SEARCH_CORPORA: readonly SearchCorpus[] = ["wiki", "memory", "all"];
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+/** Preview payload cap — a runaway file must not balloon the response. */
+const MAX_MARKDOWN_BYTES = 256 * 1024;
+
+export function coerceCorpus(raw: unknown): SearchCorpus {
+  return typeof raw === "string" && (SEARCH_CORPORA as readonly string[]).includes(raw)
+    ? (raw as SearchCorpus)
+    : "all";
+}
+
+export function coerceLimit(raw: unknown): number {
+  const parsed = typeof raw === "string" ? parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= MAX_LIMIT ? parsed : DEFAULT_LIMIT;
+}
+
+/** One hit as the memory_search tool reports it (after defensive parsing). */
+export interface RawSearchHit {
+  readonly path: string;
+  readonly snippet: string;
+  readonly score: number | null;
+}
+
+/** Defensively extract hits from the tool's response. Tolerates a missing /
+ *  non-array `results`, non-object entries, and absent fields — a malformed
+ *  upstream payload degrades to an empty result list, not a 500. */
+export function normalizeSearchResults(raw: unknown): RawSearchHit[] {
+  if (typeof raw !== "object" || raw === null) return [];
+  const results = (raw as Record<string, unknown>).results;
+  if (!Array.isArray(results)) return [];
+  const hits: RawSearchHit[] = [];
+  for (const entry of results) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.path !== "string" || e.path.length === 0) continue;
+    hits.push({
+      path: e.path,
+      snippet: typeof e.snippet === "string" ? e.snippet : "",
+      score: typeof e.score === "number" ? e.score : null,
+    });
+  }
+  return hits;
+}
+
+/** Human title for a hit: the frontmatter `title:` line when the snippet
+ *  carries one, else the filename slug de-kebabed ("taste-flat-tree" →
+ *  "Taste flat tree"). */
+export function titleForHit(snippet: string, rawPath: string): string {
+  const m = /^title:\s*(.+)$/m.exec(snippet);
+  if (m) {
+    const t = m[1]!.trim().replace(/^['"]|['"]$/g, "").trim();
+    if (t.length > 0) return t;
+  }
+  const base = path.basename(rawPath).replace(/\.mdx?$/i, "");
+  const words = base.replace(/[-_]+/g, " ").trim();
+  return words.length > 0 ? words[0]!.toUpperCase() + words.slice(1) : rawPath;
+}
+
+/** Display path: strip the brain-index-relative `../` prefix noise so the UI
+ *  shows "wiki/dashboard/foo.md", not "../../../../Users/…/foo.md". */
+export function displayPath(rawPath: string): string {
+  const normalized = rawPath.replace(/\\/g, "/");
+  // Prefer the path from a well-known content tree marker onwards.
+  for (const marker of ["wiki/", "tastes/", "memory/", "inbox/"]) {
+    const idx = normalized.lastIndexOf(`/${marker}`);
+    if (idx >= 0) return normalized.slice(idx + 1);
+    if (normalized.startsWith(marker)) return normalized;
+  }
+  // Otherwise drop any leading ../ churn and absolute prefix.
+  const stripped = normalized.replace(/^(\.\.\/)+/, "");
+  return stripped.startsWith("/") ? path.basename(stripped) : stripped;
+}
+
+/** True when `candidate` sits inside `root` (lexically — after resolution). */
+function isInsideRoot(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  return rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+/**
+ * Resolve a hit's raw path to a readable absolute path inside one of the
+ * allow-listed content roots, or null. Tries, per root:
+ *   1. the raw path taken as absolute
+ *   2. the raw path resolved against the root (handles plain "memory/x.md")
+ *   3. marker-based recovery: the substring from "/<root basename>/" onward
+ *      re-anchored at the root (handles "../../../Users/…/digital-me/wiki/x.md"
+ *      regardless of how deep the brain's index dir was)
+ * Every candidate is containment-checked, so `../` escapes resolve to null.
+ */
+export function resolveContentPath(
+  rawPath: string,
+  roots: readonly string[],
+  fileExists: (p: string) => boolean = (p) => fs.existsSync(p) && fs.statSync(p).isFile(),
+): string | null {
+  const normalized = rawPath.replace(/\\/g, "/");
+  for (const root of roots) {
+    const candidates: string[] = [];
+    if (path.isAbsolute(normalized)) candidates.push(path.resolve(normalized));
+    candidates.push(path.resolve(root, normalized));
+    const marker = `/${path.basename(root)}/`;
+    const idx = normalized.lastIndexOf(marker);
+    if (idx >= 0) {
+      candidates.push(path.resolve(root, normalized.slice(idx + marker.length)));
+    }
+    for (const candidate of candidates) {
+      if (isInsideRoot(root, candidate) && fileExists(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/** Read a resolved file for the preview panel; size-capped, error-tolerant. */
+export function loadMarkdown(
+  absPath: string,
+  readFile: (p: string) => string = (p) => fs.readFileSync(p, "utf-8"),
+): string | null {
+  try {
+    const content = readFile(absPath);
+    return content.length > MAX_MARKDOWN_BYTES
+      ? content.slice(0, MAX_MARKDOWN_BYTES)
+      : content;
+  } catch {
+    return null;
+  }
+}
+
+/** One ranked result, shaped like a Feed attachment (+ rank/score) so the
+ *  frontend reuses the post + preview design unchanged. */
+export interface SearchResultItem {
+  readonly id: string;
+  readonly rank: number;
+  readonly title: string;
+  readonly path: string;
+  readonly score: number | null;
+  readonly snippet: string;
+  readonly markdown: string | null;
+}
+
+export interface SearchResponse {
+  readonly query: string;
+  readonly corpus: SearchCorpus;
+  readonly results: readonly SearchResultItem[];
+}
+
+export type MemorySearchFn = (
+  query: string,
+  opts: { readonly corpus: SearchCorpus; readonly limit: number },
+) => Promise<unknown>;
+
+export interface SearchRouterDeps {
+  /** Calls the brain's memory_search tool; returns its raw (parsed) payload. */
+  readonly memorySearch: MemorySearchFn;
+  /** Allow-listed roots the preview loader may read from. */
+  readonly contentRoots: readonly string[];
+  /** Test seams — default to real fs. */
+  readonly fileExists?: (p: string) => boolean;
+  readonly readFile?: (p: string) => string;
+}
+
+/** Pure assembly: raw tool payload → ranked, preview-hydrated response. */
+export function buildSearchResponse(
+  query: string,
+  corpus: SearchCorpus,
+  raw: unknown,
+  deps: Pick<SearchRouterDeps, "contentRoots" | "fileExists" | "readFile">,
+): SearchResponse {
+  const results = normalizeSearchResults(raw).map((hit, i) => {
+    const resolved = deps.fileExists
+      ? resolveContentPath(hit.path, deps.contentRoots, deps.fileExists)
+      : resolveContentPath(hit.path, deps.contentRoots);
+    return {
+      id: `${displayPath(hit.path)}#${i + 1}`,
+      rank: i + 1,
+      title: titleForHit(hit.snippet, hit.path),
+      path: displayPath(hit.path),
+      score: hit.score,
+      snippet: hit.snippet,
+      markdown: resolved === null ? null : loadMarkdown(resolved, deps.readFile),
+    };
+  });
+  return { query, corpus, results };
+}
+
+/** Router for GET /api/search?q=…&corpus=…&limit=…. */
+export function buildSearchRouter(deps: SearchRouterDeps): Router {
+  const router = Router();
+  router.get("/", (req, res) => {
+    const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+    if (q.length === 0) {
+      res.status(400).json({ error: "Missing query — pass ?q=<search terms>" });
+      return;
+    }
+    const corpus = coerceCorpus(req.query.corpus);
+    const limit = coerceLimit(req.query.limit);
+    deps
+      .memorySearch(q, { corpus, limit })
+      .then((raw) => res.json(buildSearchResponse(q, corpus, raw, deps)))
+      .catch((err) => {
+        console.error("[/api/search]", err);
+        // 502: the dashboard is fine, the brain upstream isn't reachable.
+        res.status(502).json({ error: "memory_search unavailable — is the openclaw brain running?" });
+      });
+  });
+  return router;
+}

--- a/packages/services/dashboard/src/server/server.ts
+++ b/packages/services/dashboard/src/server/server.ts
@@ -10,7 +10,9 @@ import { fileURLToPath } from "url";
 import { fetchDashboardData } from "./data.mc.js";
 import { getGoals, getGoalMetrics, getAllGoalMetrics, getImprovements, getFeedback, getInsights, getCronRunsSummary, getCronRunsPerJob, getRecentTraces, getTraceById, getIssuesSummary, getIssuesTimeSeries, getTeamHealthTimeSeries, getAutomationOpportunitiesTimeSeries, getKanbanData, getLayerHealth, getWorkflowsForMechanism, getKnowledgeRows, getValidationRows } from "./db.js";
 import { getSystemStatus, loadSkillsConfig } from "./drift-status.mc.js";
-import { initBrainClient } from "./brain-client.mc.js";
+import { brainMemorySearch, initBrainClient } from "./brain-client.mc.js";
+// Feed search: ranked memory_search results with containment-checked previews.
+import { buildSearchRouter } from "./search.js";
 
 // NUX scope-down §C: new minimal metrics router for the 4-chart Metrics view.
 // Mounted alongside the legacy routes during the §C-§F transition window.
@@ -113,6 +115,21 @@ app.use("/api/mechanism", buildMechanismRouter());
 // split as the metrics endpoints); the stream_activity intake step owns the
 // brain → row mapping. See activity-feed.ts + intake/.../stream_activity.py.
 app.use("/api/activity-feed", buildActivityFeedRouter(DASHBOARD_DB_PATH));
+
+// ── Feed search: ranked knowledge search over the brain's memory_search ──
+// Preview markdown is read from disk, restricted to the user-owned knowledge
+// roots (the digital-me tree + the openclaw agent workspace) — a hit whose
+// path resolves outside them just previews as snippet-only.
+app.use(
+  "/api/search",
+  buildSearchRouter({
+    memorySearch: brainMemorySearch,
+    contentRoots: [
+      path.join(HOME, "digital-me"),
+      path.join(process.env["OPENCLAW_HOME"] ?? path.join(HOME, ".openclaw"), "workspace"),
+    ],
+  }),
+);
 // NUX §E note: buildKanbanRouter is exported but intentionally NOT mounted at
 // /api/kanban. The legacy /api/kanban endpoint below returns a rich
 // {goals, stats, pagination} shape that TaskKanban consumes; replacing it

--- a/packages/services/dashboard/vitest.config.ts
+++ b/packages/services/dashboard/vitest.config.ts
@@ -18,6 +18,16 @@ export default defineConfig({
         "src/**/*.test.ts",
         "src/server/index.ts",
         "src/server/types.ts",
+        // §0→§G migration-window modules (see server.ts header): the .mc
+        // duplicates and db.ts are legacy copies whose tested rewrites
+        // (data.ts, drift-status.ts, brain-client.ts) sit at 100%; all of
+        // these are deleted in the §G final pass.
+        "src/server/server.ts", // composition root — binds ports at import time; untestable in-process
+        "src/server/lib.ts", // pure re-export barrel over drift-status.ts (no logic)
+        "src/server/db.ts", // legacy reads (@ts-nocheck) replaced by data.ts; kanban-data.test.ts still exercises it
+        "src/server/data.mc.ts", // legacy duplicate of data.ts (tested rewrite at 100%)
+        "src/server/drift-status.mc.ts", // legacy duplicate of drift-status.ts (tested rewrite at 100%)
+        "src/server/brain-client.mc.ts", // legacy duplicate of brain-client.ts (tested rewrite at 100%)
       ],
       thresholds: {
         lines: 100,

--- a/packages/transport/brain-mcp-proxy/src/app-rate-writer.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/app-rate-writer.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import realNodeFs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   bucketKeyFor,
   createAppRateWriter,
@@ -53,6 +56,22 @@ describe("extractHitPaths", () => {
   it("returns empty array for empty content", () => {
     expect(extractHitPaths({ content: [] })).toEqual([]);
   });
+
+  it("returns empty array when the text payload is not a string", () => {
+    expect(
+      extractHitPaths({
+        content: [{ type: "text", text: 42 as unknown as string }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns empty array when the JSON payload has no results array", () => {
+    expect(
+      extractHitPaths({
+        content: [{ type: "text", text: JSON.stringify({ other: 1 }) }],
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("normaliseWikiPath", () => {
@@ -75,6 +94,15 @@ describe("normaliseWikiPath", () => {
   });
   it("filters absolute paths it can't classify", () => {
     expect(normaliseWikiPath("/etc/passwd")).toBeNull();
+  });
+  it("returns null for empty input", () => {
+    expect(normaliseWikiPath("")).toBeNull();
+  });
+  it("returns null when nothing follows the /wiki/ marker", () => {
+    expect(normaliseWikiPath("/home/test/digital-me/wiki/")).toBeNull();
+  });
+  it("returns null for a bare wiki/ prefix with nothing after it", () => {
+    expect(normaliseWikiPath("wiki/")).toBeNull();
   });
 });
 
@@ -381,5 +409,421 @@ describe("createAppRateWriter — recordSearch + flushAll integration", () => {
     expect(JSON.parse(writes[0].data).flush_reason).toBe("exit");
     writer.shutdown(); // no-op
     expect(writes).toHaveLength(1);
+  });
+});
+
+describe("createAppRateWriter — record edge cases", () => {
+  it("ignores memory_search responses with zero hits (no bucket created)", () => {
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => Date.now(),
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult([]),
+    });
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("records application_rate=null when every hit normalises away (injection still counted)", () => {
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => new Date("2026-05-26T10:00:00Z").getTime(),
+    });
+    // memory/ + absolute paths both normalise to null → surfaced stays empty.
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["memory/abc/1.md", "/etc/passwd"]),
+    });
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(1);
+    const rec = JSON.parse(writes[0].data);
+    expect(rec.hook_injections).toBe(1);
+    expect(rec.surfaced_unique).toBe(0);
+    expect(rec.application_rate).toBeNull();
+  });
+
+  it("a repeat search with no new paths keeps the bucket alive without re-flushing", () => {
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => new Date("2026-05-26T10:00:00Z").getTime(),
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    writer.flushAll("manual");
+    // Identical hit set → added=0, hookInjections=2 → keep-alive, no bump.
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(1);
+  });
+
+  it("never writes a record for a get-only bucket (no surfaced, no injections)", () => {
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => Date.now(),
+    });
+    writer.recordGet({
+      agentId: "coo",
+      toolName: "memory_get",
+      args: { path: "foo/a.md" },
+    });
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("stale GC drops a get-only bucket without ever writing", () => {
+    const { fs, writes } = fakeFs();
+    let clock = new Date("2026-05-26T10:00:00Z").getTime();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      staleBucketMs: 60_000,
+      fs,
+      now: () => clock,
+    });
+    writer.recordGet({
+      agentId: "coo",
+      toolName: "memory_get",
+      args: { path: "foo/a.md" },
+    });
+    clock += 120_000;
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(0);
+    // Bucket was dropped — nothing left to flush on later passes either.
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("stale GC drops buckets of skipped runtimes (logPath=null) silently", () => {
+    const { fs, writes } = fakeFs();
+    let clock = new Date("2026-05-26T10:00:00Z").getTime();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => null,
+      flushIntervalMs: 0,
+      staleBucketMs: 60_000,
+      fs,
+      now: () => clock,
+    });
+    writer.recordSearch({
+      agentId: "claude-code",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    clock += 120_000;
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("flushAll warns and continues when logPathForAgent itself throws (non-Error)", () => {
+    const { fs } = fakeFs();
+    const warn = vi.fn();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => {
+        // Non-Error throwable — exercises the String(err) fallback too.
+        throw "policy exploded";
+      },
+      flushIntervalMs: 0,
+      fs,
+      now: () => Date.now(),
+      warn,
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    expect(() => writer.flushAll("manual")).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("app_rate flush failed"),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("policy exploded"),
+    );
+  });
+
+  it("uses a no-op warn by default (write failure still never throws)", () => {
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs: {
+        mkdirSync: () => {},
+        appendFileSync: () => {
+          throw new Error("disk full");
+        },
+      },
+      now: () => Date.now(),
+      // no warn injected — default () => {} must absorb the failure
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    expect(() => writer.flushAll("manual")).not.toThrow();
+  });
+
+  it("recordSearch never throws when the clock is broken", () => {
+    const { fs } = fakeFs();
+    const warn = vi.fn();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => {
+        throw new Error("clock broken");
+      },
+      warn,
+    });
+    expect(() =>
+      writer.recordSearch({
+        agentId: "coo",
+        toolName: "memory_search",
+        result: memorySearchResult(["wiki/foo/a.md"]),
+      }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("recordSearch failed"),
+    );
+  });
+
+  it("recordGet never throws when the clock is broken", () => {
+    const { fs } = fakeFs();
+    const warn = vi.fn();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => {
+        throw new Error("clock broken");
+      },
+      warn,
+    });
+    expect(() =>
+      writer.recordGet({
+        agentId: "coo",
+        toolName: "memory_get",
+        args: { path: "foo/a.md" },
+      }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("recordGet failed"),
+    );
+  });
+
+  it("recordGet accepts the file_path alias for path", () => {
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => new Date("2026-05-26T10:00:00Z").getTime(),
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    writer.recordGet({
+      agentId: "coo",
+      toolName: "memory_get",
+      args: { file_path: "foo/a.md" },
+    });
+    writer.flushAll("manual");
+    expect(JSON.parse(writes[0].data).acted_paths).toEqual(["foo/a.md"]);
+  });
+
+  it("recordGet ignores missing, empty, and unmappable paths", () => {
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => Date.now(),
+    });
+    writer.recordGet({ agentId: "coo", toolName: "memory_get", args: {} });
+    writer.recordGet({
+      agentId: "coo",
+      toolName: "memory_get",
+      args: { path: "" },
+    });
+    writer.recordGet({
+      agentId: "coo",
+      toolName: "memory_get",
+      args: { path: "memory/abc/1.md" }, // normalises to null
+    });
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("mkdirs '.' when the log path has no directory component", () => {
+    const { fs, writes, mkdirs } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => Date.now(),
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    writer.flushAll("manual");
+    expect(writes).toHaveLength(1);
+    expect(mkdirs[0].path).toBe(".");
+  });
+});
+
+describe("createAppRateWriter — periodic flush timer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("starts an unref'd interval timer that flushes with reason=periodic", () => {
+    let tick: (() => void) | undefined;
+    const unref = vi.fn();
+    vi.stubGlobal("setInterval", ((fn: () => void) => {
+      tick = fn;
+      return { unref } as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setInterval);
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 60_000,
+      fs,
+      now: () => new Date("2026-05-26T10:00:00Z").getTime(),
+    });
+    expect(unref).toHaveBeenCalledOnce();
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    tick!();
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0].data).flush_reason).toBe("periodic");
+  });
+
+  it("warns instead of throwing when a periodic flush crashes", () => {
+    let tick: (() => void) | undefined;
+    vi.stubGlobal("setInterval", ((fn: () => void) => {
+      tick = fn;
+      // Plain numeric handle — also exercises the "no unref" timer shape.
+      return 42 as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setInterval);
+    const warn = vi.fn();
+    let broken = false;
+    createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 60_000,
+      fs: fakeFs().fs,
+      now: () => {
+        if (broken) throw new Error("clock broken");
+        return Date.now();
+      },
+      warn,
+    });
+    broken = true;
+    expect(() => tick!()).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("periodic flush crashed"),
+    );
+  });
+
+  it("shutdown still emits the exit flush when clearInterval throws", () => {
+    vi.stubGlobal("setInterval", (() =>
+      42 as unknown as NodeJS.Timeout) as unknown as typeof setInterval);
+    vi.stubGlobal("clearInterval", (() => {
+      throw new Error("timer subsystem gone");
+    }) as unknown as typeof clearInterval);
+    const { fs, writes } = fakeFs();
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 60_000,
+      fs,
+      now: () => new Date("2026-05-26T10:00:00Z").getTime(),
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    expect(() => writer.shutdown()).not.toThrow();
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0].data).flush_reason).toBe("exit");
+  });
+
+  it("shutdown swallows a crashing final flush", () => {
+    const { fs, writes } = fakeFs();
+    let broken = false;
+    const writer = createAppRateWriter({
+      logPathForAgent: () => ({ path: "/tmp/oc.log", surface: "openclaw" }),
+      flushIntervalMs: 0,
+      fs,
+      now: () => {
+        if (broken) throw new Error("clock broken");
+        return Date.now();
+      },
+    });
+    writer.recordSearch({
+      agentId: "coo",
+      toolName: "memory_search",
+      result: memorySearchResult(["wiki/foo/a.md"]),
+    });
+    broken = true;
+    expect(() => writer.shutdown()).not.toThrow();
+    expect(writes).toHaveLength(0);
+  });
+});
+
+describe("createAppRateWriter — real filesystem default", () => {
+  it("writes JSONL to disk when no fs is injected", () => {
+    const tmpDir = realNodeFs.mkdtempSync(
+      path.join(os.tmpdir(), "app-rate-writer-test-"),
+    );
+    try {
+      const logPath = path.join(tmpDir, "nested", "application_rate.log");
+      const writer = createAppRateWriter({
+        logPathForAgent: () => ({ path: logPath, surface: "openclaw" }),
+        flushIntervalMs: 0,
+        now: () => new Date("2026-05-26T10:00:00Z").getTime(),
+      });
+      writer.recordSearch({
+        agentId: "coo",
+        toolName: "memory_search",
+        result: memorySearchResult(["wiki/foo/a.md"]),
+      });
+      writer.flushAll("manual");
+      const lines = realNodeFs
+        .readFileSync(logPath, "utf8")
+        .trim()
+        .split("\n");
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0]).agent_id).toBe("coo");
+    } finally {
+      realNodeFs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/transport/brain-mcp-proxy/src/handler.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/handler.test.ts
@@ -8,6 +8,8 @@ import {
   type ToolCallTrace,
   type WikiBodyInliner,
 } from "./handler.js";
+import type { AppRateWriter } from "./app-rate-writer.js";
+import type { CallToolResult } from "./gateway.js";
 
 const makeInliner = (impl: WikiBodyInliner["readBody"]): WikiBodyInliner => ({
   readBody: impl,
@@ -233,6 +235,14 @@ describe("extractHitCount", () => {
   it("returns undefined when content is empty", () => {
     expect(extractHitCount("memory_search", { content: [] })).toBeUndefined();
   });
+
+  it("returns undefined when the text payload is not a string", () => {
+    expect(
+      extractHitCount("memory_search", {
+        content: [{ type: "text", text: 42 as unknown as string }],
+      }),
+    ).toBeUndefined();
+  });
 });
 
 describe("createCallToolHandler — traceWriter", () => {
@@ -430,6 +440,185 @@ describe("inlineTopHitBody", () => {
       inliner: { readBody: () => "body" },
     });
     expect(out).toBe(result);
+  });
+
+  it("returns input unchanged when content is empty", () => {
+    const result = { content: [] };
+    const out = inlineTopHitBody({
+      toolName: "memory_search",
+      result,
+      inliner: { readBody: () => "body" },
+    });
+    expect(out).toBe(result);
+  });
+
+  it("returns input unchanged when the text payload is not a string", () => {
+    const result = {
+      content: [{ type: "text" as const, text: 42 as unknown as string }],
+    };
+    const out = inlineTopHitBody({
+      toolName: "memory_search",
+      result,
+      inliner: { readBody: () => "body" },
+    });
+    expect(out).toBe(result);
+  });
+
+  it("returns input unchanged when the top hit is not an object", () => {
+    const result = memorySearchResult([null]);
+    const out = inlineTopHitBody({
+      toolName: "memory_search",
+      result,
+      inliner: { readBody: () => "body" },
+    });
+    expect(out).toBe(result);
+  });
+
+  it("returns input unchanged when the top hit has no path", () => {
+    const result = memorySearchResult([{ score: 0.9 }]);
+    const out = inlineTopHitBody({
+      toolName: "memory_search",
+      result,
+      inliner: { readBody: () => "body" },
+    });
+    expect(out).toBe(result);
+  });
+
+  it("treats a missing score as 0 (below minScore → no inline)", () => {
+    const result = memorySearchResult([{ path: "x.md" }]);
+    const reader = vi.fn().mockReturnValue("body");
+    const out = inlineTopHitBody({
+      toolName: "memory_search",
+      result,
+      inliner: { readBody: reader },
+    });
+    expect(reader).not.toHaveBeenCalled();
+    expect(out).toBe(result);
+  });
+
+  it("falls back to an empty tail when content reads back nullish while building the response", () => {
+    // Defensive path: results[0] is read from content before the augmented
+    // response re-reads content to copy the tail. An exotic result object
+    // whose content getter goes nullish must not crash the inliner.
+    const payload = JSON.stringify({ results: [{ path: "x.md", score: 0.9 }] });
+    let reads = 0;
+    const result = {
+      get content() {
+        reads += 1;
+        return reads === 1
+          ? [{ type: "text" as const, text: payload }]
+          : undefined;
+      },
+    } as unknown as CallToolResult;
+    const out = inlineTopHitBody({
+      toolName: "memory_search",
+      result,
+      inliner: { readBody: () => "BODY" },
+    });
+    expect(out.content).toHaveLength(1);
+    const parsed = JSON.parse((out.content[0] as { text: string }).text) as {
+      results: Array<Record<string, unknown>>;
+    };
+    expect(parsed.results[0]!.full_body).toBe("BODY");
+  });
+});
+
+// ─── appRateWriter wiring (M1 chokepoint, 2026-05-26) ──────────────────────
+
+function makeAppRateWriter() {
+  return {
+    recordSearch: vi.fn<AppRateWriter["recordSearch"]>(),
+    recordGet: vi.fn<AppRateWriter["recordGet"]>(),
+    flushAll: vi.fn<AppRateWriter["flushAll"]>(),
+    shutdown: vi.fn<AppRateWriter["shutdown"]>(),
+  };
+}
+
+describe("createCallToolHandler — appRateWriter wiring", () => {
+  it("routes memory_search responses to recordSearch (not recordGet)", async () => {
+    const searchResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ results: [{ path: "wiki/x.md", score: 0.9 }] }),
+        },
+      ],
+    };
+    const invoke = vi.fn().mockResolvedValue(searchResult);
+    const appRateWriter = makeAppRateWriter();
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "codex",
+      log: vi.fn(),
+      appRateWriter,
+    });
+    await handler({ name: "memory_search", arguments: { query: "x" } });
+    expect(appRateWriter.recordSearch).toHaveBeenCalledOnce();
+    expect(appRateWriter.recordSearch.mock.calls[0]![0]).toMatchObject({
+      agentId: "codex",
+      toolName: "memory_search",
+      result: searchResult,
+    });
+    expect(appRateWriter.recordGet).not.toHaveBeenCalled();
+  });
+
+  it("routes memory_get calls to recordGet with the prepared args", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "entry body" }],
+    });
+    const appRateWriter = makeAppRateWriter();
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "codex",
+      log: vi.fn(),
+      appRateWriter,
+    });
+    await handler({ name: "memory_get", arguments: { path: "foo/a.md" } });
+    expect(appRateWriter.recordGet).toHaveBeenCalledOnce();
+    expect(appRateWriter.recordGet.mock.calls[0]![0]).toMatchObject({
+      agentId: "codex",
+      toolName: "memory_get",
+      args: { path: "foo/a.md", agent_id: "codex" },
+    });
+    expect(appRateWriter.recordSearch).not.toHaveBeenCalled();
+  });
+
+  it("does not observe non-memory tools", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const appRateWriter = makeAppRateWriter();
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "codex",
+      log: vi.fn(),
+      appRateWriter,
+    });
+    await handler({ name: "tasks", arguments: { action: "board" } });
+    expect(appRateWriter.recordSearch).not.toHaveBeenCalled();
+    expect(appRateWriter.recordGet).not.toHaveBeenCalled();
+  });
+
+  it("never affects the tool response when the writer throws", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const appRateWriter = makeAppRateWriter();
+    appRateWriter.recordSearch.mockImplementation(() => {
+      throw new Error("writer disk broken");
+    });
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "codex",
+      log: vi.fn(),
+      appRateWriter,
+    });
+    const result = await handler({
+      name: "memory_search",
+      arguments: { query: "x" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect((result.content[0] as { text: string }).text).toBe("ok");
   });
 });
 

--- a/packages/transport/brain-mcp-proxy/src/trace-writer.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/trace-writer.test.ts
@@ -160,6 +160,26 @@ describe("createSqliteTraceWriter", () => {
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toMatch(/trace INSERT failed/);
   });
+
+  it("stringifies non-Error throwables in warnings", () => {
+    createTracesTable(dbPath);
+    const warnings: string[] = [];
+    const write = createSqliteTraceWriter({
+      brainDbPath: dbPath,
+      warn: (l) => warnings.push(l),
+    });
+    // A trace whose property access throws a non-Error value — the warning
+    // path must String() it rather than assume an Error instance.
+    const trace = baseTrace();
+    Object.defineProperty(trace, "query", {
+      get() {
+        throw "query-getter-exploded";
+      },
+    });
+    write(trace);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/trace INSERT failed: query-getter-exploded/);
+  });
 });
 
 describe("defaultBrainDbPath", () => {


### PR DESCRIPTION
## What

**1. \`digital-me dashboard\` CLI command** — one command to get the OA dashboard in front of you:
- already serving → opens the browser (\`open\`/\`xdg-open\`/\`start\` per platform)
- installed but down → starts the always-on service (which HTTP-verifies), then opens
- never installed → exit 2 with install guidance
- \`--port <n>\` overrides, \`--no-open\` prints the URL; README + \`--help\` updated
- decisions live in tested `packages/cli/src/dashboard-command.ts`; the bin has wiring only

**2. Feed tab search (memory_search-backed)** — a search box in the Feed masthead:
- `GET /api/search?q=…[&corpus=wiki|memory|all][&limit≤50]` calls the brain's `memory_search` and returns ranked hits shaped like feed attachments
- results render in the same FeedPost design (Living Knowledge author, `#rank · NN% match` byline, KNOWLEDGE badge); clicking a file opens the existing right-side preview panel with the entry's full rendered markdown
- preview markdown is read from disk behind a containment-checked path resolver (allow-listed roots `~/digital-me` + openclaw workspace; `../` escapes degrade to snippet-only, never a read outside the roots; 256 KiB cap)
- searching pauses the live poll; clearing restores it

## Verified live
- CLI run against the real serving dashboard (`[OK] dashboard serving at http://localhost:3458`), plus help/invalid/exit-code paths
- `/api/search` against the live brain: real ranked results with resolved paths + hydrated markdown
- UI driven in a real browser build: query → 6 ranked results → attachment card → preview panel rendering the actual wiki entry

## Coverage — a true 100%
`pnpm run ci` fully green (sanitize → build → typecheck → lint → knip → test:coverage). Every package now genuinely passes its pinned 100/100/100/100 thresholds (previously 8 of 9 packages failed them). ~1,900 tests pass. New suites across cli, all four runtime packages, brain-mcp-proxy, brain-orchestrator, and the dashboard server. Dashboard's §0→§G migration-window legacy duplicates (`*.mc.ts`, `db.ts`, `server.ts` composition root, `lib.ts` barrel) are coverage-excluded with per-file rationale — their tested rewrites sit at 100%.

## Health sweep
All five enrolled dimensions **SHIP**: data · docs (36/36 claims resolve, incl. the new command) · runtime · update · visual (re-captured 1440/375, no overflow, zero console errors). Note: the runtime sweep's two *advisory* pin mismatches (installed openclaw brain/recall plugin entries ≠ current source templates) are a pre-existing deploy-lag on this machine, not introduced here — a post-merge `digital-me deploy --runtime openclaw` clears them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)