### PR TITLE
fix(dream-cycle+digest): crosslink taste-domain crash + dual-store Codex readers

### DIFF
--- a/health-sweep/STATE-LOG.md
+++ b/health-sweep/STATE-LOG.md
@@ -555,3 +555,17 @@
 - **regression vs baseline:** 🟢 none
 - **critiques:** 🟢 cleared · **stories:** 🟢
 - **EXIT:** ✅ SHIP
+
+## 2026-07-12T16:06:51.804Z · ops · 0bfd619
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** — (no baseline)
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+
+## 2026-07-12T16:07:14.652Z · ops · 0bfd619
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** — (no baseline)
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP

--- a/health-sweep/overrides.json
+++ b/health-sweep/overrides.json
@@ -3,36 +3,48 @@
     "gate": "F1",
     "check": "path",
     "sel": "README.md:111",
-    "note": "packages/cli/dist/bin/digital-me.js is a build artifact — the sentence explicitly says 'Build the repo, then… the long way', so the claim is journey-correct at the stage it appears. Mechanical gate can't see the conditional (roadmap: ok:'conditional' state). 2026-07-02."
+    "note": "packages/cli/dist/bin/digital-me.js is a build artifact \u2014 the sentence explicitly says 'Build the repo, then\u2026 the long way', so the claim is journey-correct at the stage it appears. Mechanical gate can't see the conditional (roadmap: ok:'conditional' state). 2026-07-02."
   },
   {
     "gate": "G2",
     "check": "text-contrast",
     "sel": "h1",
-    "note": "gradient page background: effBg walk resolves transparent → reads [0,0,0]; RGB contrast math is UNMEASURABLE here, not failing (real render is dark-on-light, visibly AA+). Known adapter limitation (same class as motus-ai-web video hero). Revisit when the capture adapter samples pixels. 2026-07-03."
+    "note": "gradient page background: effBg walk resolves transparent \u2192 reads [0,0,0]; RGB contrast math is UNMEASURABLE here, not failing (real render is dark-on-light, visibly AA+). Known adapter limitation (same class as motus-ai-web video hero). Revisit when the capture adapter samples pixels. 2026-07-03."
   },
   {
     "gate": "G2",
     "check": "text-contrast",
     "sel": "nav button",
-    "note": "gradient page background: effBg walk resolves transparent → reads [0,0,0]; RGB contrast math is UNMEASURABLE here, not failing (real render is dark-on-light, visibly AA+). Known adapter limitation (same class as motus-ai-web video hero). Revisit when the capture adapter samples pixels. 2026-07-03."
+    "note": "gradient page background: effBg walk resolves transparent \u2192 reads [0,0,0]; RGB contrast math is UNMEASURABLE here, not failing (real render is dark-on-light, visibly AA+). Known adapter limitation (same class as motus-ai-web video hero). Revisit when the capture adapter samples pixels. 2026-07-03."
   },
   {
     "gate": "G2",
     "check": "text-contrast",
     "sel": "body",
-    "note": "gradient page background: effBg walk resolves transparent → reads [0,0,0]; RGB contrast math is UNMEASURABLE here, not failing (real render is dark-on-light, visibly AA+). Known adapter limitation (same class as motus-ai-web video hero). Revisit when the capture adapter samples pixels. 2026-07-03."
+    "note": "gradient page background: effBg walk resolves transparent \u2192 reads [0,0,0]; RGB contrast math is UNMEASURABLE here, not failing (real render is dark-on-light, visibly AA+). Known adapter limitation (same class as motus-ai-web video hero). Revisit when the capture adapter samples pixels. 2026-07-03."
   },
   {
     "gate": "R2",
     "check": "pin",
     "sel": "openclaw-brain-plugin-entry",
-    "note": "INTENTIONAL for now: installed file is the ratified 2026-07-01 hand-deployed esbuild bundle (M1 agent_end hotfix) — a built artifact will never sha-match the source template. Reconcile at the next `digital-me install --runtime openclaw` (which restores template provenance), then REMOVE this override so the pin guards again. 2026-07-03."
+    "note": "INTENTIONAL for now: installed file is the ratified 2026-07-01 hand-deployed esbuild bundle (M1 agent_end hotfix) \u2014 a built artifact will never sha-match the source template. Reconcile at the next `digital-me install --runtime openclaw` (which restores template provenance), then REMOVE this override so the pin guards again. 2026-07-03."
   },
   {
     "gate": "R2",
     "check": "pin",
     "sel": "openclaw-recall-plugin-entry",
-    "note": "INTENTIONAL for now: installed file is the ratified 2026-07-01 hand-deployed esbuild bundle (M1 agent_end hotfix) — a built artifact will never sha-match the source template. Reconcile at the next `digital-me install --runtime openclaw` (which restores template provenance), then REMOVE this override so the pin guards again. 2026-07-03."
+    "note": "INTENTIONAL for now: installed file is the ratified 2026-07-01 hand-deployed esbuild bundle (M1 agent_end hotfix) \u2014 a built artifact will never sha-match the source template. Reconcile at the next `digital-me install --runtime openclaw` (which restores template provenance), then REMOVE this override so the pin guards again. 2026-07-03."
+  },
+  {
+    "gate": "O1",
+    "check": "schedule-failed",
+    "sel": "708c9948-3461-4093-851a-c0148f1cab33",
+    "reason": "nightly-health-sweep last cron fire (2026-07-11 03:30) predates the capture fixes; fleet re-run green same day (11/11 SHIP) and a manual workflow re-run was dispatched 2026-07-12. RETIRE this override after the 2026-07-13 03:30 fire records completed."
+  },
+  {
+    "gate": "O2",
+    "check": "step-error",
+    "sel": "dream-cycle#crosslink",
+    "reason": "Known + fixed: generate_overviews taste-domain ENOENT (wiki/storytelling missing). Fix in digital-me PR #49; deploys on merge + main-checkout pull. The 07-12 log entry predates deploy. RETIRE once a post-merge nightly log shows crosslink clean."
   }
 ]

--- a/health-sweep/profiles/ops.json
+++ b/health-sweep/profiles/ops.json
@@ -1,0 +1,55 @@
+{
+  "_doc": "OPS profile for the GLOBAL motus-ops-sweep engine \u2014 gates the machine that runs the machines on THIS machine: the openclaw orchestrator's schedules, the dream-cycle's step log, and the transcript/artifact sources every digest and dashboard count depends on. Personal-machine ops config (paths are ~-absolute, like fleet.json); the engine is dimension-registered in motus-sweep/dimensions.json.",
+  "dimension": "ops",
+  "artifacts": "scoped",
+  "critiques": "none",
+  "brainDb": "~/.openclaw/data/brain.db",
+  "opsRules": {
+    "zombieStreak": 10
+  },
+  "stepLogs": [
+    {
+      "id": "dream-cycle",
+      "dir": "~/digital-me/dream_cycle/logs",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}\\.md$",
+      "_why": "The logs dir mixes families (lint-/consolidate-/drift- prefixed reports); only the main <date>.md is the step log."
+    }
+  ],
+  "sources": [
+    {
+      "id": "claude-code",
+      "path": "~/.claude/projects",
+      "cadenceHours": 24
+    },
+    {
+      "id": "openclaw-agents",
+      "path": "~/.openclaw/agents",
+      "cadenceHours": 24
+    },
+    {
+      "id": "digests",
+      "path": "~/digital-me/digests",
+      "cadenceHours": 24
+    },
+    {
+      "id": "dream-cycle-logs",
+      "path": "~/digital-me/dream_cycle/logs",
+      "cadenceHours": 24
+    },
+    {
+      "id": "codex-local",
+      "path": "~/.codex/sessions",
+      "cadenceHours": 24,
+      "required": false,
+      "_why": "Codex moved to ChatGPT-app cloud threads 2026-07-04 \u2014 no local artifacts. Advisory keeps the gap visible until the local surface returns or a cloud poller lands (wiki: codex/codex-session-store-migration-breaks-jsonl-readers)."
+    },
+    {
+      "id": "hermes",
+      "path": "~/.hermes/sessions",
+      "cadenceHours": 168,
+      "required": false,
+      "_why": "Hermes is used sporadically; weekly cadence, advisory-only."
+    }
+  ],
+  "captureCmd": "node \"$HOME/.agents/skills/motus-ops-sweep/engine/lib/capture-ops.mjs\" --repo . --profile health-sweep/profiles/ops.json --out health-sweep/capture-ops.json"
+}

--- a/packages/services/digest/src/digest/daily_digest.py
+++ b/packages/services/digest/src/digest/daily_digest.py
@@ -669,19 +669,103 @@ def _decode_claude_project_name(encoded: str) -> str:
     return name
 
 
-def _codex_raw_prompts(start_ms: int, end_ms: int, root: Path) -> list[str]:
-    """Flat list of first-user-prompts across all Codex sessions in window."""
-    if not root.exists():
+def _codex_state_db(sessions_root: Path) -> Optional[Path]:
+    """Current codex state DB (threads table), next to the sessions/ dir.
+
+    Codex names it state_<N>.sqlite and bumps N across schema generations —
+    take the highest N present.
+    """
+    dbs = sorted(sessions_root.parent.glob("state_*.sqlite"))
+    return dbs[-1] if dbs else None
+
+
+def _codex_sqlite_prompts(
+    start_ms: int, end_ms: int, sessions_root: Path, skip_rollout_paths: set[str],
+) -> list[str]:
+    """First-user-messages from codex's threads table, for sessions in window.
+
+    Newer codex builds record threads in ~/.codex/state_*.sqlite and may not
+    write rollout JSONLs at all, so reading only ~/.codex/sessions silently
+    reports "no activity" (the 2026-07 codex gap: rollouts stopped 07-04).
+    Threads whose rollout file was already counted by the JSONL walk are
+    skipped via skip_rollout_paths.
+    """
+    db = _codex_state_db(sessions_root)
+    if db is None:
         return []
-    prompts: list[str] = []
-    for jsonl in root.rglob("*.jsonl"):
+    try:
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        rows = con.execute(
+            "SELECT COALESCE(rollout_path,''), COALESCE(first_user_message,''),"
+            "       COALESCE(title,'')"
+            "  FROM threads"
+            " WHERE COALESCE(updated_at, created_at) * 1000 >= ?"
+            "   AND COALESCE(updated_at, created_at) * 1000 < ?",
+            (start_ms, end_ms),
+        ).fetchall()
+        con.close()
+    except (sqlite3.Error, OSError):
+        return []
+    return [
+        first_msg or title
+        for rollout_path, first_msg, title in rows
+        if rollout_path not in skip_rollout_paths and (first_msg or title)
+    ]
+
+
+def _codex_last_seen_iso(sessions_root: Path) -> Optional[str]:
+    """Date (PT) of the most recent locally-recorded Codex session, if any.
+
+    Rendered when the window itself is empty so the digest says "last local
+    session was <date>" instead of a bare "no activity" — an empty window can
+    mean the user moved to a surface that leaves no local record (Codex in
+    the ChatGPT desktop app runs threads cloud-side).
+    """
+    last_ms = 0
+    if sessions_root.exists():
+        for jsonl in sessions_root.rglob("*.jsonl"):
+            try:
+                last_ms = max(last_ms, int(jsonl.stat().st_mtime * 1000))
+            except OSError:
+                continue
+    db = _codex_state_db(sessions_root)
+    if db is not None:
         try:
-            mtime_ms = int(jsonl.stat().st_mtime * 1000)
-        except OSError:
-            continue
-        if not (start_ms <= mtime_ms < end_ms):
-            continue
-        prompt = _extract_first_user_prompt(jsonl)
+            con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+            row = con.execute(
+                "SELECT MAX(COALESCE(updated_at, created_at)) FROM threads"
+            ).fetchone()
+            con.close()
+            if row and row[0]:
+                last_ms = max(last_ms, int(row[0]) * 1000)
+        except (sqlite3.Error, OSError):
+            pass
+    if not last_ms:
+        return None
+    return datetime.datetime.fromtimestamp(last_ms / 1000, TZ).date().isoformat()
+
+
+def _codex_raw_prompts(start_ms: int, end_ms: int, root: Path) -> list[str]:
+    """Flat list of first-user-prompts across all Codex sessions in window.
+
+    Union of both local stores: legacy rollout JSONLs under sessions/ and
+    the threads table in state_*.sqlite (see _codex_sqlite_prompts).
+    """
+    raw: list[str] = []
+    seen_rollouts: set[str] = set()
+    if root.exists():
+        for jsonl in root.rglob("*.jsonl"):
+            try:
+                mtime_ms = int(jsonl.stat().st_mtime * 1000)
+            except OSError:
+                continue
+            if not (start_ms <= mtime_ms < end_ms):
+                continue
+            seen_rollouts.add(str(jsonl))
+            raw.append(_extract_first_user_prompt(jsonl))
+    raw.extend(_codex_sqlite_prompts(start_ms, end_ms, root, seen_rollouts))
+    prompts: list[str] = []
+    for prompt in raw:
         topic = _topic_from_prompt(prompt)
         prompts.append(topic if _DETERMINISTIC_TOPIC.match(topic or "") else prompt)
     return prompts
@@ -1004,7 +1088,23 @@ def render_full(date_str: str) -> tuple[str, dict]:
         _render_agent(f"OpenClaw - {agent_name}", topics)
 
     _render_agent("Hermes Agent", hermes_topics)
-    _render_agent("Codex CLI", codex_topics)
+    codex_last_seen: Optional[str] = None
+    if codex_topics:
+        _render_agent("Codex CLI", codex_topics)
+    else:
+        # Silence is signal: distinguish "no local record in window" from a
+        # bare "no activity". Codex sessions run through the ChatGPT desktop
+        # app live cloud-side and never touch ~/.codex/sessions or the state
+        # DB, so an empty window may just mean the surface moved.
+        codex_last_seen = _codex_last_seen_iso(Path(sources["codex-jsonl"]["path"]))
+        if codex_last_seen:
+            lines.append(
+                f"- **Codex CLI:** _no locally-recorded sessions in window "
+                f"(last local session {codex_last_seen}; Codex app/cloud "
+                f"sessions leave no local record)_"
+            )
+        else:
+            _render_agent("Codex CLI", codex_topics)
 
     full_md = "\n".join(lines)
 
@@ -1023,6 +1123,7 @@ def render_full(date_str: str) -> tuple[str, dict]:
         "skill_files": skill_files,
         "cc_topics": cc_topics,
         "codex_topics": codex_topics,
+        "codex_last_seen": codex_last_seen,
         "hermes_topics": hermes_topics,
         "openclaw_topics": openclaw_topics,
         "coo_goals": coo_goals,
@@ -1111,7 +1212,13 @@ def render_components(s: dict) -> dict:
     if not s["openclaw_topics"]:
         agent_blocks.append("**OpenClaw agents** — _no activity_")
     agent_blocks.append(_agent_block("Hermes Agent", s.get("hermes_topics", [])))
-    agent_blocks.append(_agent_block("Codex CLI", s["codex_topics"]))
+    if not s["codex_topics"] and s.get("codex_last_seen"):
+        agent_blocks.append(
+            f"**Codex CLI** — _no locally-recorded sessions "
+            f"(last local session {s['codex_last_seen']})_"
+        )
+    else:
+        agent_blocks.append(_agent_block("Codex CLI", s["codex_topics"]))
 
     # Each agent block as its own text block so the divider visual stays tight
     for block in agent_blocks:
@@ -1662,6 +1769,10 @@ def write_raw_staging(path: Path, target_iso: str, dream_cycle_iso: str) -> None
         "wiki_entries": wiki_entries,
         "taste_entries": taste_entries,
         "agent_raw_prompts": agent_raw_prompts,
+        "codex_last_seen": (
+            None if codex_raw
+            else _codex_last_seen_iso(Path(sources["codex-jsonl"]["path"]))
+        ),
         "presentation": None,
         "markdown": None,
     }

--- a/packages/services/digest/tests/test_codex_sources.py
+++ b/packages/services/digest/tests/test_codex_sources.py
@@ -1,0 +1,92 @@
+"""Tests for the dual-store Codex session readers.
+
+Regression (2026-07 codex gap): newer codex builds record threads in
+~/.codex/state_*.sqlite and stopped writing rollout JSONLs under
+~/.codex/sessions on 2026-07-04, so the digest — which walked only the
+JSONL tree — reported "Codex CLI: no activity" while codex was in daily
+use. _codex_raw_prompts now unions both stores, and an empty window is
+rendered with the last locally-recorded session date instead of a bare
+"no activity" (silence is signal).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from digest.daily_digest import (
+    _codex_last_seen_iso,
+    _codex_raw_prompts,
+    _codex_sqlite_prompts,
+)
+
+WINDOW_START = 1_783_000_000_000  # arbitrary epoch-ms window
+WINDOW_END = WINDOW_START + 86_400_000
+
+
+def _make_state_db(codex_home: Path, rows: list[tuple]) -> Path:
+    db = codex_home / "state_5.sqlite"
+    con = sqlite3.connect(db)
+    con.execute(
+        "CREATE TABLE threads ("
+        " id TEXT PRIMARY KEY, rollout_path TEXT, created_at INTEGER,"
+        " updated_at INTEGER, first_user_message TEXT, title TEXT)"
+    )
+    con.executemany("INSERT INTO threads VALUES (?,?,?,?,?,?)", rows)
+    con.commit()
+    con.close()
+    return db
+
+
+def test_sqlite_threads_counted_without_rollout_files(tmp_path):
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    in_window_s = (WINDOW_START + 3_600_000) // 1000
+    _make_state_db(tmp_path, [
+        ("t1", "/nonexistent/rollout-a.jsonl", in_window_s, in_window_s,
+         "fix the video pipeline", "Fix video pipeline"),
+        ("t2", "/nonexistent/rollout-b.jsonl", 1, 1,  # far out of window
+         "old thread", "Old"),
+    ])
+
+    prompts = _codex_raw_prompts(WINDOW_START, WINDOW_END, sessions)
+    assert prompts == ["fix the video pipeline"]
+
+
+def test_rollout_already_counted_is_not_double_counted(tmp_path):
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    rollout = sessions / "rollout-c.jsonl"
+    rollout.write_text("")  # empty file: JSONL walk yields one (empty) prompt
+    mtime_s = (WINDOW_START + 1000) / 1000
+    import os
+    os.utime(rollout, (mtime_s, mtime_s))
+
+    _make_state_db(tmp_path, [
+        ("t3", str(rollout), int(mtime_s), int(mtime_s),
+         "duplicate thread", "Dup"),
+    ])
+
+    sqlite_only = _codex_sqlite_prompts(
+        WINDOW_START, WINDOW_END, sessions, {str(rollout)}
+    )
+    assert sqlite_only == []
+    # The union path counts the session exactly once (via the JSONL walk).
+    assert len(_codex_raw_prompts(WINDOW_START, WINDOW_END, sessions)) == 1
+
+
+def test_last_seen_uses_max_across_stores(tmp_path):
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    newer_s = int(time.time()) - 3600
+    _make_state_db(tmp_path, [
+        ("t4", "/nonexistent/rollout-d.jsonl", newer_s, newer_s, "hi", "Hi"),
+    ])
+    assert _codex_last_seen_iso(sessions) is not None
+
+
+def test_missing_stores_degrade_to_empty(tmp_path):
+    sessions = tmp_path / "sessions"  # never created, no state db
+    assert _codex_raw_prompts(WINDOW_START, WINDOW_END, sessions) == []
+    assert _codex_last_seen_iso(sessions) is None

--- a/packages/services/dream-cycle/src/dream_cycle/crosslink.py
+++ b/packages/services/dream-cycle/src/dream_cycle/crosslink.py
@@ -130,9 +130,19 @@ def generate_graph(entries: list[dict]) -> str:
 
 
 def generate_overviews(config: Config, entries: list[dict]) -> int:
-    """Generate _OVERVIEW.md for each domain directory."""
+    """Generate _OVERVIEW.md for each wiki domain directory.
+
+    Wiki-only surface: the tastes tree stays flat (leaves + status flips,
+    no machine files), and a taste-only domain (e.g. tastes/storytelling/)
+    has no wiki/<domain>/ directory — writing there raised ENOENT and
+    killed the whole crosslink step from 2026-07-09 on. Splitting on the
+    `_tree` tag also keeps taste leaves out of wiki overviews, where their
+    `path.name` relative links would dangle.
+    """
     by_domain = defaultdict(list)
     for e in entries:
+        if e.get('_tree') != 'wiki':
+            continue
         by_domain[e['_domain']].append(e)
 
     count = 0
@@ -141,6 +151,8 @@ def generate_overviews(config: Config, entries: list[dict]) -> int:
             continue
 
         domain_dir = config.wiki_dir / domain
+        if not domain_dir.is_dir():
+            continue
         overview_path = domain_dir / "_OVERVIEW.md"
 
         lines = [

--- a/packages/services/dream-cycle/tests/test_crosslink_overviews.py
+++ b/packages/services/dream-cycle/tests/test_crosslink_overviews.py
@@ -1,0 +1,92 @@
+"""Tests for generate_overviews' wiki-only scope.
+
+Regression: collect_entries indexes BOTH trees (wiki/ and tastes/), but
+generate_overviews wrote every domain's _OVERVIEW.md under wiki/<domain>/.
+A taste-only domain (tastes/storytelling/ with no wiki/storytelling/ dir)
+made the write raise ENOENT, which killed the whole crosslink step —
+observed nightly from 2026-07-09 through 2026-07-11.
+
+After the fix, overviews are a wiki-only surface: tastes-tree entries are
+excluded (the tastes tree stays flat — leaves + status flips only), and a
+wiki domain whose directory is missing is skipped instead of crashing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from dream_cycle.crosslink import generate_overviews
+
+
+def _entry(path: Path, domain: str, tree: str, title: str) -> dict:
+    return {
+        "title": title,
+        "_path": path,
+        "_rel_path": Path(domain) / path.name,
+        "_domain": domain,
+        "_tree": tree,
+        "_body": "Body sentence.",
+    }
+
+
+def test_taste_only_domain_does_not_crash_or_write(tmp_path):
+    wiki = tmp_path / "wiki"
+    (wiki / "infra").mkdir(parents=True)
+    tastes = tmp_path / "tastes"
+    (tastes / "storytelling").mkdir(parents=True)
+
+    wiki_md = wiki / "infra" / "a.md"
+    wiki_md.write_text("body")
+    taste_md = tastes / "storytelling" / "b.md"
+    taste_md.write_text("body")
+
+    config = SimpleNamespace(wiki_dir=wiki, wiki_root=tmp_path)
+    entries = [
+        _entry(wiki_md, "infra", "wiki", "Wiki entry"),
+        _entry(taste_md, "storytelling", "tastes", "Taste leaf"),
+    ]
+
+    count = generate_overviews(config, entries)
+
+    assert count == 1
+    assert (wiki / "infra" / "_OVERVIEW.md").exists()
+    # The tastes tree stays flat: no machine files, and no phantom wiki dir.
+    assert not (tastes / "storytelling" / "_OVERVIEW.md").exists()
+    assert not (wiki / "storytelling").exists()
+
+
+def test_missing_wiki_domain_dir_is_skipped(tmp_path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    ghost_md = wiki / "ghost" / "a.md"  # dir intentionally not created
+
+    config = SimpleNamespace(wiki_dir=wiki, wiki_root=tmp_path)
+    entries = [_entry(ghost_md, "ghost", "wiki", "Ghost entry")]
+
+    assert generate_overviews(config, entries) == 0
+
+
+def test_taste_leaves_do_not_pollute_shared_domain_overview(tmp_path):
+    """A domain present in BOTH trees lists only its wiki entries —
+    taste leaves' path.name relative links would dangle from wiki/<domain>/."""
+    wiki = tmp_path / "wiki"
+    (wiki / "design").mkdir(parents=True)
+    tastes = tmp_path / "tastes"
+    (tastes / "design").mkdir(parents=True)
+
+    wiki_md = wiki / "design" / "tokens.md"
+    wiki_md.write_text("body")
+    taste_md = tastes / "design" / "leaf.md"
+    taste_md.write_text("body")
+
+    config = SimpleNamespace(wiki_dir=wiki, wiki_root=tmp_path)
+    entries = [
+        _entry(wiki_md, "design", "wiki", "Tokens"),
+        _entry(taste_md, "design", "tastes", "Leaf"),
+    ]
+
+    generate_overviews(config, entries)
+    overview = (wiki / "design" / "_OVERVIEW.md").read_text()
+    assert "tokens.md" in overview
+    assert "leaf.md" not in overview


### PR DESCRIPTION
## What broke (surfaced by the 2026-07-10 daily digest)

**1. Nightly crosslink crashed every night since 07-09.** `generate_overviews` wrote every domain's `_OVERVIEW.md` under `wiki/<domain>/`, but `collect_entries` indexes the tastes tree too. `tastes/storytelling/` has no `wiki/storytelling/` dir → `ENOENT` → the whole crosslink step died (`## crosslink — error` in the dream-cycle logs, 07-09 → 07-11).

**2. "Codex CLI: no activity" was a source-migration lie.** Codex stopped writing rollout JSONLs to `~/.codex/sessions` on 07-04 — newer builds record threads in `~/.codex/state_*.sqlite`, and threads run through the ChatGPT desktop app live cloud-side with no local artifacts at all. The digest read only the JSONL tree, so daily Codex use rendered as *no activity*.

## The fix

- **crosslink**: overviews are a wiki-only surface — split on the entry `_tree` tag (tastes tree stays flat: leaves + status flips only), skip wiki domains whose dir is missing, and stop leaking taste `path.name` links into shared-domain overviews where they'd dangle.
- **digest**: `_codex_raw_prompts` unions the rollout JSONLs with the state DB `threads` table (deduped by `rollout_path`); when the window is still empty, the digest renders `no locally-recorded sessions in window (last local session <date>; Codex app/cloud sessions leave no local record)` instead of a bare `_no activity_` — the reader can now distinguish "idle" from "the source moved".

## Verification

- 202 tests green (154 dream-cycle · 48 digest), including new regression suites `test_crosslink_overviews.py` and `test_codex_sources.py`.
- `run_crosslink()` against the live wiki: 987 entries, 76 related-updates, 85 overviews, **0 errors**.
- `daily_digest --date 2026-07-10 --dry-run` renders the honest Codex line and the (truthful) 0-taste count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)