### PR TITLE
fix(brain-mcp-proxy): memory_get schema parity (corpus/from/lines) — wiki reads stop looking "disabled on this server"

### DIFF
--- a/packages/transport/brain-mcp-proxy/src/handler.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/handler.test.ts
@@ -188,6 +188,34 @@ describe("createCallToolHandler", () => {
     );
   });
 
+  it("forwards memory_get corpus/from/lines to the gateway unchanged", async () => {
+    // The proxy forwards whatever args it's given; the only thing that blocks
+    // corpus today is the advertised inputSchema (widened in tools.ts). This
+    // asserts the handler itself passes the widened params straight through.
+    const invoke = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "body" }],
+    });
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "default-agent",
+      log: vi.fn(),
+    });
+    await handler({
+      name: "memory_get",
+      arguments: { path: "wiki/x.md", corpus: "wiki", from: 3, lines: 20 },
+    });
+    expect(invoke.mock.calls[0]![0]).toMatchObject({
+      toolName: "memory_get",
+      args: {
+        path: "wiki/x.md",
+        corpus: "wiki",
+        from: 3,
+        lines: 20,
+        agent_id: "default-agent",
+      },
+    });
+  });
+
   it("accepts undefined arguments and passes empty args to the gateway", async () => {
     const invoke = vi.fn().mockResolvedValue({
       content: [{ type: "text", text: "ok" }],

--- a/packages/transport/brain-mcp-proxy/src/http-app.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/http-app.test.ts
@@ -450,6 +450,37 @@ describe("streamable HTTP end-to-end", () => {
     await client.close();
   });
 
+  it("advertises memory_get's widened corpus/from/lines schema and forwards corpus:\"wiki\" end-to-end", async () => {
+    const { deps, calls } = makeDeps();
+    const port = await startServer(deps);
+    const client = await connectClient(port, {
+      headers: { "x-agent-id": "windows-claude" },
+    });
+
+    // The listed schema must expose corpus so a remote client is allowed to
+    // send it (clients only send params the advertised schema exposes).
+    const tools = await client.listTools();
+    const memoryGet = tools.tools.find((t) => t.name === "memory_get")!;
+    const props = memoryGet.inputSchema.properties as Record<
+      string,
+      { enum?: string[] }
+    >;
+    expect(props.corpus?.enum).toEqual(["memory", "wiki", "all"]);
+    expect(props.from).toBeDefined();
+    expect(props.lines).toBeDefined();
+
+    await client.callTool({
+      name: "memory_get",
+      arguments: { path: "wiki/x.md", corpus: "wiki" },
+    });
+    expect(calls[0]?.args).toMatchObject({
+      path: "wiki/x.md",
+      corpus: "wiki",
+      agent_id: "windows-claude",
+    });
+    await client.close();
+  });
+
   it("overrides a payload-declared agent_id with the authenticated transport identity", async () => {
     const { deps, calls, logs } = makeDeps();
     const port = await startServer(deps);

--- a/packages/transport/brain-mcp-proxy/src/stdio-e2e.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/stdio-e2e.test.ts
@@ -1,0 +1,155 @@
+/**
+ * End-to-end over the stdio-shaped MCP path with an in-process SDK client.
+ *
+ * server.ts wires the @modelcontextprotocol SDK Server to a StdioServer
+ * transport in production; that integration layer is excluded from coverage.
+ * This test reproduces the SAME wiring — ListTools → TOOLS, CallTool →
+ * createCallToolHandler — but over an InMemoryTransport linked pair so a real
+ * SDK Client drives it. It proves the widened memory_get schema reaches the
+ * client and that a client's corpus:"wiki" arg forwards to the gateway
+ * invoker unchanged, matching the HTTP e2e in http-app.test.ts.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CallToolResult } from "./gateway.js";
+import { createCallToolHandler, type GatewayInvoker } from "./handler.js";
+import { TOOLS } from "./tools.js";
+
+// The ~789-char MEMORY.md body the agent workspace returns (abbreviated).
+const AGENT_MEMORY_BODY = "# MEMORY\n- agent's own memory body\n";
+
+/**
+ * Stand-in for the openclaw HTTP gateway, matching its observed behavior:
+ *   - memory_get with corpus:"wiki" → disabled:true (supplement empty on host)
+ *   - memory_get for MEMORY.md (default corpus) → the agent memory body
+ * Records every forwarded arg set for passthrough assertions.
+ */
+function fakeGateway(): { invoke: GatewayInvoker; calls: Record<string, unknown>[] } {
+  const calls: Record<string, unknown>[] = [];
+  const invoke: GatewayInvoker = async ({ toolName, args }) => {
+    calls.push({ toolName, ...args });
+    if (toolName === "memory_get") {
+      if (args.corpus === "wiki") {
+        return jsonResult({
+          path: args.path,
+          text: "",
+          disabled: true,
+          error: "wiki corpus result not found",
+        });
+      }
+      return jsonResult({ path: args.path, text: AGENT_MEMORY_BODY });
+    }
+    return { content: [{ type: "text", text: "ok" }] };
+  };
+  return { invoke, calls };
+}
+
+function jsonResult(obj: unknown): CallToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(obj) }] };
+}
+
+async function connect(invoke: GatewayInvoker): Promise<{
+  client: Client;
+  close: () => Promise<void>;
+}> {
+  const server = new Server(
+    { name: "openclaw-brain", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+  const handle = createCallToolHandler({
+    invokeFn: invoke,
+    defaultAgentId: "claude-code-windows",
+    log: vi.fn(),
+  });
+  server.setRequestHandler(CallToolRequestSchema, async (req) =>
+    handle({ name: req.params.name, arguments: req.params.arguments }),
+  );
+
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverT);
+  const client = new Client({ name: "stdio-e2e", version: "0.0.0" });
+  await client.connect(clientT);
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("stdio transport end-to-end (in-process SDK client)", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+  afterEach(async () => {
+    if (cleanup) await cleanup();
+    cleanup = null;
+  });
+
+  it("advertises memory_get with the widened corpus/from/lines schema", async () => {
+    const { invoke } = fakeGateway();
+    const { client, close } = await connect(invoke);
+    cleanup = close;
+
+    const tools = await client.listTools();
+    const memoryGet = tools.tools.find((t) => t.name === "memory_get")!;
+    const props = memoryGet.inputSchema.properties as Record<
+      string,
+      { enum?: string[]; type?: string }
+    >;
+    expect(memoryGet.inputSchema.required).toEqual(["path"]);
+    expect(props.corpus?.enum).toEqual(["memory", "wiki", "all"]);
+    expect(props.from?.type).toBe("number");
+    expect(props.lines?.type).toBe("number");
+  });
+
+  it("lets a client send memory_get {path, corpus:\"wiki\"} — forwarded to the gateway unchanged", async () => {
+    const { invoke, calls } = fakeGateway();
+    const { client, close } = await connect(invoke);
+    cleanup = close;
+
+    const result = await client.callTool({
+      name: "memory_get",
+      arguments: { path: "wiki/x.md", corpus: "wiki" },
+    });
+    // The corpus arg reached the gateway (the whole point of the schema widen).
+    expect(calls[0]).toMatchObject({
+      toolName: "memory_get",
+      path: "wiki/x.md",
+      corpus: "wiki",
+      agent_id: "claude-code-windows",
+    });
+    // Gateway's wiki-empty response is surfaced verbatim (a per-path miss, not
+    // a transport-level failure).
+    const parsed = JSON.parse(
+      (result.content as Array<{ text: string }>)[0]!.text,
+    ) as { disabled?: boolean; error?: string };
+    expect(parsed.disabled).toBe(true);
+    expect(parsed.error).toBe("wiki corpus result not found");
+  });
+
+  it("still returns the agent memory body for memory_get {path:\"MEMORY.md\"}", async () => {
+    const { invoke, calls } = fakeGateway();
+    const { client, close } = await connect(invoke);
+    cleanup = close;
+
+    const result = await client.callTool({
+      name: "memory_get",
+      arguments: { path: "MEMORY.md" },
+    });
+    expect(calls[0]).toMatchObject({ toolName: "memory_get", path: "MEMORY.md" });
+    expect(calls[0]!.corpus).toBeUndefined();
+    const parsed = JSON.parse(
+      (result.content as Array<{ text: string }>)[0]!.text,
+    ) as { text?: string; disabled?: boolean };
+    expect(parsed.disabled).toBeUndefined();
+    expect(parsed.text).toBe(AGENT_MEMORY_BODY);
+  });
+});

--- a/packages/transport/brain-mcp-proxy/src/tools.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/tools.test.ts
@@ -60,6 +60,50 @@ describe("TOOLS schema", () => {
     expect((t.inputSchema as { required?: readonly string[] }).required).toBeUndefined();
   });
 
+  it("memory_get requires `path` and nothing else", () => {
+    const t = TOOLS.find((t) => t.name === "memory_get")!;
+    expect((t.inputSchema as { required?: readonly string[] }).required).toEqual([
+      "path",
+    ]);
+  });
+
+  it("memory_get advertises corpus/from/lines at parity with the gateway tool", () => {
+    // Regression: the proxy previously advertised only `path`, so MCP clients
+    // could never send corpus:"wiki" (clients only send params the schema
+    // exposes). Every memory_get fell through to the agent workspace and a
+    // wiki path missed with disabled:true — surfacing as "disabled on this
+    // server". Bring the schema to parity with memory_search / the gateway.
+    const t = TOOLS.find((t) => t.name === "memory_get")!;
+    const props = t.inputSchema.properties as Record<
+      string,
+      { type?: string; enum?: readonly string[] }
+    >;
+    expect(props.corpus?.enum).toEqual(["memory", "wiki", "all"]);
+    expect(props.from?.type).toBe("number");
+    expect(props.lines?.type).toBe("number");
+  });
+
+  it("memory_get's corpus enum matches memory_search's corpus enum", () => {
+    const get = TOOLS.find((t) => t.name === "memory_get")!;
+    const search = TOOLS.find((t) => t.name === "memory_search")!;
+    const getEnum = (
+      get.inputSchema.properties as { corpus: { enum: readonly string[] } }
+    ).corpus.enum;
+    const searchEnum = (
+      search.inputSchema.properties as { corpus: { enum: readonly string[] } }
+    ).corpus.enum;
+    expect(getEnum).toEqual(searchEnum);
+  });
+
+  it("memory_get's description de-escalates the disabled=true path-miss so clients don't read it as a server-wide disable", () => {
+    const t = TOOLS.find((t) => t.name === "memory_get")!;
+    // Points clients at memory_search for wiki bodies …
+    expect(t.description).toMatch(/memory_search/);
+    // … and explicitly says a per-path miss is NOT a server-wide disable.
+    expect(t.description.toLowerCase()).toContain("per-path miss");
+    expect(t.description.toLowerCase()).toContain("not a server-wide disable");
+  });
+
   it("traces_query's kind enum includes the proxy's own trace kind", () => {
     // Regression: the proxy writes kind='mcp_tool_call' (trace-writer.ts) but
     // it was missing from the queryable enum, so a client couldn't filter for

--- a/packages/transport/brain-mcp-proxy/src/tools.ts
+++ b/packages/transport/brain-mcp-proxy/src/tools.ts
@@ -322,11 +322,32 @@ export const TOOLS = [
   },
   {
     name: "memory_get",
-    description: "Retrieve a specific memory file by path",
+    description:
+      "Read an exact excerpt from the CALLING AGENT'S OWN memory files (MEMORY.md or memory/*.md) by path. Returns a bounded excerpt (with truncation/continuation info) when `lines` is omitted. This reads agent memory, NOT the shared knowledge wiki: to fetch a wiki/knowledge entry's body, use memory_search — it inlines the top hit's full body, so a follow-up memory_get is unnecessary. `corpus:\"wiki\"` reads registered compiled-wiki supplements, which may be empty on a given host. A `disabled:true` response with error \"path required\" (or \"…result not found\") means the requested path simply isn't a file in the resolved corpus — it is a per-path miss, NOT a server-wide disable of memory retrieval; do not report memory_get as disabled on this server.",
     inputSchema: {
       type: "object",
       properties: {
-        path: { type: "string", description: "Memory file path to retrieve" },
+        path: {
+          type: "string",
+          description:
+            "Memory file path to retrieve (e.g. 'MEMORY.md' or 'memory/some-note.md'), relative to the corpus root.",
+        },
+        corpus: {
+          type: "string",
+          enum: ["memory", "wiki", "all"],
+          description:
+            "Which corpus to read from: memory (default — the agent's own MEMORY.md + memory/*.md), wiki (registered compiled-wiki supplements — may be empty on this host), all (both). Mirror of memory_search's corpus.",
+        },
+        from: {
+          type: "number",
+          description:
+            "1-based line number to start the excerpt from (positive integer). Defaults to the start of the file.",
+        },
+        lines: {
+          type: "number",
+          description:
+            "Maximum number of lines to return starting at `from` (positive integer). Defaults to a bounded excerpt.",
+        },
         ...AGENT_ID_PROP,
       },
       required: ["path"],


### PR DESCRIPTION
## Symptom
A second machine's Claude Code (`claude-code-windows`) reported *"memory_get is disabled on this server, so it can't fetch the data."* It is **not** globally disabled — `memory_get {path:"MEMORY.md", agent_id:"claude-code"}` returns the agent memory body with no `disabled` flag. It returned `{disabled:true, error:"path required"}` only when a client tried to fetch a **wiki entry by path**.

## Root cause
**Schema under-declaration.** The gateway's `memory_get` tool (openclaw memory-core `MemoryGetSchema`) accepts `path`, `corpus` (enum `memory`|`wiki`|`all`), `from`, `lines`. But the proxy's tool schema advertised **only** `path` (+ the shared `agent_id`). MCP clients only send params the advertised schema exposes, so a remote client could never request `corpus:"wiki"`. Every `memory_get` fell through to the agent memory workspace; a wiki path isn't a regular file there → the gateway returned `{disabled:true, error:"path required"}` → Claude Code, following the memory-tool `disabled=true` contract, surfaced it as *"disabled on this server."*

`memory_search`'s proxy schema already exposes `corpus`; that asymmetry **was** the bug. This brings `memory_get` to parity.

## Fix (lowest-surface)
1. **Widen** the proxy's `memory_get` `inputSchema` to `corpus` (enum memory|wiki|all), `from` (number), `lines` (number) — each with a clear description — mirroring the gateway tool. `path` stays required. The proxy already forwards whatever args it's given to the gateway as `{tool, args}` via `invokeGatewayTool`, so widening the schema is sufficient to let clients pass `corpus` through.
2. **Enrich the `memory_get` description** (chosen over handler-level remapping — no gateway behavior touched): it now states memory_get reads the *calling agent's own* memory files, that wiki/knowledge bodies are fetched via `memory_search` (which inlines the top hit's body so no follow-up `memory_get` is needed), and — critically — that a `disabled:true` path-miss is a **per-path miss, NOT a server-wide disable**.

## ⚠️ Open question to flag (not silently fixed)
Exposing `corpus:"wiki"` gives **parity and a correct error**, but it does **not** make wiki-by-path reads work on this host. Verified at the gateway: `memory_get corpus:"wiki"` returns `{disabled:true, error:"wiki corpus result not found"}` and `memory_search corpus:"wiki"` returns 0 results even for old indexed entries — the gateway's compiled-wiki *supplement* is empty/unpopulated here. Wiki knowledge is actually served through the **default** memory corpus + `memorySearch.extraPaths` (pointing at `~/digital-me/wiki`), and the proxy's `handler.ts` deliberately **inlines** the top `memory_search` hit's full body so clients don't need a follow-up `memory_get` for wiki bodies.

**So: should `corpus:"wiki"` resolve wiki entries by path, or is it dead surface until the compiled-wiki supplement is populated?** This PR makes the surface *correct and honest* (right error, right guidance); it does not claim to make wiki-by-path reads functional. Flagging for a decision.

## Tests — e2e over BOTH transports
- `tools.test.ts`: memory_get now advertises corpus/from/lines; corpus enum matches memory_search's; description de-escalates the disabled=true path-miss.
- `handler.test.ts`: handler forwards `corpus`/`from`/`lines` through `invokeGatewayTool` unchanged.
- **stdio** (new `stdio-e2e.test.ts`): in-process MCP SDK `Client` ↔ `Server` over `InMemoryTransport` (same wiring as `server.ts`) — client can `listTools` and see the widened schema, send `memory_get {path, corpus:"wiki"}` (forwarded unchanged), and `memory_get {path:"MEMORY.md"}` still returns the agent memory body.
- **HTTP** (extended `http-app.test.ts`): real SDK client over Streamable HTTP confirms `listTools` advertises corpus and `memory_get {path, corpus:"wiki"}` reaches the handler with the arg intact.

`pnpm run ci` green — **100% coverage retained** (lines/branches/functions/statements) for `@digital-me/brain-mcp-proxy`.

## 🚀 Deploy note (do NOT skip — merge ≠ deployed)
The live **stdio** proxy AND the live **HTTP** service (`ai.digital-me.brain-mcp-http` launchd on the Mac, tailnet `100.103.208.81:18790`) both run from the **main checkout's built `dist/`** (`~/digital-me-os`), not a worktree. A merged PR is not deployed until:

```bash
cd ~/digital-me-os && git pull
pnpm --filter '@digital-me/brain-mcp-proxy...' build
launchctl kickstart -k gui/$UID/ai.digital-me.brain-mcp-http   # HTTP service
# …and restart any stdio client (Claude Code / Codex) so it reloads the proxy
```

The Windows client only gets the fix after that deploy + a client restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)