### PR TITLE
fix(security): clear 2 Dependabot DoS alerts + close DNS-rebinding & latent SQLi

### DIFF
--- a/packages/plugins/brain-orchestrator/src/store/cron-runs.ts
+++ b/packages/plugins/brain-orchestrator/src/store/cron-runs.ts
@@ -135,7 +135,12 @@ export function createCronTools(deps: { db: DatabaseSync }): CronTools {
       params.until = dateFromEpochMs(args.until);
     }
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
-    const limitClause = args.limit !== undefined ? `LIMIT ${args.limit}` : "";
+    // Bind LIMIT as a parameter, never string-interpolate it (SQLi guard).
+    let limitClause = "";
+    if (args.limit !== undefined) {
+      limitClause = "LIMIT @limit";
+      params.limit = args.limit;
+    }
     const rows = db
       .prepare(
         `SELECT date, cron_name, scheduled_time, run_time, status, duration_ms, error

--- a/packages/plugins/brain-orchestrator/src/store/feedback.ts
+++ b/packages/plugins/brain-orchestrator/src/store/feedback.ts
@@ -105,7 +105,12 @@ export function createFeedbackTools(deps: {
       params.since = dateFromEpochMs(args.since);
     }
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
-    const limitClause = args.limit !== undefined ? `LIMIT ${args.limit}` : "";
+    // Bind LIMIT as a parameter, never string-interpolate it (SQLi guard).
+    let limitClause = "";
+    if (args.limit !== undefined) {
+      limitClause = "LIMIT @limit";
+      params.limit = args.limit;
+    }
     const rows = db
       .prepare(
         `SELECT id, date, type, agent, description, severity, source, related_goal, resolved

--- a/packages/plugins/brain-orchestrator/src/store/insights.ts
+++ b/packages/plugins/brain-orchestrator/src/store/insights.ts
@@ -117,7 +117,12 @@ export function createInsightTools(deps: {
       });
     }
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
-    const limitClause = args.limit !== undefined ? `LIMIT ${args.limit}` : "";
+    // Bind LIMIT as a parameter, never string-interpolate it (SQLi guard).
+    let limitClause = "";
+    if (args.limit !== undefined) {
+      limitClause = "LIMIT @limit";
+      params.limit = args.limit;
+    }
     const rows = db
       .prepare(
         `SELECT id, date, type, observation, why_it_matters, question_for_jing,

--- a/packages/plugins/brain-orchestrator/src/store/issues.ts
+++ b/packages/plugins/brain-orchestrator/src/store/issues.ts
@@ -160,7 +160,14 @@ export function createIssueTools(deps: {
       params.until = dateFromEpochMs(args.until);
     }
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
-    const limitClause = args.limit !== undefined ? `LIMIT ${args.limit}` : "";
+    // Bind LIMIT as a parameter, never string-interpolate it — a non-integer
+    // `limit` reaching here (e.g. from an unvalidated caller) would otherwise be
+    // SQL injection. Bound params make injection structurally impossible.
+    let limitClause = "";
+    if (args.limit !== undefined) {
+      limitClause = "LIMIT @limit";
+      params.limit = args.limit;
+    }
     const rows = db
       .prepare(
         `SELECT id, date, type, goal, title, description, category, severity, status, reported_by

--- a/packages/services/dashboard/src/server/host-guard.test.ts
+++ b/packages/services/dashboard/src/server/host-guard.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { extractHostname, isLoopbackHost } from "./host-guard.js";
+
+describe("extractHostname", () => {
+  it("strips the port from a named host", () => {
+    expect(extractHostname("localhost:3458")).toBe("localhost");
+  });
+
+  it("returns a bare host unchanged", () => {
+    expect(extractHostname("127.0.0.1")).toBe("127.0.0.1");
+  });
+
+  it("unwraps an IPv6 literal with a port", () => {
+    expect(extractHostname("[::1]:3458")).toBe("::1");
+  });
+
+  it("unwraps a bare IPv6 literal", () => {
+    expect(extractHostname("[::1]")).toBe("::1");
+  });
+
+  it("lowercases the hostname", () => {
+    expect(extractHostname("EVIL.Example")).toBe("evil.example");
+  });
+
+  it("returns null for a malformed IPv6 literal with no closing bracket", () => {
+    expect(extractHostname("[::1")).toBeNull();
+  });
+
+  it("returns null when the host is empty before the port", () => {
+    expect(extractHostname(":3458")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(extractHostname("")).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(extractHostname(undefined)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(extractHostname(null)).toBeNull();
+  });
+});
+
+describe("isLoopbackHost", () => {
+  it.each([
+    "localhost",
+    "localhost:3458",
+    "127.0.0.1",
+    "127.0.0.1:3458",
+    "[::1]",
+    "[::1]:3458",
+    "LOCALHOST:3458",
+  ])("allows loopback host %s", (h) => {
+    expect(isLoopbackHost(h)).toBe(true);
+  });
+
+  it.each([
+    "evil.example",
+    "evil.example:3458",
+    "127.0.0.1.evil.example",
+    "192.168.1.10:3458",
+    "attacker.local",
+    ":3458",
+    "",
+    undefined,
+    null,
+  ])("rejects non-loopback host %s", (h) => {
+    expect(isLoopbackHost(h)).toBe(false);
+  });
+});

--- a/packages/services/dashboard/src/server/host-guard.ts
+++ b/packages/services/dashboard/src/server/host-guard.ts
@@ -1,0 +1,55 @@
+/**
+ * DNS-rebinding guard for the unauthenticated dashboard API.
+ *
+ * The dashboard serves the user's entire personal "brain" with NO auth. Its
+ * whole perimeter is (a) binding to loopback only and (b) deliberately omitting
+ * CORS (see server.ts). Same-origin policy alone does NOT close that perimeter:
+ * a malicious site the user visits can re-resolve its own hostname to 127.0.0.1
+ * (DNS rebinding) and, because the browser then treats the response as
+ * same-origin with the attacker's page, read every `/api/*` payload. Loopback
+ * binding does not help — the rebound request still arrives on 127.0.0.1.
+ *
+ * The standard defense is to reject any request whose `Host` header is not a
+ * known loopback name. Legitimate local clients (the browser hitting
+ * http://localhost:PORT, the Vite dev proxy hitting 127.0.0.1:PORT) always send
+ * a loopback Host; an attacker's rebound request carries the attacker's own
+ * hostname (e.g. `evil.example`) and is rejected. The attacker cannot forge a
+ * loopback Host without also making the browser treat the origin as the
+ * loopback origin — at which point SOP + no-CORS already blocks the read.
+ */
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/**
+ * Extract the lowercased hostname from a `Host` header value, stripping any
+ * `:port` suffix and IPv6 brackets. Returns null for missing/empty/malformed
+ * values (which are treated as not-allowed by callers).
+ *
+ *   "localhost:3458"  -> "localhost"
+ *   "127.0.0.1"       -> "127.0.0.1"
+ *   "[::1]:3458"      -> "::1"
+ *   "EVIL.example"    -> "evil.example"
+ *   ":3458" / "" / undefined -> null
+ */
+export function extractHostname(hostHeader: string | undefined | null): string | null {
+  if (!hostHeader) return null;
+  let name: string;
+  if (hostHeader.startsWith("[")) {
+    // IPv6 literal: "[::1]" or "[::1]:3458". Take what's inside the brackets.
+    const end = hostHeader.indexOf("]");
+    if (end === -1) return null; // malformed — no closing bracket
+    name = hostHeader.slice(1, end);
+  } else {
+    name = hostHeader.split(":")[0];
+  }
+  return name.length > 0 ? name.toLowerCase() : null;
+}
+
+/**
+ * True only when the `Host` header names a loopback host. Used to reject
+ * DNS-rebinding requests against the unauthenticated dashboard API.
+ */
+export function isLoopbackHost(hostHeader: string | undefined | null): boolean {
+  const name = extractHostname(hostHeader);
+  return name !== null && LOOPBACK_HOSTNAMES.has(name);
+}

--- a/packages/services/dashboard/src/server/server.ts
+++ b/packages/services/dashboard/src/server/server.ts
@@ -24,8 +24,25 @@ import { buildActivityFeedRouter } from "./activity-feed.js";
 // Remote MCP clients: external CLIs (other machines) that reach the brain over
 // the HTTP transport and thus never appear in the openclaw agent roster.
 import { buildRemoteClientsRouter } from "./remote-clients-routes.js";
+// DNS-rebinding guard: reject any request whose Host isn't a loopback name.
+import { isLoopbackHost } from "./host-guard.js";
 
 const app = express();
+// DNS-rebinding guard — MUST be the first middleware, before body parsing and
+// every route. This API is unauthenticated and its only perimeter is loopback
+// binding + no CORS (see below). That perimeter is defeated by DNS rebinding
+// unless we also validate the Host header: a site the browser visits can
+// re-resolve its hostname to 127.0.0.1 and read this personal-data API under
+// its own origin. Legit local clients (browser → localhost, Vite proxy →
+// 127.0.0.1) always send a loopback Host; rebound requests carry the attacker's
+// hostname and are rejected here. See host-guard.ts for the full rationale.
+app.use((req, res, next) => {
+  if (!isLoopbackHost(req.headers.host)) {
+    res.status(403).json({ error: "forbidden host" });
+    return;
+  }
+  next();
+});
 // No CORS middleware on purpose: the SPA is served same-origin from this app,
 // and the Vite dev server proxies /api here (see vite.config.ts), so no
 // cross-origin requests exist. A `cors()` wildcard would let any website the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@5: ^5.0.7
+  js-yaml@4: ^4.2.0
+
 importers:
 
   .:
@@ -1435,8 +1439,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2181,8 +2185,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3605,7 +3609,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4327,7 +4331,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5120,7 +5124,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -5586,7 +5590,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,9 @@ packages:
 allowBuilds:
   better-sqlite3: true
   esbuild: true
+# Security floors for transitive (lint-time) dev deps flagged by Dependabot.
+# brace-expansion GHSA-3jxr-9vmj-r5cp (<5.0.7) and js-yaml GHSA-h67p-54hq-rp68 (<=4.1.1).
+# Caret floors so Dependabot can still bump within the major.
+overrides:
+  brace-expansion@5: ^5.0.7
+  js-yaml@4: ^4.2.0


### PR DESCRIPTION
## Summary

Security-review remediation. Fixes the two open Dependabot alerts and closes two code-level findings surfaced by a focused review of the network/auth and CLI/services surfaces.

| # | Severity | Surface | Fix |
|---|----------|---------|-----|
| Dependabot #33 | High | lint-time dev dep | `brace-expansion` 5.0.6 → **5.0.7** (GHSA-3jxr-9vmj-r5cp) |
| Dependabot #32 | Moderate | lint-time dev dep | `js-yaml` 4.1.1 → **4.3.0** (GHSA-h67p-54hq-rp68) |
| Finding 1 | Medium | dashboard HTTP API | Host-header guard vs **DNS rebinding** |
| Finding 2 | Low (latent) | brain-orchestrator store | Bind `LIMIT` param (latent **SQLi** hardening) |

## 1. Dependabot DoS alerts

Both vulnerable packages resolve **only** through the ESLint / typescript-eslint toolchain (`scope: development`) and are never shipped to any runtime — so real-world exposure was low, but the alerts are now cleared at the source. Applied via `pnpm-workspace.yaml` `overrides` with **caret floors** (`^5.0.7`, `^4.2.0`) so Dependabot can still bump within the major. (pnpm 10+ reads `overrides` from `pnpm-workspace.yaml`, not the root `package.json` `pnpm` field — the latter is silently ignored.)

## 2. Dashboard DNS-rebinding (Medium)

`packages/services/dashboard` serves the user's entire personal "brain" (goals, tasks, traces, feedback, insights, memory search) with **no authentication**; its whole perimeter was loopback-bind + a deliberate no-CORS choice. Same-origin policy does **not** stop DNS rebinding: a site the user visits can re-resolve its hostname to `127.0.0.1` and read every `/api/*` payload under its own origin. Added a Host-header allow-list as the **first middleware** (rejects non-loopback `Host` with 403). Logic extracted to a fully-tested `host-guard.ts`. Impact was read-only (all endpoints are GET; no write/dispatch surface). Dev (Vite proxy → `127.0.0.1`) and prod (browser → `localhost`) are unaffected.

## 3. Latent SQL injection — defense in depth (Low)

Four store `list()`/`timeseries()` functions built `LIMIT ${args.limit}` by string interpolation. **No untrusted-input path reaches them in-repo today** (they're exported but not wired to any registered MCP tool with client input), so this is hardening, not an active exploit. Bound `LIMIT` as a parameter in `issues` / `feedback` / `insights` / `cron-runs` so a non-integer `limit` can never inject.

## What was reviewed and found clean

- **brain-mcp-proxy HTTP transport** — mandatory bearer token (≥16 chars, no default), **timing-safe** comparison before body read, per-request `X-Agent-Id` enforced over payload-declared ids. No bypass.
- **CLI / runtimes / services** — all shell-outs use argv arrays (no `shell:true`); YAML via `safe_load`; wiki writes slugified + `relative_to`-guarded; MCP tool inputs type-coerced + allowlisted; all other SQL parameterized. No high-confidence findings.

## Verification

`pnpm run ci` green: sanitize, build, typecheck, lint (0 errors), knip, **100% coverage** workspace-wide. New `host-guard.ts` at 100%; the "respects limit" store tests confirm `node:sqlite` binds `@limit` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)