### PR TITLE
feat(dream-cycle): tree-consistent domain overviews (tastes tree included)

### DIFF
--- a/packages/services/dream-cycle/src/dream_cycle/crosslink.py
+++ b/packages/services/dream-cycle/src/dream_cycle/crosslink.py
@@ -130,29 +130,35 @@ def generate_graph(entries: list[dict]) -> str:
 
 
 def generate_overviews(config: Config, entries: list[dict]) -> int:
-    """Generate _OVERVIEW.md for each wiki domain directory.
+    """Generate _OVERVIEW.md for each domain directory, in BOTH trees.
 
-    Wiki-only surface: the tastes tree stays flat (leaves + status flips,
-    no machine files), and a taste-only domain (e.g. tastes/storytelling/)
-    has no wiki/<domain>/ directory — writing there raised ENOENT and
-    killed the whole crosslink step from 2026-07-09 on. Splitting on the
-    `_tree` tag also keeps taste leaves out of wiki overviews, where their
-    `path.name` relative links would dangle.
+    Tree-consistent (ratified 2026-07-12): wiki/<domain>/ and
+    tastes/<domain>/ each get an overview built from their OWN entries —
+    grouping by tree keeps every `path.name` relative link within its
+    directory, so shared-name domains (wiki/design vs tastes/design) never
+    dangle. `_`-prefixed files are invisible to every consumer (dream-cycle
+    collect/compile, dashboard intake scan_knowledge_trees, the openclaw
+    recall indexer, the digest taste counter), so a machine overview in the
+    tastes tree does not pollute the leaf stream: the flat-tree model
+    constrains leaf LIFECYCLE (publish-immediately, status-flip promotion,
+    no staging dirs), not generated nav files. Domains whose directory is
+    missing are skipped — writing wiki/storytelling/_OVERVIEW.md for a
+    taste-only domain was the ENOENT that killed crosslink 2026-07-09..11.
     """
-    by_domain = defaultdict(list)
+    tastes_dir = config.wiki_dir.parent / "tastes"
+    by_dir = defaultdict(list)
     for e in entries:
-        if e.get('_tree') != 'wiki':
-            continue
-        by_domain[e['_domain']].append(e)
-
-    count = 0
-    for domain, domain_entries in by_domain.items():
+        domain = e['_domain']
         if domain == "root":
             continue
+        base = tastes_dir if e.get('_tree') == 'tastes' else config.wiki_dir
+        by_dir[base / domain].append(e)
 
-        domain_dir = config.wiki_dir / domain
+    count = 0
+    for domain_dir, domain_entries in by_dir.items():
         if not domain_dir.is_dir():
             continue
+        domain = domain_dir.name
         overview_path = domain_dir / "_OVERVIEW.md"
 
         lines = [

--- a/packages/services/dream-cycle/tests/test_crosslink_overviews.py
+++ b/packages/services/dream-cycle/tests/test_crosslink_overviews.py
@@ -1,14 +1,20 @@
-"""Tests for generate_overviews' wiki-only scope.
+"""Tests for generate_overviews' tree-consistent scope.
 
-Regression: collect_entries indexes BOTH trees (wiki/ and tastes/), but
-generate_overviews wrote every domain's _OVERVIEW.md under wiki/<domain>/.
-A taste-only domain (tastes/storytelling/ with no wiki/storytelling/ dir)
-made the write raise ENOENT, which killed the whole crosslink step —
-observed nightly from 2026-07-09 through 2026-07-11.
+History: collect_entries indexes BOTH trees (wiki/ and tastes/), but
+generate_overviews originally wrote every domain's _OVERVIEW.md under
+wiki/<domain>/ — a taste-only domain (tastes/storytelling/ with no
+wiki/storytelling/ dir) made the write raise ENOENT, killing the whole
+crosslink step nightly 2026-07-09..11. The first fix scoped overviews to
+the wiki; on 2026-07-12 the owner ratified tree-CONSISTENT overviews
+instead: each tree's domain dir gets an overview built from its OWN
+entries.
 
-After the fix, overviews are a wiki-only surface: tastes-tree entries are
-excluded (the tastes tree stays flat — leaves + status flips only), and a
-wiki domain whose directory is missing is skipped instead of crashing.
+Invariants:
+- overviews land in the entry's own tree (wiki/<d>/ and tastes/<d>/);
+- links never cross trees (path.name links stay within their directory);
+- a domain directory that doesn't exist is skipped, never created;
+- `_`-prefixed files are invisible to all consumers, so tastes overviews
+  don't pollute the leaf stream (lifecycle stays flat + status-flip).
 """
 
 from __future__ import annotations
@@ -30,7 +36,11 @@ def _entry(path: Path, domain: str, tree: str, title: str) -> dict:
     }
 
 
-def test_taste_only_domain_does_not_crash_or_write(tmp_path):
+def _config(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(wiki_dir=tmp_path / "wiki", wiki_root=tmp_path)
+
+
+def test_overviews_written_in_both_trees(tmp_path):
     wiki = tmp_path / "wiki"
     (wiki / "infra").mkdir(parents=True)
     tastes = tmp_path / "tastes"
@@ -41,35 +51,41 @@ def test_taste_only_domain_does_not_crash_or_write(tmp_path):
     taste_md = tastes / "storytelling" / "b.md"
     taste_md.write_text("body")
 
-    config = SimpleNamespace(wiki_dir=wiki, wiki_root=tmp_path)
     entries = [
         _entry(wiki_md, "infra", "wiki", "Wiki entry"),
         _entry(taste_md, "storytelling", "tastes", "Taste leaf"),
     ]
 
-    count = generate_overviews(config, entries)
+    count = generate_overviews(_config(tmp_path), entries)
 
-    assert count == 1
+    assert count == 2
     assert (wiki / "infra" / "_OVERVIEW.md").exists()
-    # The tastes tree stays flat: no machine files, and no phantom wiki dir.
-    assert not (tastes / "storytelling" / "_OVERVIEW.md").exists()
+    assert (tastes / "storytelling" / "_OVERVIEW.md").exists()
+    # No phantom cross-tree dir gets created.
     assert not (wiki / "storytelling").exists()
+    taste_overview = (tastes / "storytelling" / "_OVERVIEW.md").read_text()
+    assert "Taste leaf" in taste_overview and "b.md" in taste_overview
 
 
-def test_missing_wiki_domain_dir_is_skipped(tmp_path):
+def test_missing_domain_dir_is_skipped_in_either_tree(tmp_path):
     wiki = tmp_path / "wiki"
     wiki.mkdir()
-    ghost_md = wiki / "ghost" / "a.md"  # dir intentionally not created
+    ghost_wiki = wiki / "ghost" / "a.md"          # dir intentionally missing
+    ghost_taste = tmp_path / "tastes" / "gone" / "b.md"  # dir intentionally missing
 
-    config = SimpleNamespace(wiki_dir=wiki, wiki_root=tmp_path)
-    entries = [_entry(ghost_md, "ghost", "wiki", "Ghost entry")]
+    entries = [
+        _entry(ghost_wiki, "ghost", "wiki", "Ghost entry"),
+        _entry(ghost_taste, "gone", "tastes", "Gone leaf"),
+    ]
 
-    assert generate_overviews(config, entries) == 0
+    assert generate_overviews(_config(tmp_path), entries) == 0
+    assert not (wiki / "ghost").exists()
+    assert not (tmp_path / "tastes" / "gone").exists()
 
 
-def test_taste_leaves_do_not_pollute_shared_domain_overview(tmp_path):
-    """A domain present in BOTH trees lists only its wiki entries —
-    taste leaves' path.name relative links would dangle from wiki/<domain>/."""
+def test_shared_domain_overviews_do_not_cross_trees(tmp_path):
+    """wiki/design and tastes/design each list only their own entries —
+    a cross-tree path.name link would dangle from the other directory."""
     wiki = tmp_path / "wiki"
     (wiki / "design").mkdir(parents=True)
     tastes = tmp_path / "tastes"
@@ -80,13 +96,13 @@ def test_taste_leaves_do_not_pollute_shared_domain_overview(tmp_path):
     taste_md = tastes / "design" / "leaf.md"
     taste_md.write_text("body")
 
-    config = SimpleNamespace(wiki_dir=wiki, wiki_root=tmp_path)
     entries = [
         _entry(wiki_md, "design", "wiki", "Tokens"),
         _entry(taste_md, "design", "tastes", "Leaf"),
     ]
 
-    generate_overviews(config, entries)
-    overview = (wiki / "design" / "_OVERVIEW.md").read_text()
-    assert "tokens.md" in overview
-    assert "leaf.md" not in overview
+    assert generate_overviews(_config(tmp_path), entries) == 2
+    wiki_overview = (wiki / "design" / "_OVERVIEW.md").read_text()
+    taste_overview = (tastes / "design" / "_OVERVIEW.md").read_text()
+    assert "tokens.md" in wiki_overview and "leaf.md" not in wiki_overview
+    assert "leaf.md" in taste_overview and "tokens.md" not in taste_overview


### PR DESCRIPTION
Follow-up to #49, per owner's call: make `_OVERVIEW.md` generation consistent across both trees instead of wiki-only.

- `wiki/<domain>/` and `tastes/<domain>/` each get an overview built from their **own** entries — grouping by tree means `path.name` relative links never dangle across trees (wiki/design vs tastes/design).
- Missing domain dirs are skipped, never created — the taste-only-domain ENOENT class (storytelling, 07-09..11) stays dead.
- Safe under the flat-tree taste ratification: every consumer skips `_`-prefixed files (dream-cycle collect/compile, dashboard intake `scan_knowledge_trees`, the openclaw recall indexer, the digest taste counter), so overviews are invisible to the leaf stream; the ratification constrains leaf *lifecycle*, not generated nav files.

Verified: 154 dream-cycle tests green (regression suite updated to the new contract); live `run_crosslink()` on the real corpus: 993 entries → 89 overviews (85 wiki + `tastes/{design,infra,knowledge,storytelling}`), 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)