### PR TITLE
fix(brain-mcp-proxy): oversize-result guard — tasks format:json no longer kills MCP clients

### DIFF
--- a/packages/plugins/brain-orchestrator/src/plugin/router.test.ts
+++ b/packages/plugins/brain-orchestrator/src/plugin/router.test.ts
@@ -707,6 +707,108 @@ describe("dispatchAction(board)", () => {
     const r = await dispatchAction(deps, "board", { format: "json" });
     expect((r.json as { goals: unknown[] }).goals).toHaveLength(1);
   });
+
+  it("windows failed goals by updatedAt like other terminal statuses", async () => {
+    const deps = makeDeps();
+    deps.goals.create({
+      id: "f-old",
+      name: "Fold",
+      description: "",
+      status: "failed",
+      type: "project",
+      taskIds: [],
+      createdAt: 0,
+      updatedAt: 5000,
+      createdBy: "t",
+    });
+    deps.goals.create({
+      id: "f-new",
+      name: "Fnew",
+      description: "",
+      status: "failed",
+      type: "project",
+      taskIds: [],
+      createdAt: 0,
+      updatedAt: 20_000,
+      createdBy: "t",
+    });
+    const r = await dispatchAction(deps, "board", {
+      format: "json",
+      since: 9999,
+    });
+    const goals = (r.json as { goals: Array<{ id: string }> }).goals;
+    expect(goals.map((g) => g.id)).toEqual(["f-new"]);
+  });
+
+  it("caps the payload to the most recently updated `limit` goals", async () => {
+    const deps = makeDeps();
+    for (let i = 1; i <= 4; i++) {
+      deps.goals.create({
+        id: `g-${i}`,
+        name: `G${i}`,
+        description: "",
+        status: "running",
+        type: "project",
+        taskIds: [],
+        createdAt: 0,
+        updatedAt: i * 1000,
+        createdBy: "t",
+      });
+    }
+    const r = await dispatchAction(deps, "board", {
+      format: "json",
+      since: 0,
+      limit: 2,
+    });
+    const goals = (r.json as { goals: Array<{ id: string }> }).goals;
+    expect(goals.map((g) => g.id)).toEqual(["g-4", "g-3"]);
+  });
+
+  it("ignores non-positive or non-integer limit values", async () => {
+    const deps = makeDeps();
+    for (let i = 1; i <= 3; i++) {
+      deps.goals.create({
+        id: `g-${i}`,
+        name: `G${i}`,
+        description: "",
+        status: "running",
+        type: "project",
+        taskIds: [],
+        createdAt: 0,
+        updatedAt: i * 1000,
+        createdBy: "t",
+      });
+    }
+    for (const limit of [0, -1, 1.5, "2" as unknown as number]) {
+      const r = await dispatchAction(deps, "board", {
+        format: "json",
+        since: 0,
+        limit,
+      });
+      expect((r.json as { goals: unknown[] }).goals).toHaveLength(3);
+    }
+  });
+
+  it("leaves the payload untouched when limit exceeds the goal count", async () => {
+    const deps = makeDeps();
+    deps.goals.create({
+      id: "g",
+      name: "G",
+      description: "",
+      status: "running",
+      type: "project",
+      taskIds: [],
+      createdAt: 0,
+      updatedAt: 0,
+      createdBy: "t",
+    });
+    const r = await dispatchAction(deps, "board", {
+      format: "json",
+      since: 0,
+      limit: 10,
+    });
+    expect((r.json as { goals: unknown[] }).goals).toHaveLength(1);
+  });
 });
 
 describe("dispatchAction(status)", () => {

--- a/packages/plugins/brain-orchestrator/src/plugin/router.ts
+++ b/packages/plugins/brain-orchestrator/src/plugin/router.ts
@@ -323,10 +323,25 @@ function handleBoardJson(
     if (g.status === "completed") {
       return (g.completedAt ?? g.updatedAt) >= sinceMs;
     }
-    if (g.status === "cancelled") return g.updatedAt >= sinceMs;
+    // failed and cancelled are terminal too — without the window, every
+    // failed goal ever accumulates into the payload forever (1k+ goals in
+    // the 2026-07 oversize incident that crashed MCP clients).
+    if (g.status === "cancelled" || g.status === "failed") {
+      return g.updatedAt >= sinceMs;
+    }
     return true;
   });
-  const payload = filtered.map((g) => ({
+  // Optional bound for MCP-agent callers: most recently updated N goals.
+  // The dashboard omits it and keeps the full window.
+  const limit =
+    typeof params.limit === "number" && Number.isInteger(params.limit) && params.limit > 0
+      ? params.limit
+      : undefined;
+  const bounded =
+    limit !== undefined && filtered.length > limit
+      ? [...filtered].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, limit)
+      : filtered;
+  const payload = bounded.map((g) => ({
     ...g,
     tasks: deps.tasks.listForGoal(g.id),
   }));

--- a/packages/services/dashboard/src/server/brain-client.mc.ts
+++ b/packages/services/dashboard/src/server/brain-client.mc.ts
@@ -10,6 +10,7 @@
 import { createRequire } from "node:module";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { MAX_RESULT_BYTES_ENV } from "@digital-me/brain-mcp-proxy";
 
 // ── In-process TTL Cache ──────��───────────────────────────────────
 
@@ -77,7 +78,14 @@ async function getClient(): Promise<Client> {
     const transport = new StdioClientTransport({
       command: nodeBin,
       args: [proxyPath],
-      env: { ...process.env } as Record<string, string>,
+      // Disable the proxy's oversize-result guard for this spawn: the
+      // dashboard is the one consumer that legitimately reads the full
+      // board JSON (tens of MB — Kanban stats, workflow run counts), and
+      // the SDK client handles it fine. Agent-facing spawns keep the cap.
+      env: {
+        ...process.env,
+        [MAX_RESULT_BYTES_ENV]: "0",
+      } as Record<string, string>,
     });
 
     const c = new Client(

--- a/packages/transport/brain-mcp-proxy/src/handler.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/handler.test.ts
@@ -3,8 +3,11 @@ import {
   attributionLabel,
   buildToolArgs,
   createCallToolHandler,
+  DEFAULT_MAX_RESULT_BYTES,
   extractHitCount,
   inlineTopHitBody,
+  resolveMaxResultBytes,
+  resultContentBytes,
   type ToolCallTrace,
   type WikiBodyInliner,
 } from "./handler.js";
@@ -693,5 +696,191 @@ describe("createCallToolHandler — wikiBodyInliner wiring", () => {
       results: Array<Record<string, unknown>>;
     };
     expect(parsed.results[0]!.full_body).toBeUndefined();
+  });
+});
+
+describe("resolveMaxResultBytes", () => {
+  it("returns the default when the env var is unset or empty", () => {
+    expect(resolveMaxResultBytes({})).toBe(DEFAULT_MAX_RESULT_BYTES);
+    expect(resolveMaxResultBytes({ BRAIN_MCP_MAX_RESULT_BYTES: "" })).toBe(
+      DEFAULT_MAX_RESULT_BYTES,
+    );
+  });
+
+  it("parses a non-negative integer byte count", () => {
+    expect(resolveMaxResultBytes({ BRAIN_MCP_MAX_RESULT_BYTES: "1024" })).toBe(
+      1024,
+    );
+  });
+
+  it("returns 0 (guard disabled) for '0'", () => {
+    expect(resolveMaxResultBytes({ BRAIN_MCP_MAX_RESULT_BYTES: "0" })).toBe(0);
+  });
+
+  it("falls back to the default on invalid values so a typo can't disable the guard", () => {
+    expect(
+      resolveMaxResultBytes({ BRAIN_MCP_MAX_RESULT_BYTES: "unlimited" }),
+    ).toBe(DEFAULT_MAX_RESULT_BYTES);
+    expect(resolveMaxResultBytes({ BRAIN_MCP_MAX_RESULT_BYTES: "-1" })).toBe(
+      DEFAULT_MAX_RESULT_BYTES,
+    );
+    expect(resolveMaxResultBytes({ BRAIN_MCP_MAX_RESULT_BYTES: "1.5" })).toBe(
+      DEFAULT_MAX_RESULT_BYTES,
+    );
+  });
+});
+
+describe("resultContentBytes", () => {
+  it("sums UTF-8 byte lengths of text content items", () => {
+    expect(
+      resultContentBytes({
+        content: [
+          { type: "text", text: "abc" },
+          { type: "text", text: "héllo" }, // é is 2 bytes in UTF-8
+        ],
+      }),
+    ).toBe(3 + 6);
+  });
+
+  it("measures non-text items by their JSON serialization", () => {
+    const item = { type: "image", data: "ZZZZ" };
+    expect(resultContentBytes({ content: [item] })).toBe(
+      Buffer.byteLength(JSON.stringify(item), "utf8"),
+    );
+  });
+
+  it("returns 0 for missing or empty content", () => {
+    expect(resultContentBytes({ content: [] })).toBe(0);
+    expect(
+      resultContentBytes({ content: undefined as unknown as [] }),
+    ).toBe(0);
+  });
+});
+
+describe("createCallToolHandler — oversize-result guard", () => {
+  const bigResult = (chars: number): CallToolResult => ({
+    content: [{ type: "text", text: "x".repeat(chars) }],
+  });
+
+  it("replaces an oversized result with an isError explanation", async () => {
+    const invoke = vi.fn().mockResolvedValue(bigResult(100));
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "claude-code",
+      log: vi.fn(),
+      maxResultBytes: 50,
+    });
+    const out = await handler({
+      name: "tasks",
+      arguments: { action: "board", format: "json" },
+    });
+    expect(out.isError).toBe(true);
+    const text = (out.content[0] as { text: string }).text;
+    expect(text).toContain("'tasks' returned 100 bytes");
+    expect(text).toContain("50-byte forwarding cap");
+    expect(text).toContain("since");
+    expect(text).toContain("BRAIN_MCP_MAX_RESULT_BYTES");
+  });
+
+  it("passes results at or under the cap through unchanged", async () => {
+    const invoke = vi.fn().mockResolvedValue(bigResult(50));
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "claude-code",
+      log: vi.fn(),
+      maxResultBytes: 50,
+    });
+    const out = await handler({ name: "tasks", arguments: { action: "board" } });
+    expect(out.isError).toBeUndefined();
+    expect((out.content[0] as { text: string }).text).toHaveLength(50);
+  });
+
+  it("maxResultBytes: 0 disables the guard entirely", async () => {
+    const invoke = vi.fn().mockResolvedValue(bigResult(10_000));
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "dashboard",
+      log: vi.fn(),
+      maxResultBytes: 0,
+    });
+    const out = await handler({
+      name: "tasks",
+      arguments: { action: "board", format: "json" },
+    });
+    expect(out.isError).toBeUndefined();
+    expect((out.content[0] as { text: string }).text).toHaveLength(10_000);
+  });
+
+  it("applies the default cap when maxResultBytes is omitted", async () => {
+    const invoke = vi
+      .fn()
+      .mockResolvedValue(bigResult(DEFAULT_MAX_RESULT_BYTES + 1));
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "claude-code",
+      log: vi.fn(),
+    });
+    const out = await handler({
+      name: "tasks",
+      arguments: { action: "board", format: "json" },
+    });
+    expect(out.isError).toBe(true);
+  });
+
+  it("logs the replacement so operators can see what tripped the cap", async () => {
+    const log = vi.fn();
+    const invoke = vi.fn().mockResolvedValue(bigResult(100));
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "claude-code",
+      log,
+      maxResultBytes: 50,
+    });
+    await handler({ name: "tasks", arguments: { action: "board" } });
+    expect(
+      log.mock.calls.some(
+        (c) =>
+          typeof c[0] === "string" &&
+          c[0].includes("oversized") &&
+          c[0].includes("tasks"),
+      ),
+    ).toBe(true);
+  });
+
+  it("records the trace against the replacement error result", async () => {
+    const traces: ToolCallTrace[] = [];
+    const invoke = vi.fn().mockResolvedValue(bigResult(100));
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "claude-code",
+      log: vi.fn(),
+      traceWriter: (t) => traces.push(t),
+      maxResultBytes: 50,
+    });
+    await handler({ name: "tasks", arguments: { action: "board" } });
+    expect(traces).toHaveLength(1);
+    expect(traces[0]!.isError).toBe(true);
+  });
+
+  it("measures after wiki-body inlining so the guarded size matches the wire size", async () => {
+    // Search result is under the cap, but the inlined body pushes it over.
+    const searchPayload = JSON.stringify({
+      results: [{ path: "wiki/x.md", score: 0.9 }],
+    });
+    const invoke = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: searchPayload }],
+    });
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "codex",
+      log: vi.fn(),
+      wikiBodyInliner: makeInliner(() => "B".repeat(500)),
+      maxResultBytes: searchPayload.length + 100,
+    });
+    const out = await handler({
+      name: "memory_search",
+      arguments: { query: "x" },
+    });
+    expect(out.isError).toBe(true);
   });
 });

--- a/packages/transport/brain-mcp-proxy/src/handler.ts
+++ b/packages/transport/brain-mcp-proxy/src/handler.ts
@@ -104,6 +104,76 @@ export function inlineTopHitBody(input: {
   };
 }
 
+// ─── Oversize-result guard (2026-07-16) ─────────────────────────────────────
+//
+// A single oversized tool result can kill the MCP client outright: the live
+// incident was `tasks {action:"board", format:"json"}` returning a ~59 MB
+// board (every-minute scheduled-workflow goals × full task records), which
+// Claude Code's stdio client answered with "Connection closed". The proxy
+// process itself survives — it's the client that dies — so the guard's job
+// is to never forward a result that large in the first place. Applies to
+// both transports (stdio + Streamable HTTP) since both share this handler.
+
+/** Default cap on the bytes of content forwarded per tool result. Legitimate
+ * agent-facing results are orders of magnitude smaller (a max-limit
+ * traces_query is ~100 KB); agent clients truncate far below this anyway. */
+export const DEFAULT_MAX_RESULT_BYTES = 4 * 1024 * 1024;
+
+/** Env override for the cap. `0` disables the guard entirely — the
+ * dashboard's brain client sets that: it spawns its own proxy and
+ * legitimately consumes the full board JSON. */
+export const MAX_RESULT_BYTES_ENV = "BRAIN_MCP_MAX_RESULT_BYTES";
+
+/** Resolve the result-size cap from the environment: a non-negative integer
+ * number of bytes, 0 meaning "disabled". Unset/invalid values fall back to
+ * the default so a typo can't silently disable the guard. */
+export function resolveMaxResultBytes(env: NodeJS.ProcessEnv): number {
+  const raw = env[MAX_RESULT_BYTES_ENV];
+  if (raw === undefined || raw === "") return DEFAULT_MAX_RESULT_BYTES;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    return DEFAULT_MAX_RESULT_BYTES;
+  }
+  return n;
+}
+
+/** Total UTF-8 bytes a result's content would occupy on the wire. Non-text
+ * content items (none exist today — the gateway only returns text) are
+ * measured by their JSON serialization. */
+export function resultContentBytes(result: CallToolResult): number {
+  let total = 0;
+  for (const item of result.content ?? []) {
+    const text = (item as { text?: unknown }).text;
+    total +=
+      typeof text === "string"
+        ? Buffer.byteLength(text, "utf8")
+        : Buffer.byteLength(JSON.stringify(item), "utf8");
+  }
+  return total;
+}
+
+/** The isError result returned in place of an oversized one. */
+export function oversizeResult(input: {
+  toolName: string;
+  bytes: number;
+  maxBytes: number;
+}): CallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `MCP proxy: '${input.toolName}' returned ${input.bytes} bytes, over the ` +
+          `${input.maxBytes}-byte forwarding cap (oversized results crash MCP clients). ` +
+          `Narrow the call — e.g. tasks board with format:"json" accepts since (epoch ms) ` +
+          `and limit, or omit format:"json" for the compact markdown board. ` +
+          `Operators can tune the cap via ${MAX_RESULT_BYTES_ENV} (0 disables).`,
+      },
+    ],
+    isError: true,
+  };
+}
+
 export type GatewayInvoker = (input: {
   toolName: string;
   args: Record<string, unknown>;
@@ -213,6 +283,13 @@ export function createCallToolHandler(deps: {
    * See wiki: infrastructure/m1-application-rate-openclaw-hermes-hook-lifecycle.md
    */
   appRateWriter?: AppRateWriter;
+  /**
+   * Cap (bytes) on the content forwarded per tool result; oversized results
+   * are replaced with an isError explanation instead of being shipped to the
+   * client (see the oversize-result guard above). 0 disables the guard.
+   * Defaults to DEFAULT_MAX_RESULT_BYTES when omitted.
+   */
+  maxResultBytes?: number;
 }): (req: CallToolRequest) => Promise<CallToolResult> {
   const {
     invokeFn,
@@ -222,6 +299,7 @@ export function createCallToolHandler(deps: {
     wikiBodyInliner,
     appRateWriter,
   } = deps;
+  const maxResultBytes = deps.maxResultBytes ?? DEFAULT_MAX_RESULT_BYTES;
 
   return async (req) => {
     const args = buildToolArgs(req.arguments, defaultAgentId);
@@ -266,6 +344,21 @@ export function createCallToolHandler(deps: {
         } catch {
           // Inlining must never affect the tool response. Fall through.
           finalResult = result;
+        }
+      }
+      // Oversize guard — measured after inlining (which adds bytes) so the
+      // check reflects what would actually go over the wire.
+      if (maxResultBytes > 0) {
+        const bytes = resultContentBytes(finalResult);
+        if (bytes > maxResultBytes) {
+          log(
+            `[brain] ${req.name} result oversized (${bytes} > ${maxResultBytes} bytes), replaced with error`,
+          );
+          finalResult = oversizeResult({
+            toolName: req.name,
+            bytes,
+            maxBytes: maxResultBytes,
+          });
         }
       }
       recordTrace(finalResult, !!finalResult.isError);

--- a/packages/transport/brain-mcp-proxy/src/http-server.ts
+++ b/packages/transport/brain-mcp-proxy/src/http-server.ts
@@ -22,7 +22,7 @@ import {
 } from "./app-rate-writer.js";
 import { loadGatewayConfig } from "./config.js";
 import { invokeGatewayTool } from "./gateway.js";
-import { createCallToolHandler } from "./handler.js";
+import { createCallToolHandler, resolveMaxResultBytes } from "./handler.js";
 import { createRequestListener, MCP_PATH } from "./http-app.js";
 import { isLoopbackHost, loadHttpConfig } from "./http-config.js";
 import {
@@ -93,6 +93,7 @@ export async function mainHttp(): Promise<void> {
         log: emitStderr,
         traceWriter,
         appRateWriter,
+        maxResultBytes: resolveMaxResultBytes(process.env),
       }),
   });
 

--- a/packages/transport/brain-mcp-proxy/src/index.ts
+++ b/packages/transport/brain-mcp-proxy/src/index.ts
@@ -33,6 +33,11 @@ export {
   attributionLabel,
   createCallToolHandler,
   extractHitCount,
+  DEFAULT_MAX_RESULT_BYTES,
+  MAX_RESULT_BYTES_ENV,
+  oversizeResult,
+  resolveMaxResultBytes,
+  resultContentBytes,
 } from "./handler.js";
 export type {
   CallToolRequest,

--- a/packages/transport/brain-mcp-proxy/src/server.ts
+++ b/packages/transport/brain-mcp-proxy/src/server.ts
@@ -16,7 +16,7 @@ import {
 import { loadConfig } from "@digital-me/contracts";
 import { loadGatewayConfig, resolveDefaultAgentId } from "./config.js";
 import { invokeGatewayTool } from "./gateway.js";
-import { createCallToolHandler } from "./handler.js";
+import { createCallToolHandler, resolveMaxResultBytes } from "./handler.js";
 import { startParentPidWatcher } from "./lifecycle.js";
 import { TOOLS } from "./tools.js";
 import {
@@ -123,6 +123,7 @@ export async function main(): Promise<void> {
     log: emitStderr,
     traceWriter,
     appRateWriter,
+    maxResultBytes: resolveMaxResultBytes(process.env),
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (req) =>

--- a/packages/transport/brain-mcp-proxy/src/tools.ts
+++ b/packages/transport/brain-mcp-proxy/src/tools.ts
@@ -122,6 +122,22 @@ export const TOOLS = [
           enum: [...TASK_ACTIONS],
         },
         ...AGENT_ID_PROP,
+        format: {
+          type: "string",
+          enum: ["json", "markdown"],
+          description:
+            'Output format for board/status/schedule_list/workflow_list. Default markdown (compact, active goals only). "json" returns structured records — board JSON spans a 7-day history window and can be very large; bound it with since and/or limit.',
+        },
+        since: {
+          type: "number",
+          description:
+            "Board JSON only: include completed/cancelled/failed goals updated at/after this epoch-ms timestamp (default: 7 days ago).",
+        },
+        limit: {
+          type: "number",
+          description:
+            "Board JSON only: cap the number of goals returned (most recently updated first).",
+        },
         description: { type: "string", description: "Goal description (for run_goal)" },
         workflowJson: {
           type: "string",


### PR DESCRIPTION
## Symptom

Calling the openclaw-brain `tasks` tool with `format:"json"` (e.g. `{action:"board", format:"json"}`) through the live stdio proxy made the MCP client report **"Connection closed"**. The documented workaround was read-only sqlite for task-id lookups.

## Root cause

The proxy never crashed. The gateway's board JSON returned **58.8 MB** — 9.7k completed goals inside the default 7-day window (the every-minute dashboard-intake workflow) plus **1,091 all-time failed goals** (the `failed` status bypassed the window entirely), each goal carrying its full task records. The proxy forwarded that as one giant JSON-RPC message and Claude Code's stdio client died on it. A plain MCP SDK client survives the same payload, which is why the dashboard (same proxy, same call) kept working.

## Fix (layered)

- **`handler.ts` — oversize-result guard**, shared by both transports (stdio + Streamable HTTP since both feed `createCallToolHandler`). Results whose content exceeds `BRAIN_MCP_MAX_RESULT_BYTES` (default 4 MiB; `0` disables; invalid values fall back to the default so a typo can't disable the guard) are replaced with an `isError` explanation naming the size, the cap, and how to narrow the call. Measured after wiki-body inlining so the check reflects wire size.
- **`brain-client.mc.ts` (dashboard)** sets `BRAIN_MCP_MAX_RESULT_BYTES=0` for its own proxy spawn — it legitimately consumes the full board JSON (Kanban stats, workflow run counts) and the SDK client handles it.
- **`router.ts` (brain-orchestrator)** board JSON now windows `failed` goals by `updatedAt` like completed/cancelled, and accepts `limit` (most recently updated N) for bounded agent calls. Needs the bundled `digital-me-brain` extension redeployed (`digital-me install --runtime openclaw` + gateway restart) to take effect live.
- **`tools.ts`** declares `format`/`since`/`limit` on the `tasks` tool schema so agent clients can discover the bounded-call escape hatches.

## Verification

Hermetic e2e with an MCP SDK client spawning the proxy exactly as registered, against the live gateway:

| call | before | after |
|---|---|---|
| `{action:"board"}` (markdown) | 761 chars, ok | unchanged |
| `{action:"board", format:"json"}` | 58.8 MB single message → live client dies | clean `isError` with remediation hint |
| follow-up call on same connection | n/a (connection dead) | works — connection survives |

`pnpm run ci` green (workspace-wide 100% coverage maintained); regression tests added for the guard (env resolution, byte counting, cap/disable/default paths, post-inline measurement, trace recording) and for board JSON `failed`-windowing + `limit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)