### PR TITLE
feat(retention): sweep ALL terminal goals of scheduled workflows (ratified policy) + self-healing web capture

### DIFF
--- a/health-sweep/STATE-LOG.md
+++ b/health-sweep/STATE-LOG.md
@@ -541,3 +541,17 @@
 - **regression vs baseline:** 🟢 none
 - **critiques:** — (no critique lane for this profile)
 - **EXIT:** ✅ SHIP
+
+## 2026-07-10T17:08:14.335Z · web · 1c4ba75
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** 🟢 cleared · **stories:** 🟢
+- **EXIT:** ✅ SHIP
+
+## 2026-07-10T17:08:31.168Z · web · 1c4ba75
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** 🟢 cleared · **stories:** 🟢
+- **EXIT:** ✅ SHIP

--- a/health-sweep/profiles/web.json
+++ b/health-sweep/profiles/web.json
@@ -45,7 +45,7 @@
       "scope": "free"
     }
   ],
-  "captureCmd": null,
+  "captureCmd": "node ~/.agents/skills/motusai-visual-sweep/engine/lib/drive-headless.mjs --repo . --profile health-sweep/profiles/web.json --out health-sweep/capture-web.json",
   "requireDeployed": false,
   "brandRules": {
     "noItalic": "block",

--- a/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/scheduler.test.ts
@@ -1195,12 +1195,13 @@ describe("sweepCronGoalRetention", () => {
     expect(logs.some((l) => l.message.includes("retention sweep deleted 1"))).toBe(true);
   });
 
-  it("preserves manual run_workflow goals of a scheduled template", () => {
+  it("sweeps manual run_workflow replays and pre-stamping legacy goals of a scheduled template (ratified 2026-07-10)", () => {
     const { deps } = makeDeps({ now: 10_000, cronGoalRetentionMs: 1_000 });
     seedWorkflow(deps, "wf-1");
     seedSchedule(deps, { workflowId: "wf-1" });
-    // Same template, same age — but created by a manual run_workflow call
-    // (created_by != 'scheduler'), so it is not operational cron exhaust.
+    // Any terminal goal of a SCHEDULED workflow past retention is exhaust,
+    // regardless of created_by: manual replays and rows predating
+    // origin-stamping (which the old created_by guard left immortal).
     seedGoal(deps, {
       id: "g-manual-run",
       status: "completed",
@@ -1216,8 +1217,8 @@ describe("sweepCronGoalRetention", () => {
       createdBy: "scheduler",
     });
     const r = sweepCronGoalRetention(deps);
-    expect(r.goalsDeleted).toBe(1);
-    expect(deps.goals.get("g-manual-run")).toBeDefined();
+    expect(r.goalsDeleted).toBe(2);
+    expect(deps.goals.get("g-manual-run")).toBeUndefined();
     expect(deps.goals.get("g-cron-run")).toBeUndefined();
   });
 

--- a/packages/plugins/brain-orchestrator/src/handlers/scheduler.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/scheduler.ts
@@ -590,18 +590,21 @@ export type RetentionSweepResult = {
 };
 
 /**
- * Delete terminal (completed/failed) goals instantiated BY THE SCHEDULER
- * whose completion is older than the retention window, along with their
- * tasks, attempts, and (when a traces store is provided) traces. There are
- * no FK cascades in the schema — children are removed explicitly, leaf-first.
+ * Delete terminal (completed/failed) goals of SCHEDULED workflows whose
+ * completion is older than the retention window, along with their tasks,
+ * attempts, and (when a traces store is provided) traces. There are no FK
+ * cascades in the schema — children are removed explicitly, leaf-first.
  *
- * Two independent guards keep non-cron work safe: the workflow must appear
- * in the schedules table, AND the goal must be stamped
- * `created_by = 'scheduler'` (set via instantiateWorkflow's
- * `origin: "schedule"`). A manual `run_workflow` of a scheduled template is
- * created_by "orchestrator" and is never touched. The per-workflow id lookup
- * runs against idx_goals_workflow, so the sweep is an indexed no-op when
- * nothing expired.
+ * Ratified policy (2026-07-10): any terminal goal of a workflow currently in
+ * the schedules table, older than the retention window, is operational
+ * exhaust — regardless of who instantiated it. That includes manual
+ * `run_workflow` replays of a scheduled template, and legacy rows from before
+ * `created_by` origin-stamping existed, which the previous
+ * `created_by = 'scheduler'` guard left immortal. The remaining guards:
+ * schedules-table membership, terminal status, and `type = 'project'` —
+ * one-off goals of non-scheduled workflows and evergreen concerns are never
+ * touched. The per-workflow id lookup runs against idx_goals_workflow, so the
+ * sweep is an indexed no-op when nothing expired.
  */
 export function sweepCronGoalRetention(
   deps: SchedulerDeps,
@@ -621,7 +624,6 @@ export function sweepCronGoalRetention(
     const goalIds = deps.goals.findTerminalIdsByWorkflowBefore(
       workflowId,
       cutoff,
-      "scheduler",
     );
     for (const goalId of goalIds) {
       // Collect task ids BEFORE deleting the tasks: traces may carry a

--- a/packages/plugins/brain-orchestrator/src/store/goals.test.ts
+++ b/packages/plugins/brain-orchestrator/src/store/goals.test.ts
@@ -299,9 +299,7 @@ describe("createGoalsStore.findTerminalIdsByWorkflowBefore", () => {
     store.create(
       baseGoal({ id: "other-wf", status: "completed", sourceWorkflowId: "wf-2", completedAt: 100, createdBy: "scheduler" }),
     );
-    const ids = store
-      .findTerminalIdsByWorkflowBefore("wf-1", 1_000, "scheduler")
-      .sort();
+    const ids = store.findTerminalIdsByWorkflowBefore("wf-1", 1_000).sort();
     expect(ids).toEqual(["old-done", "old-failed"]);
   });
 
@@ -316,37 +314,31 @@ describe("createGoalsStore.findTerminalIdsByWorkflowBefore", () => {
         createdBy: "scheduler",
       }),
     );
-    expect(
-      store.findTerminalIdsByWorkflowBefore("wf-1", 1_000, "scheduler"),
-    ).toEqual(["no-stamp"]);
-    expect(
-      store.findTerminalIdsByWorkflowBefore("wf-1", 50, "scheduler"),
-    ).toEqual([]);
+    expect(store.findTerminalIdsByWorkflowBefore("wf-1", 1_000)).toEqual([
+      "no-stamp",
+    ]);
+    expect(store.findTerminalIdsByWorkflowBefore("wf-1", 50)).toEqual([]);
   });
 
-  it("never returns cancelled or manually-created goals", () => {
+  it("never returns cancelled goals or goals with no workflow linkage", () => {
     const store = createGoalsStore({ db });
     store.create(
       baseGoal({ id: "cancelled", status: "cancelled", sourceWorkflowId: "wf-1", completedAt: 100, createdBy: "scheduler" }),
     );
     store.create(baseGoal({ id: "manual", status: "completed", completedAt: 100 }));
-    expect(
-      store.findTerminalIdsByWorkflowBefore("wf-1", 1_000, "scheduler"),
-    ).toEqual([]);
+    expect(store.findTerminalIdsByWorkflowBefore("wf-1", 1_000)).toEqual([]);
   });
 
-  it("excludes manual run_workflow goals of a scheduled template (created_by mismatch)", () => {
+  it("includes goals of the workflow regardless of created_by (ratified 2026-07-10: terminal runs of a scheduled workflow past retention are exhaust — manual replays and pre-stamping legacy rows included)", () => {
     const store = createGoalsStore({ db });
-    // Same workflow, same age — only the scheduler-created one is returned.
     store.create(
       baseGoal({ id: "cron-run", status: "completed", sourceWorkflowId: "wf-1", completedAt: 100, createdBy: "scheduler" }),
     );
     store.create(
       baseGoal({ id: "manual-run", status: "completed", sourceWorkflowId: "wf-1", completedAt: 100, createdBy: "orchestrator" }),
     );
-    expect(
-      store.findTerminalIdsByWorkflowBefore("wf-1", 1_000, "scheduler"),
-    ).toEqual(["cron-run"]);
+    const ids = store.findTerminalIdsByWorkflowBefore("wf-1", 1_000).sort();
+    expect(ids).toEqual(["cron-run", "manual-run"]);
   });
 });
 

--- a/packages/plugins/brain-orchestrator/src/store/goals.ts
+++ b/packages/plugins/brain-orchestrator/src/store/goals.ts
@@ -219,7 +219,6 @@ export type GoalsStore = {
   findTerminalIdsByWorkflowBefore(
     workflowId: string,
     completedBefore: number,
-    createdBy: string,
   ): string[];
   listChildren(parentGoalId: string): GoalRecord[];
   /** Count existing goals whose branch_name starts with the given prefix.
@@ -275,7 +274,7 @@ export function createGoalsStore(deps: {
     "SELECT * FROM goals WHERE source_workflow_id = ? AND status IN ('pending', 'running') AND type = 'project' ORDER BY created_at ASC",
   );
   const selectTerminalIdsByWorkflowBefore = db.prepare(
-    "SELECT id FROM goals WHERE source_workflow_id = ? AND status IN ('completed', 'failed') AND type = 'project' AND created_by = ? AND COALESCE(completed_at, updated_at) < ?",
+    "SELECT id FROM goals WHERE source_workflow_id = ? AND status IN ('completed', 'failed') AND type = 'project' AND COALESCE(completed_at, updated_at) < ?",
   );
   const selectChildren = db.prepare(
     "SELECT * FROM goals WHERE parent_goal_id = ? ORDER BY created_at ASC",
@@ -350,11 +349,9 @@ export function createGoalsStore(deps: {
   function findTerminalIdsByWorkflowBefore(
     workflowId: string,
     completedBefore: number,
-    createdBy: string,
   ): string[] {
     const rows = selectTerminalIdsByWorkflowBefore.all(
       workflowId,
-      createdBy,
       completedBefore,
     ) as Array<{ id: string }>;
     return rows.map((r) => r.id);

--- a/packages/services/dashboard/workflows/dashboard-intake.json
+++ b/packages/services/dashboard/workflows/dashboard-intake.json
@@ -1,7 +1,7 @@
 {
   "id": "dashboard-intake",
   "name": "Dashboard Intake",
-  "description": "Populate the dashboard SQLite DB from primary sources every day. Four independent collectors run in parallel: runtime transcripts (daa), wiki+tastes frontmatter (knowledge_taste_changes + distribution), runtime hook logs (application_rate + breakdowns), brain agent-activity (captured/applied/workflow → delivery feed). Parameterized by {{python_path}} so a fresh `digital-me install --runtime dashboard` lands the same workflow against any user's intake venv.",
+  "description": "Populate the dashboard SQLite DB from primary sources every minute (the companion schedule pins * * * * * for a near-real-time Feed; terminal runs are swept by the scheduler's retention window). Four independent collectors run in parallel: runtime transcripts (daa), wiki+tastes frontmatter (knowledge_taste_changes + distribution), runtime hook logs (application_rate + breakdowns), brain agent-activity (captured/applied/workflow → delivery feed). Parameterized by {{python_path}} so a fresh `digital-me install --runtime dashboard` lands the same workflow against any user's intake venv.",
   "version": 1,
   "display": {
     "mechanism_view": true


### PR DESCRIPTION
## What (two approved fixes from the 2026-07-10 post-update sweep)

### 1. Retention policy — drop the `created_by` guard
**Ratified policy:** any terminal goal of a workflow currently in the schedules table, older than the retention window, is operational exhaust — regardless of who instantiated it.

The sweep (`sweepCronGoalRetention`, 7d window / hourly) worked, but its `created_by='scheduler'` guard made the **18,472 dashboard-intake goals from before origin-stamping (2026-05-28→06-11) immortal**, and manual replays of scheduled workflows accumulated forever by the same mechanism. Remaining guards: schedules-table membership, terminal status, `type='project'` — one-off goals and evergreen concerns are never touched.

After deploy, the live hourly sweep drains the fossil layer on its own — no manual purge, and every OSS install with the same pre-stamping fossil self-heals.

### 2. Visual dimension self-heals (no more staleness rot)
`health-sweep/profiles/web.json` gains a `captureCmd` pointing at the new dependency-free headless driver ([agent-skills c827643](https://github.com/Amyssjj/agent-skills/commit/c827643)): system Chrome `--headless=new` over raw CDP, reusing the engine's existing `SNIPPET`/`assembleCapture`. Nightly fleet runs now refresh the capture instead of failing the 24h staleness gate. Verified: driver output is shape-identical to the agent-driven capture and gates **GREEN · SHIP** on `localhost:3458`, fused `run visual` works end-to-end unattended.

### Rider
`dashboard-intake.json` description said "every day" while its companion schedule pins `* * * * *` — prose now matches reality.

## Verification
- brain-orchestrator: 851/851 tests (retention tests updated to assert the ratified policy)
- workspace `pnpm run ci`: green
- `motus-sweep run visual --repo .`: capture→gate unattended, GREEN · SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)