### PR TITLE
feat(dashboard): Remote MCP clients panel — surface off-roster HTTP-transport clients

### DIFF
--- a/packages/services/dashboard/src/frontend/components/RemoteClientsCard.tsx
+++ b/packages/services/dashboard/src/frontend/components/RemoteClientsCard.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+
+import { useDateRange } from "../hooks/DateRangeContext";
+import { AGENT_COLORS, AGENT_FALLBACK } from "./metric-charts/chart-style";
+
+/**
+ * "Remote MCP clients" panel.
+ *
+ * External MCP clients — a second machine's Claude Code, a Codex CLI — reach the
+ * brain over the Streamable-HTTP transport, attributed by the `X-Agent-Id`
+ * header. They leave a footprint only in brain.db `traces`, never in the
+ * openclaw agent roster, so no agent-card surfaces them. This table shows every
+ * non-roster client seen in the window: who they are (runtime / version when
+ * they called agent_identify), how many brain calls they made, and when they
+ * were last active. Clients that never identified (e.g. the `unknown:mcp`
+ * fallback bucket — MCP traffic with no agent id set) still appear, flagged so
+ * their attribution gap is visible.
+ */
+
+type RemoteClient = {
+  agent_id: string;
+  runtime: string | null;
+  version: string | null;
+  capabilities: string[];
+  identified: boolean;
+  calls: number;
+  first_active: string;
+  last_active: string;
+  kinds: Record<string, number>;
+};
+
+type Result = {
+  clients: RemoteClient[];
+  window_days: number;
+  generated_at: string;
+  error?: string;
+};
+
+/** Compact "3m / 5h / 2d ago" relative time from an ISO timestamp. */
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return "—";
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+export function RemoteClientsCard({ index = 0 }: { readonly index?: number }) {
+  const { days } = useDateRange();
+  const [data, setData] = useState<Result | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/remote-clients?days=${days}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<Result>;
+      })
+      .then((json) => {
+        if (!cancelled) setData(json);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  const clients = data?.clients ?? [];
+  // A transport read failure surfaces as `error` in the 200 body (the endpoint
+  // degrades rather than 500-ing) — treat it like the fetch-level error.
+  const errMsg = error ?? data?.error ?? null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.05 * index }}
+      className="glass-card p-5"
+    >
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-800">
+            Remote MCP clients
+          </h3>
+          <p className="text-[11px] text-gray-400 mt-0.5">
+            External CLIs reaching the brain over HTTP — not in the agent roster
+          </p>
+        </div>
+        <span className="text-[11px] text-gray-400 tabular-nums">
+          {loading ? "…" : errMsg ? "—" : `${clients.length} seen`}
+        </span>
+      </div>
+
+      <div className="my-3 border-t border-gray-100" />
+
+      {loading ? (
+        <div className="py-8 text-center text-[11px] text-gray-400">
+          loading…
+        </div>
+      ) : errMsg ? (
+        <div className="py-8 text-center text-[11px] text-red-500 font-mono">
+          {errMsg}
+        </div>
+      ) : clients.length === 0 ? (
+        <div className="py-8 text-center text-[11px] text-gray-400">
+          no remote MCP clients seen in this window
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-[11px]">
+            <thead>
+              <tr className="text-gray-400 text-left">
+                <th className="font-medium pb-2 pr-3">Client</th>
+                <th className="font-medium pb-2 pr-3">Runtime</th>
+                <th className="font-medium pb-2 pr-3 text-right">Calls</th>
+                <th className="font-medium pb-2 pr-3 text-right">Last active</th>
+              </tr>
+            </thead>
+            <tbody>
+              {clients.map((c) => (
+                <ClientRow key={c.agent_id} client={c} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function ClientRow({ client }: { client: RemoteClient }) {
+  const color = AGENT_COLORS[client.runtime ?? ""] ?? AGENT_FALLBACK;
+  const kindSummary = Object.entries(client.kinds)
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, n]) => `${k}: ${n}`)
+    .join(" · ");
+  return (
+    <tr className="border-t border-gray-50">
+      <td className="py-2 pr-3">
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block w-2 h-2 rounded-full shrink-0"
+            style={{ background: color, opacity: 0.85 }}
+          />
+          <span
+            className="text-gray-700 font-medium truncate max-w-[220px]"
+            title={client.agent_id}
+          >
+            {client.agent_id}
+          </span>
+          {!client.identified && (
+            <span
+              className="text-[9px] uppercase tracking-wide text-amber-600 bg-amber-50 rounded px-1 py-0.5"
+              title="No agent_identify / X-Agent-Id — attributed to a fallback bucket"
+            >
+              unidentified
+            </span>
+          )}
+        </div>
+      </td>
+      <td className="py-2 pr-3 text-gray-500">
+        {client.runtime ?? "—"}
+        {client.version ? (
+          <span className="text-gray-300"> · {client.version}</span>
+        ) : null}
+      </td>
+      <td
+        className="py-2 pr-3 text-right font-mono text-gray-700 tabular-nums"
+        title={kindSummary || undefined}
+      >
+        {client.calls}
+      </td>
+      <td className="py-2 pr-3 text-right text-gray-500 tabular-nums whitespace-nowrap">
+        {relativeTime(client.last_active)}
+      </td>
+    </tr>
+  );
+}

--- a/packages/services/dashboard/src/frontend/components/SystemHealth.tsx
+++ b/packages/services/dashboard/src/frontend/components/SystemHealth.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { ApplicationRateLeftCard } from "./ApplicationRateLeftCard";
 import { KnowledgeTasteLeftCard } from "./KnowledgeTasteLeftCard";
 import { MetricChartPanel, type MetricId } from "./MetricChartPanel";
+import { RemoteClientsCard } from "./RemoteClientsCard";
 import { SessionsLeftCard } from "./SessionsLeftCard";
 
 /**
@@ -63,6 +64,8 @@ export function SystemHealth() {
           </div>
         ))}
       </div>
+
+      <RemoteClientsCard index={ROWS.length} />
 
       <motion.div
         className="text-center py-2"

--- a/packages/services/dashboard/src/server/remote-clients-routes.test.ts
+++ b/packages/services/dashboard/src/server/remote-clients-routes.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import type { AddressInfo } from "node:net";
+import { execSync } from "node:child_process";
+import Database from "better-sqlite3";
+
+import {
+  buildRemoteClientsRouter,
+  defaultListRosterIds,
+} from "./remote-clients-routes.js";
+
+vi.mock("node:child_process", () => ({ execSync: vi.fn() }));
+const execSyncMock = vi.mocked(execSync);
+
+let tmpDir: string;
+let dbPath: string;
+let server: http.Server;
+let base: string;
+
+const NOW = 1_784_000_000_000;
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function seedBrainDb(file: string): void {
+  const db = new Database(file);
+  db.exec(`
+    CREATE TABLE traces (
+      id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, kind TEXT NOT NULL,
+      payload TEXT NOT NULL DEFAULT '{}', task_id TEXT, goal_id TEXT,
+      duration_ms INTEGER, t INTEGER NOT NULL
+    );
+    CREATE TABLE brain_agents (
+      agent_id TEXT PRIMARY KEY, runtime TEXT NOT NULL, version TEXT,
+      capabilities TEXT NOT NULL DEFAULT '[]',
+      first_seen_at INTEGER NOT NULL, last_seen_at INTEGER NOT NULL,
+      session_token TEXT NOT NULL, token_expires_at INTEGER NOT NULL
+    );
+  `);
+  const tr = db.prepare(
+    `INSERT INTO traces (id, agent_id, kind, t) VALUES (?, ?, ?, ?)`,
+  );
+  tr.run("t1", "coo", "tool_call", NOW - HOUR); // roster → excluded
+  tr.run("t2", "codex-windows", "memory_search", NOW - HOUR);
+  tr.run("t3", "claude-code-windows", "tool_call", NOW - 2 * DAY);
+  tr.run("t4", "codex-windows", "tool_call", NOW - 40 * DAY); // out of 30d window
+  db.prepare(
+    `INSERT INTO brain_agents
+       (agent_id, runtime, version, capabilities, first_seen_at, last_seen_at,
+        session_token, token_expires_at)
+     VALUES ('codex-windows', 'codex', 'gpt-5', '["wiki","tasks"]', 0, 0, 'x', 0)`,
+  ).run();
+  db.close();
+}
+
+/** Mount the router with a stubbed roster + fixed clock on an ephemeral port. */
+async function listen(
+  dbFile: string,
+  roster: string[] = ["coo"],
+): Promise<void> {
+  const app = express();
+  app.use(
+    "/api/remote-clients",
+    buildRemoteClientsRouter(dbFile, () => new Set(roster), () => NOW),
+  );
+  server = http.createServer(app);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "remote-clients-"));
+  dbPath = path.join(tmpDir, "brain.db");
+});
+
+afterEach(async () => {
+  if (server) await new Promise((r) => server.close(r));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("buildRemoteClientsRouter", () => {
+  it("returns non-roster clients within the window, roster excluded", async () => {
+    seedBrainDb(dbPath);
+    await listen(dbPath);
+
+    const res = await fetch(`${base}/api/remote-clients?days=30`);
+    const body = (await res.json()) as {
+      clients: Array<{ agent_id: string; calls: number; runtime: string | null }>;
+      window_days: number;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.window_days).toBe(30);
+    // coo excluded (roster); codex-windows out-of-window trace not counted.
+    expect(body.clients.map((c) => c.agent_id)).toEqual([
+      "codex-windows",
+      "claude-code-windows",
+    ]);
+    const codex = body.clients.find((c) => c.agent_id === "codex-windows");
+    expect(codex).toMatchObject({ calls: 1, runtime: "codex" });
+  });
+
+  it("honors the days window (40d includes the older codex trace)", async () => {
+    seedBrainDb(dbPath);
+    await listen(dbPath);
+
+    const res = await fetch(`${base}/api/remote-clients?days=60`);
+    const body = (await res.json()) as {
+      clients: Array<{ agent_id: string; calls: number }>;
+    };
+    const codex = body.clients.find((c) => c.agent_id === "codex-windows");
+    expect(codex?.calls).toBe(2);
+  });
+
+  it("respects the limit param", async () => {
+    seedBrainDb(dbPath);
+    await listen(dbPath);
+
+    const res = await fetch(`${base}/api/remote-clients?days=30&limit=1`);
+    const body = (await res.json()) as { clients: unknown[] };
+    expect(body.clients).toHaveLength(1);
+  });
+
+  it("degrades to an empty payload with error when brain.db is missing", async () => {
+    // Do not seed — dbPath doesn't exist; fileMustExist should surface an error.
+    await listen(dbPath);
+
+    const res = await fetch(`${base}/api/remote-clients?days=30`);
+    const body = (await res.json()) as {
+      clients: unknown[];
+      error?: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.clients).toEqual([]);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("over-shows (empty roster) rather than hiding when the roster is empty", async () => {
+    seedBrainDb(dbPath);
+    await listen(dbPath, []); // roster fetch failed → empty set
+
+    const res = await fetch(`${base}/api/remote-clients?days=30`);
+    const body = (await res.json()) as {
+      clients: Array<{ agent_id: string }>;
+    };
+    // With no roster to exclude, the orchestrator agent shows up too.
+    expect(body.clients.map((c) => c.agent_id)).toContain("coo");
+  });
+
+  it("falls back to the default window on a missing/invalid days param", async () => {
+    seedBrainDb(dbPath);
+    await listen(dbPath);
+
+    const res = await fetch(`${base}/api/remote-clients?days=oops`);
+    const body = (await res.json()) as { window_days: number };
+    expect(body.window_days).toBe(14); // DEFAULT_DAYS
+  });
+
+  it("stringifies a non-Error thrown while resolving the roster", async () => {
+    const app = express();
+    app.use(
+      "/api/remote-clients",
+      buildRemoteClientsRouter(
+        dbPath,
+        () => {
+          throw "roster boom"; // non-Error → String(err) branch
+        },
+        () => NOW,
+      ),
+    );
+    server = http.createServer(app);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+    const res = await fetch(`${base}/api/remote-clients?days=30`);
+    const body = (await res.json()) as { clients: unknown[]; error?: string };
+    expect(body.clients).toEqual([]);
+    expect(body.error).toBe("roster boom");
+  });
+});
+
+describe("defaultListRosterIds", () => {
+  afterEach(() => execSyncMock.mockReset());
+
+  it("parses ids from an { agents: [...] } payload, skipping blanks", () => {
+    execSyncMock.mockReturnValue(
+      JSON.stringify({
+        agents: [{ id: "coo" }, { id: "" }, { name: "no-id" }, { id: "main" }],
+      }),
+    );
+    expect(defaultListRosterIds()).toEqual(new Set(["coo", "main"]));
+  });
+
+  it("parses ids from a bare array payload", () => {
+    execSyncMock.mockReturnValue(JSON.stringify([{ id: "a1" }, { id: "a2" }]));
+    expect(defaultListRosterIds()).toEqual(new Set(["a1", "a2"]));
+  });
+
+  it("returns an empty set for a non-array/agentless object", () => {
+    execSyncMock.mockReturnValue(JSON.stringify({ unrelated: 1 }));
+    expect(defaultListRosterIds().size).toBe(0);
+  });
+
+  it("returns an empty set on unparseable output", () => {
+    execSyncMock.mockReturnValue("not json");
+    expect(defaultListRosterIds().size).toBe(0);
+  });
+
+  it("returns an empty set when the openclaw CLI throws", () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error("command not found: openclaw");
+    });
+    expect(defaultListRosterIds().size).toBe(0);
+  });
+});

--- a/packages/services/dashboard/src/server/remote-clients-routes.ts
+++ b/packages/services/dashboard/src/server/remote-clients-routes.ts
@@ -1,0 +1,129 @@
+/**
+ * Express router for the "Remote MCP clients" panel.
+ *
+ * Mounted at /api/remote-clients by server.ts. One endpoint:
+ *
+ *   GET /api/remote-clients?days=N&limit=M
+ *     → { clients: RemoteClientRow[], window_days, generated_at, error? }
+ *
+ * The router owns two side-effecting inputs the query module stays pure over:
+ *   1. the clock — `days` becomes `sinceMs = now - days*86400_000`
+ *   2. the orchestrator roster — `openclaw agents list --json`, the same
+ *      command the agent-card grid uses (data.ts). Injected as `listRosterIds`
+ *      so tests supply a stub instead of shelling out.
+ *
+ * brain.db is opened readonly per request (better-sqlite3 open is ~1ms). A read
+ * failure (brain.db absent, table missing, openclaw CLI unavailable) degrades
+ * to `{ clients: [], error }` with HTTP 200 — the panel renders an empty state
+ * rather than 500-ing the whole view, matching the dashboard's "start even when
+ * the brain is unreachable" stance.
+ */
+
+import { execSync } from "node:child_process";
+import Database from "better-sqlite3";
+import { Router } from "express";
+
+import { queryRemoteClients } from "./remote-clients.js";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DEFAULT_DAYS = 14;
+const MAX_DAYS = 3650; // matches the "All time" date-range preset
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+function parsePositiveInt(
+  raw: unknown,
+  fallback: number,
+  max: number,
+): number {
+  const n = typeof raw === "string" ? parseInt(raw, 10) : Number.NaN;
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(n, max);
+}
+
+/** Roster-id source: the orchestrator agents already shown as cards. Returns a
+ *  Set of ids to exclude; an empty set (CLI missing / parse failure) means the
+ *  panel over-shows rather than hides — a safer degraded mode. */
+export type ListRosterIds = () => Set<string>;
+
+/** Default roster fetch — mirrors data.ts's `openclaw agents list --json`. */
+export function defaultListRosterIds(): Set<string> {
+  const ids = new Set<string>();
+  let raw: string;
+  try {
+    raw = execSync("openclaw agents list --json 2>/dev/null", {
+      timeout: 15000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch {
+    return ids;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return ids;
+  }
+  const list =
+    parsed !== null &&
+    typeof parsed === "object" &&
+    Array.isArray((parsed as { agents?: unknown[] }).agents)
+      ? (parsed as { agents: unknown[] }).agents
+      : Array.isArray(parsed)
+        ? (parsed as unknown[])
+        : [];
+  for (const entry of list) {
+    const id = (entry as { id?: unknown }).id;
+    if (typeof id === "string" && id !== "") ids.add(id);
+  }
+  return ids;
+}
+
+/**
+ * Build the remote-clients router.
+ *
+ * @param brainDbPath   Absolute path to brain.db (the traces store).
+ * @param listRosterIds Roster-id source; defaults to the openclaw CLI.
+ * @param now           Clock injection for deterministic tests.
+ */
+export function buildRemoteClientsRouter(
+  brainDbPath: string,
+  listRosterIds: ListRosterIds = defaultListRosterIds,
+  now: () => number = Date.now,
+): Router {
+  const router = Router();
+
+  router.get("/", (req, res) => {
+    const days = parsePositiveInt(req.query.days, DEFAULT_DAYS, MAX_DAYS);
+    const limit = parsePositiveInt(req.query.limit, DEFAULT_LIMIT, MAX_LIMIT);
+    const sinceMs = now() - days * MS_PER_DAY;
+
+    let db: Database.Database | null = null;
+    try {
+      const rosterAgentIds = [...listRosterIds()];
+      db = new Database(brainDbPath, { readonly: true, fileMustExist: true });
+      const clients = queryRemoteClients(db, {
+        rosterAgentIds,
+        sinceMs,
+        limit,
+      });
+      res.json({
+        clients,
+        window_days: days,
+        generated_at: new Date(now()).toISOString(),
+      });
+    } catch (err) {
+      res.json({
+        clients: [],
+        window_days: days,
+        generated_at: new Date(now()).toISOString(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      db?.close();
+    }
+  });
+
+  return router;
+}

--- a/packages/services/dashboard/src/server/remote-clients.test.ts
+++ b/packages/services/dashboard/src/server/remote-clients.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+
+import { queryRemoteClients } from "./remote-clients.js";
+
+let db: Database.Database;
+
+/** Fixed clock so windows are deterministic. 2026-07-16T00:00:00Z-ish. */
+const NOW = 1_784_000_000_000;
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/** Create the brain.db tables this module reads (mirrors trace-writer.ts +
+ *  the agents store schema). */
+function createSchema(d: Database.Database): void {
+  d.exec(`
+    CREATE TABLE traces (
+      id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, kind TEXT NOT NULL,
+      payload TEXT NOT NULL DEFAULT '{}', task_id TEXT, goal_id TEXT,
+      duration_ms INTEGER, t INTEGER NOT NULL
+    );
+    CREATE TABLE brain_agents (
+      agent_id TEXT PRIMARY KEY, runtime TEXT NOT NULL, version TEXT,
+      capabilities TEXT NOT NULL DEFAULT '[]',
+      first_seen_at INTEGER NOT NULL, last_seen_at INTEGER NOT NULL,
+      session_token TEXT NOT NULL, token_expires_at INTEGER NOT NULL
+    );
+  `);
+}
+
+let traceSeq = 0;
+function insertTrace(
+  d: Database.Database,
+  agentId: string,
+  kind: string,
+  t: number,
+): void {
+  d.prepare(
+    `INSERT INTO traces (id, agent_id, kind, t) VALUES (?, ?, ?, ?)`,
+  ).run(`tr-${traceSeq++}`, agentId, kind, t);
+}
+
+function insertAgent(
+  d: Database.Database,
+  agentId: string,
+  runtime: string,
+  version: string | null,
+  capabilities: string[],
+): void {
+  d.prepare(
+    `INSERT INTO brain_agents
+       (agent_id, runtime, version, capabilities, first_seen_at, last_seen_at,
+        session_token, token_expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    agentId,
+    runtime,
+    version,
+    JSON.stringify(capabilities),
+    NOW - 5 * DAY,
+    NOW,
+    "tok",
+    NOW + DAY,
+  );
+}
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  createSchema(db);
+  traceSeq = 0;
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("queryRemoteClients", () => {
+  it("excludes orchestrator-roster agents", () => {
+    insertTrace(db, "coo", "tool_call", NOW - HOUR);
+    insertTrace(db, "codex-windows", "tool_call", NOW - HOUR);
+
+    const rows = queryRemoteClients(db, {
+      rosterAgentIds: ["coo", "main", "podcast"],
+    });
+
+    expect(rows.map((r) => r.agent_id)).toEqual(["codex-windows"]);
+  });
+
+  it("enriches identified clients from brain_agents", () => {
+    insertTrace(db, "codex-windows", "memory_search", NOW - HOUR);
+    insertAgent(db, "codex-windows", "codex", "gpt-5", [
+      "wiki",
+      "memory",
+      "tasks",
+    ]);
+
+    const [row] = queryRemoteClients(db, { rosterAgentIds: [] });
+
+    expect(row).toMatchObject({
+      agent_id: "codex-windows",
+      runtime: "codex",
+      version: "gpt-5",
+      capabilities: ["wiki", "memory", "tasks"],
+      identified: true,
+    });
+  });
+
+  it("keeps unidentified clients (traces with no brain_agents row)", () => {
+    insertTrace(db, "unknown:mcp", "tool_call", NOW - HOUR);
+
+    const [row] = queryRemoteClients(db, { rosterAgentIds: [] });
+
+    expect(row).toMatchObject({
+      agent_id: "unknown:mcp",
+      runtime: null,
+      version: null,
+      capabilities: [],
+      identified: false,
+    });
+  });
+
+  it("aggregates call count + kind breakdown + first/last active", () => {
+    insertTrace(db, "claude-code-windows", "tool_call", NOW - 3 * HOUR);
+    insertTrace(db, "claude-code-windows", "tool_call", NOW - 2 * HOUR);
+    insertTrace(db, "claude-code-windows", "memory_search", NOW - HOUR);
+
+    const [row] = queryRemoteClients(db, { rosterAgentIds: [] });
+
+    expect(row.calls).toBe(3);
+    expect(row.kinds).toEqual({ tool_call: 2, memory_search: 1 });
+    expect(row.first_active).toBe(new Date(NOW - 3 * HOUR).toISOString());
+    expect(row.last_active).toBe(new Date(NOW - HOUR).toISOString());
+  });
+
+  it("filters traces before sinceMs", () => {
+    insertTrace(db, "codex-windows", "tool_call", NOW - 40 * DAY); // out of window
+    insertTrace(db, "codex-windows", "tool_call", NOW - 2 * DAY); // in window
+
+    const [row] = queryRemoteClients(db, {
+      rosterAgentIds: [],
+      sinceMs: NOW - 30 * DAY,
+    });
+
+    expect(row.calls).toBe(1);
+    expect(row.first_active).toBe(new Date(NOW - 2 * DAY).toISOString());
+  });
+
+  it("drops a client whose only traces fall outside the window", () => {
+    insertTrace(db, "codex-windows", "tool_call", NOW - 40 * DAY);
+
+    const rows = queryRemoteClients(db, {
+      rosterAgentIds: [],
+      sinceMs: NOW - 30 * DAY,
+    });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("sorts by last-active desc, then calls, then id; respects limit", () => {
+    insertTrace(db, "b-newest", "k", NOW - HOUR);
+    insertTrace(db, "a-older", "k", NOW - 5 * HOUR);
+    insertTrace(db, "c-older", "k", NOW - 5 * HOUR);
+    insertTrace(db, "c-older", "k", NOW - 6 * HOUR); // 2 calls → outranks a-older
+
+    const rows = queryRemoteClients(db, { rosterAgentIds: [], limit: 2 });
+
+    expect(rows.map((r) => r.agent_id)).toEqual(["b-newest", "c-older"]);
+  });
+
+  it("returns empty when every traced agent is in the roster", () => {
+    insertTrace(db, "coo", "k", NOW - HOUR);
+    expect(queryRemoteClients(db, { rosterAgentIds: ["coo"] })).toEqual([]);
+  });
+
+  function seedCapabilities(raw: string): void {
+    insertTrace(db, "codex-windows", "k", NOW - HOUR);
+    db.prepare(
+      `INSERT INTO brain_agents
+         (agent_id, runtime, version, capabilities, first_seen_at, last_seen_at,
+          session_token, token_expires_at)
+       VALUES ('codex-windows', 'codex', NULL, ?, 0, 0, 'tok', 0)`,
+    ).run(raw);
+  }
+
+  it("tolerates malformed (unparseable) capabilities JSON", () => {
+    seedCapabilities("not-json");
+    const [row] = queryRemoteClients(db, { rosterAgentIds: [] });
+    expect(row.capabilities).toEqual([]);
+    expect(row.identified).toBe(true);
+  });
+
+  it("ignores valid-but-non-array capabilities JSON", () => {
+    seedCapabilities('{"wiki":true}');
+    const [row] = queryRemoteClients(db, { rosterAgentIds: [] });
+    expect(row.capabilities).toEqual([]);
+  });
+
+  it("drops non-string entries from the capabilities array", () => {
+    seedCapabilities('["wiki", 123, "tasks"]');
+    const [row] = queryRemoteClients(db, { rosterAgentIds: [] });
+    expect(row.capabilities).toEqual(["wiki", "tasks"]);
+  });
+});

--- a/packages/services/dashboard/src/server/remote-clients.ts
+++ b/packages/services/dashboard/src/server/remote-clients.ts
@@ -1,0 +1,175 @@
+/**
+ * Remote MCP clients — read side.
+ *
+ * The agent-roster grid (data.ts) enumerates `openclaw agents list`, i.e. the
+ * orchestrator's own registered agents. But external MCP clients that reach the
+ * brain over the Streamable-HTTP transport (a Windows Claude Code, a Codex CLI,
+ * a second machine) are NOT orchestrator agents — they only ever leave a
+ * footprint in the brain's `traces` table, attributed by the `X-Agent-Id`
+ * header / `?agent_id=` query the transport resolves. So they show up nowhere
+ * in the dashboard today.
+ *
+ * This module surfaces them: every `agent_id` seen in `traces` that isn't in
+ * the orchestrator roster, aggregated to one row per client (call count, trace
+ * kinds, first/last activity), and LEFT-JOINed to `brain_agents` for identity
+ * enrichment (runtime / version / capabilities) when the client called
+ * `agent_identify`. Clients that never identified (e.g. the `unknown:mcp`
+ * fallback bucket) still appear — flagged `identified: false` — because they
+ * are real, un-attributed MCP traffic worth seeing.
+ *
+ * Reads brain.db directly (readonly). The `traces_query` MCP tool returns raw
+ * rows capped at 1000 with no aggregation, which would silently drop a
+ * low-volume client (e.g. a Codex CLI with 9 lifetime calls) below the cap —
+ * a GROUP BY in SQL is both exact and cheaper.
+ */
+
+import type Database from "better-sqlite3";
+
+export type RemoteClientRow = {
+  /** Attribution identity as recorded on the trace (transport-resolved). */
+  readonly agent_id: string;
+  /** Runtime from `brain_agents` (e.g. "claude-code", "codex"); null if the
+   *  client never called agent_identify. */
+  readonly runtime: string | null;
+  /** Version string from `brain_agents` when identified. */
+  readonly version: string | null;
+  /** Declared capabilities from `brain_agents` when identified. */
+  readonly capabilities: readonly string[];
+  /** True when the client registered via agent_identify (present in
+   *  brain_agents). False for the raw `traces`-only fallback buckets. */
+  readonly identified: boolean;
+  /** Trace count for this client inside the window. */
+  readonly calls: number;
+  /** ISO-8601 timestamp of the client's earliest trace in the window. */
+  readonly first_active: string;
+  /** ISO-8601 timestamp of the client's most recent trace in the window. */
+  readonly last_active: string;
+  /** Trace-kind → count breakdown inside the window. */
+  readonly kinds: Readonly<Record<string, number>>;
+};
+
+export type QueryRemoteClientsOpts = {
+  /** Orchestrator roster ids to exclude — the agents already shown as cards. */
+  readonly rosterAgentIds: readonly string[];
+  /** Only count traces with `t >= sinceMs`. Omit / undefined for all-time. */
+  readonly sinceMs?: number;
+  /** Max clients returned, sorted by last-active desc. Default 50. */
+  readonly limit?: number;
+};
+
+type TraceKindRow = {
+  readonly agent_id: string;
+  readonly kind: string;
+  readonly c: number;
+  readonly min_t: number;
+  readonly max_t: number;
+};
+
+type AgentIdentityRow = {
+  readonly agent_id: string;
+  readonly runtime: string;
+  readonly version: string | null;
+  readonly capabilities: string;
+};
+
+const DEFAULT_LIMIT = 50;
+
+/** Parse a `brain_agents.capabilities` JSON blob into a string[], tolerating
+ *  malformed / non-array payloads (returns []). */
+function parseCapabilities(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((c): c is string => typeof c === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Aggregate the non-roster clients from brain.db `traces`, enriched from
+ * `brain_agents`. Pure over its inputs (deterministic given `sinceMs`), so the
+ * router owns the clock and tests pass an explicit window.
+ */
+export function queryRemoteClients(
+  db: Database.Database,
+  opts: QueryRemoteClientsOpts,
+): RemoteClientRow[] {
+  const since = opts.sinceMs ?? 0;
+  const limit =
+    typeof opts.limit === "number" && opts.limit > 0
+      ? opts.limit
+      : DEFAULT_LIMIT;
+  const roster = new Set(opts.rosterAgentIds);
+
+  // One row per (agent, kind): count + time bounds. Folded into per-agent
+  // rows below so the kind breakdown and the totals come from one scan.
+  const kindRows = db
+    .prepare(
+      `SELECT agent_id, kind, COUNT(*) AS c, MIN(t) AS min_t, MAX(t) AS max_t
+         FROM traces
+        WHERE t >= ?
+        GROUP BY agent_id, kind`,
+    )
+    .all(since) as TraceKindRow[];
+
+  // Identity map — LEFT JOIN done in JS so a client that never identified
+  // still yields a row (identified: false).
+  const identities = new Map<string, AgentIdentityRow>();
+  for (const row of db
+    .prepare(
+      `SELECT agent_id, runtime, version, capabilities FROM brain_agents`,
+    )
+    .all() as AgentIdentityRow[]) {
+    identities.set(row.agent_id, row);
+  }
+
+  type Acc = {
+    calls: number;
+    minT: number;
+    maxT: number;
+    kinds: Record<string, number>;
+  };
+  const byAgent = new Map<string, Acc>();
+  for (const row of kindRows) {
+    if (roster.has(row.agent_id)) continue;
+    const acc = byAgent.get(row.agent_id) ?? {
+      calls: 0,
+      minT: row.min_t,
+      maxT: row.max_t,
+      kinds: {},
+    };
+    acc.calls += row.c;
+    acc.minT = Math.min(acc.minT, row.min_t);
+    acc.maxT = Math.max(acc.maxT, row.max_t);
+    acc.kinds[row.kind] = (acc.kinds[row.kind] ?? 0) + row.c;
+    byAgent.set(row.agent_id, acc);
+  }
+
+  const clients: RemoteClientRow[] = [];
+  for (const [agent_id, acc] of byAgent) {
+    const identity = identities.get(agent_id);
+    clients.push({
+      agent_id,
+      runtime: identity?.runtime ?? null,
+      version: identity?.version ?? null,
+      capabilities: identity ? parseCapabilities(identity.capabilities) : [],
+      identified: identity !== undefined,
+      calls: acc.calls,
+      first_active: new Date(acc.minT).toISOString(),
+      last_active: new Date(acc.maxT).toISOString(),
+      kinds: acc.kinds,
+    });
+  }
+
+  // Most-recently-active first, then busiest, then a stable id tiebreak so the
+  // ordering is deterministic for a fixed snapshot.
+  clients.sort(
+    (a, b) =>
+      b.last_active.localeCompare(a.last_active) ||
+      b.calls - a.calls ||
+      a.agent_id.localeCompare(b.agent_id),
+  );
+
+  return clients.slice(0, limit);
+}

--- a/packages/services/dashboard/src/server/server.ts
+++ b/packages/services/dashboard/src/server/server.ts
@@ -21,6 +21,9 @@ import { buildMetricsRouter } from "./metrics-routes.js";
 import { buildKanbanRouter, buildMechanismRouter } from "./mechanism-routes.js";
 // Delivery view: unified agent-activity feed, read live from the brain DB.
 import { buildActivityFeedRouter } from "./activity-feed.js";
+// Remote MCP clients: external CLIs (other machines) that reach the brain over
+// the HTTP transport and thus never appear in the openclaw agent roster.
+import { buildRemoteClientsRouter } from "./remote-clients-routes.js";
 
 const app = express();
 // No CORS middleware on purpose: the SPA is served same-origin from this app,
@@ -77,6 +80,15 @@ const LEGACY_DB_PATH = path.join(
 );
 const DASHBOARD_DB_PATH = process.env["DASHBOARD_DB"] ?? DEFAULT_DB_PATH;
 
+// Brain traces store. This is a DIFFERENT DB from dashboard.db: traces +
+// brain_agents live in brain.db, written by the brain-mcp proxy's trace-writer.
+// Path source-of-truth matches trace-writer.ts (~/.openclaw/data/brain.db);
+// honor $BRAIN_DB, then $OPENCLAW_DATA_DIR, else the canonical home path.
+const OPENCLAW_DATA_DIR =
+  process.env["OPENCLAW_DATA_DIR"] ?? path.join(HOME, ".openclaw", "data");
+const BRAIN_DB_PATH =
+  process.env["BRAIN_DB"] ?? path.join(OPENCLAW_DATA_DIR, "brain.db");
+
 (function migrateLegacyDbIfNeeded() {
   if (process.env["DASHBOARD_DB"]) return; // explicit override — don't touch.
   if (!fs.existsSync(LEGACY_DB_PATH) || fs.existsSync(DEFAULT_DB_PATH)) return;
@@ -115,6 +127,13 @@ app.use("/api/mechanism", buildMechanismRouter());
 // split as the metrics endpoints); the stream_activity intake step owns the
 // brain → row mapping. See activity-feed.ts + intake/.../stream_activity.py.
 app.use("/api/activity-feed", buildActivityFeedRouter(DASHBOARD_DB_PATH));
+
+// ── Remote MCP clients ──
+// External MCP clients (a second machine's Claude Code / Codex CLI) reach the
+// brain over the Streamable-HTTP transport, attributed by X-Agent-Id. They
+// leave a footprint only in brain.db `traces`, never in the openclaw roster, so
+// no agent-card surfaces them. This endpoint aggregates the non-roster clients.
+app.use("/api/remote-clients", buildRemoteClientsRouter(BRAIN_DB_PATH));
 
 // ── Feed search: ranked knowledge search over the brain's memory_search ──
 // Preview markdown is read from disk, restricted to the user-owned knowledge


### PR DESCRIPTION
## Why

You have two Windows clients on the brain — `claude-code-windows` and `codex-windows` — but neither shows up in the OA Dashboard. This diagnoses and fixes that.

**Root cause (not an attribution bug):** both clients connect and are attributed correctly — they're right there in brain.db `traces` (19 / 21 calls, `identified: true`). The problem is that **no dashboard surface reads the place they're recorded**:

- The **agent-card grid** enumerates `openclaw agents list` — the orchestrator's registered agents. External MCP clients reaching the brain over the Streamable-HTTP transport (attributed by `X-Agent-Id`) are *not* orchestrator agents, so no card can represent them.
- The **per-agent M1 chart** is fed by a rollup that skips `claude-code-*` (the proxy assumes claude-code self-reports via a local Stop-hook — true for the Mac, but a *Windows* client's self-report never crosses to the Mac store), and a raw Codex client emits no ack events at all.

So they were invisible everywhere.

## What

Adds a **"Remote MCP clients"** panel to the Topline Metrics view: every `agent_id` in `traces` that isn't in the orchestrator roster, aggregated per client — call count, trace-kind breakdown, first/last active — LEFT-JOINed to `brain_agents` for runtime / version / capabilities when the client called `agent_identify`. Unidentified buckets (e.g. `unknown:mcp`) still appear, flagged, since they're real un-attributed MCP traffic worth seeing.

### Design notes
- **Reads brain.db directly with a `GROUP BY`.** The `traces_query` MCP tool caps at 1000 rows with no aggregation, which would silently drop a low-volume client (a CLI with 9 lifetime calls) below the cap. SQL aggregation is exact and cheaper.
- **brain.db path** mirrors `trace-writer.ts` (`~/.openclaw/data/brain.db`), honoring `$BRAIN_DB` / `$OPENCLAW_DATA_DIR`. Distinct from `dashboard.db`.
- **Degrades gracefully:** readonly, per-request connection; a read failure (brain.db absent, `openclaw` CLI unavailable) returns an empty payload with an `error` field rather than 500-ing the view. Empty roster → over-shows rather than hides.

## Files
- `server/remote-clients.ts` — the aggregation query (pure over `sinceMs`)
- `server/remote-clients-routes.ts` — `GET /api/remote-clients?days&limit` + roster fetch, wired in `server.ts`
- `frontend/components/RemoteClientsCard.tsx` — the panel, rendered under the metric rows in `SystemHealth`

## Verification
- `pnpm typecheck` (server + frontend), `eslint`, `vite build`: clean
- **100% coverage retained** — query + route + `defaultListRosterIds` unit tests (255 dashboard tests pass)
- **Live-smoked against the real brain.db:** both Windows clients surface at the top of the panel (`codex-windows` codex/21 calls, `claude-code-windows` claude-code/19 calls); the 10 orchestrator agents are correctly excluded; `unknown:mcp` (140 unattributed calls) shows as an attribution-hygiene signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)