### PR TITLE
fix(cli): make the fresh-install memory index actually work end-to-end

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -95,7 +95,7 @@ With the npm install, the only directory that's yours to own is `~/digital-me`
 
 | Path | What it is |
 |---|---|
-| `~/digital-me/` | **your** data: wiki, inbox, config (own it in a private git repo) |
+| `~/digital-me/` | **your** data: wiki, tastes, inbox, config (own it in a private git repo) |
 | `~/.openclaw/` | openclaw gateway home (brain database, plugins) |
 
 *(Installed [from source](#from-source)? The repo checkout lives at

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,8 @@
     "@digital-me/runtime-codex": "workspace:*",
     "@digital-me/runtime-hermes": "workspace:*",
     "@digital-me/runtime-openclaw": "workspace:*",
-    "esbuild": "^0.28.0"
+    "esbuild": "^0.28.0",
+    "json5": "^2.2.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -400,6 +400,7 @@ function doctor(runtimes: RuntimeId[]): number {
       env: process.env,
       which,
       execCommand,
+      readFile: (p) => readFileSync(p, "utf-8"),
       brainMcpProxyBinPath: BRAIN_MCP_PROXY_BIN,
       repoRoot: resolveRepoRoot(),
     },
@@ -1363,9 +1364,26 @@ async function installOpenclaw(
   } else {
     console.log(`     memory_search already indexes the wiki + tastes trees.`);
   }
+  if (mem.ok && mem.seededLocalFallback) {
+    console.log(
+      `[OK] memory_search embeddings: no provider configured — seeded ` +
+        `fallback: "local" (openclaw's keyless bundled embedder) so the index ` +
+        `builds without an API key. Override under agents.defaults.memorySearch ` +
+        `in ${mem.configPath}.`,
+    );
+  }
+  if (mem.ok && mem.json5Rewritten) {
+    console.log(
+      `     note: ${mem.configPath} contained JSON5 syntax (comments, trailing ` +
+        `commas, …); it was rewritten as plain JSON — the same normalization ` +
+        `openclaw's own config writer applies.`,
+    );
+  }
 
   console.log(
-    `     Restart openclaw (gateway daemon) for the plugins to load.\n` +
+    `     Restart openclaw (gateway daemon) for the plugins to load and the\n` +
+      `     memory index to pick up the wiki + tastes trees (indexing resumes\n` +
+      `     asynchronously after restart).\n` +
       `     Then: 'digital-me doctor' should show all checks green.`,
   );
   return 0;

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -6,7 +6,9 @@ import {
   formatReport,
   parsePythonVersion,
   runDoctor,
+  runEmbeddingsCheck,
   runLlmAuthCheck,
+  runMemoryIndexChecks,
   runOpenclawShadowCheck,
   type DoctorDeps,
 } from "./doctor.js";
@@ -863,5 +865,223 @@ describe("runOpenclawShadowCheck", () => {
     expect(paths).toContain(
       "$HOME/openclaw/extensions/digital-me-recall/index.mjs",
     );
+  });
+});
+
+// ── Memory-index wiring checks ────────────────────────────────────────────
+
+describe("runMemoryIndexChecks", () => {
+  const wiki = "/home/u/digital-me/wiki";
+  const tastes = "/home/u/digital-me/tastes";
+  const cfgPath = "/home/u/.openclaw/openclaw.json";
+  const DIRS = "openclaw: knowledge dirs";
+  const PATHS = "openclaw: memory_search extraPaths";
+  const EMB = "openclaw: memory embeddings";
+  const goodCfg = JSON.stringify({
+    agents: {
+      defaults: {
+        memorySearch: { fallback: "local", extraPaths: [wiki, tastes] },
+      },
+    },
+  });
+  const find = (checks: ReturnType<typeof runMemoryIndexChecks>, label: string) =>
+    checks.find((c) => c.label === label)!;
+
+  it("is all green when dirs exist, paths are wired, and fallback is keyless", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({ fileExists: () => true, readFile: () => goodCfg }),
+    );
+    expect(checks).toHaveLength(3);
+    expect(checks.every((c) => c.ok)).toBe(true);
+    const paths = find(checks, PATHS);
+    if (paths.ok) expect(paths.note).toContain(cfgPath);
+  });
+
+  it("flags missing knowledge dirs with the startup-watch explanation", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({
+        fileExists: (p) => p === cfgPath || p === wiki,
+        readFile: () => goodCfg,
+      }),
+    );
+    const dirs = find(checks, DIRS);
+    expect(dirs.ok).toBe(false);
+    if (!dirs.ok) {
+      expect(dirs.reason).toContain(tastes);
+      expect(dirs.reason).not.toContain(`${wiki},`);
+      expect(dirs.reason).toMatch(/exist at startup/);
+    }
+  });
+
+  it("FAILs the extraPaths check when the config file is absent (embeddings skip)", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({ fileExists: (p) => p === wiki || p === tastes }),
+    );
+    expect(find(checks, DIRS).ok).toBe(true);
+    const paths = find(checks, PATHS);
+    expect(paths.ok).toBe(false);
+    if (!paths.ok) expect(paths.reason).toMatch(/not found/);
+    const emb = find(checks, EMB);
+    expect(emb.ok).toBe(true);
+    if (emb.ok) expect(emb.note).toMatch(/skipped — openclaw config not found/);
+  });
+
+  it("skips the content checks when the caller provides no readFile", () => {
+    const checks = runMemoryIndexChecks(makeDeps({ fileExists: () => true }));
+    const paths = find(checks, PATHS);
+    expect(paths.ok).toBe(true);
+    if (paths.ok) expect(paths.note).toMatch(/did not provide readFile/);
+    const emb = find(checks, EMB);
+    expect(emb.ok).toBe(true);
+    if (emb.ok) expect(emb.note).toMatch(/did not provide readFile/);
+  });
+
+  it("FAILs when the config is not even JSON5", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({ fileExists: () => true, readFile: () => "{ totally: broken" }),
+    );
+    const paths = find(checks, PATHS);
+    expect(paths.ok).toBe(false);
+    if (!paths.ok) expect(paths.reason).toMatch(/could not be read as JSON5/);
+    const emb = find(checks, EMB);
+    expect(emb.ok).toBe(true);
+    if (emb.ok) expect(emb.note).toMatch(/unreadable/);
+  });
+
+  it("stringifies a non-Error readFile throw", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({
+        fileExists: () => true,
+        readFile: () => {
+          throw "boom";
+        },
+      }),
+    );
+    const paths = find(checks, PATHS);
+    expect(paths.ok).toBe(false);
+    if (!paths.ok) expect(paths.reason).toContain("boom");
+  });
+
+  it("accepts the JSON5 dialect (comments, single quotes) like the gateway", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({
+        fileExists: () => true,
+        readFile: () =>
+          `{
+            // hand-annotated — legal for openclaw's JSON5 parser
+            agents: { defaults: { memorySearch: {
+              fallback: 'local',
+              extraPaths: ['${wiki}', '${tastes}',],
+            } } },
+          }`,
+      }),
+    );
+    expect(checks.every((c) => c.ok)).toBe(true);
+  });
+
+  it("FAILs when extraPaths misses the tastes tree (non-strings ignored)", () => {
+    const cfg = JSON.stringify({
+      agents: { defaults: { memorySearch: { fallback: "local", extraPaths: [wiki, 42] } } },
+    });
+    const checks = runMemoryIndexChecks(
+      makeDeps({ fileExists: () => true, readFile: () => cfg }),
+    );
+    const paths = find(checks, PATHS);
+    expect(paths.ok).toBe(false);
+    if (!paths.ok) {
+      expect(paths.reason).toContain(tastes);
+      expect(paths.reason).toMatch(/restart the openclaw gateway/);
+    }
+  });
+
+  it("treats a null config and a non-object agents node as unwired", () => {
+    for (const raw of ["null", JSON.stringify({ agents: "nope" })]) {
+      const checks = runMemoryIndexChecks(
+        makeDeps({ fileExists: () => true, readFile: () => raw }),
+      );
+      expect(find(checks, PATHS).ok).toBe(false);
+    }
+  });
+
+  it("falls back to USERPROFILE then empty home for path resolution", () => {
+    const win = runMemoryIndexChecks(
+      makeDeps({ env: { USERPROFILE: "/win/u" }, fileExists: () => false }),
+    );
+    const winPaths = find(win, PATHS);
+    if (!winPaths.ok) expect(winPaths.reason).toContain("/win/u/.openclaw/openclaw.json");
+    // With no HOME at all, path.join("", ".openclaw", …) is relative.
+    const bare = runMemoryIndexChecks(makeDeps({ env: {}, fileExists: () => false }));
+    const barePaths = find(bare, PATHS);
+    if (!barePaths.ok) expect(barePaths.reason).toContain(".openclaw/openclaw.json");
+  });
+
+  it("runs from runDoctor only for the openclaw runtime", () => {
+    const without = runDoctor(makeDeps(), ["hermes"]);
+    expect(without.checks.some((c) => c.label === DIRS)).toBe(false);
+    const withOc = runDoctor(makeDeps(), ["openclaw"]);
+    expect(withOc.checks.some((c) => c.label === DIRS)).toBe(true);
+  });
+});
+
+describe("runEmbeddingsCheck", () => {
+  const EMB = "openclaw: memory embeddings";
+
+  it("passes a key-optional primary provider", () => {
+    const c = runEmbeddingsCheck({}, { provider: "local" });
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.note).toMatch(/provider=local .*without an API key/);
+  });
+
+  it("passes a key-optional fallback under the implicit default provider", () => {
+    const c = runEmbeddingsCheck({}, { fallback: "local" });
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.note).toMatch(/provider=openai \(default\), fallback=local/);
+  });
+
+  it("passes a key-optional fallback under an explicit remote provider", () => {
+    const c = runEmbeddingsCheck({}, { provider: "gemini", fallback: "local" });
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.note).toMatch(/provider=gemini, fallback=local/);
+  });
+
+  it("trusts an explicit provider without verifying its key", () => {
+    const c = runEmbeddingsCheck({}, { provider: "voyage" });
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.note).toMatch(/key not verified here/);
+  });
+
+  it("passes the implicit default when remote.apiKey is set", () => {
+    const c = runEmbeddingsCheck({}, { remote: { apiKey: "sk-x" } });
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.note).toMatch(/API key detected/);
+  });
+
+  it("passes the implicit default when $OPENAI_API_KEY is set", () => {
+    const c = runEmbeddingsCheck({ OPENAI_API_KEY: "sk-env" }, {});
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.note).toMatch(/API key detected/);
+  });
+
+  it("FAILs the keyless implicit default — the fresh-install trap", () => {
+    const c = runEmbeddingsCheck({}, {});
+    expect(c.label).toBe(EMB);
+    expect(c.ok).toBe(false);
+    if (!c.ok) {
+      expect(c.reason).toMatch(/will NOT build/);
+      expect(c.reason).toMatch(/fallback: 'local'/);
+    }
+  });
+
+  it("FAILs an explicit keyless fallback: 'none'", () => {
+    const c = runEmbeddingsCheck({}, { fallback: "none" });
+    expect(c.ok).toBe(false);
+  });
+
+  it("ignores blank strings and non-string values when resolving the config", () => {
+    const c = runEmbeddingsCheck(
+      { OPENAI_API_KEY: "  " },
+      { provider: "  ", fallback: 42, remote: { apiKey: "" } },
+    );
+    expect(c.ok).toBe(false);
   });
 });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -9,7 +9,19 @@
  *   2. The openclaw config file is readable.
  *   3. Each enabled runtime has its hook scripts / templates installed.
  *   4. The brain MCP proxy is on PATH.
+ *   5. The memory index is actually wired: the wiki + tastes dirs exist, both
+ *      sit in openclaw's `agents.defaults.memorySearch.extraPaths`, and the
+ *      embedding config can build an index on this machine (openclaw's
+ *      default provider is `openai`, which silently indexes nothing without
+ *      an API key — the #1 "memory_search finds nothing" fresh-install trap).
  */
+
+import JSON5 from "json5";
+import {
+  KEY_OPTIONAL_EMBEDDING_PROVIDERS,
+  digitalMeKnowledgePaths,
+  resolveOpenclawConfigPath,
+} from "./openclaw-memory.js";
 
 export type CheckResult =
   | { readonly ok: true; readonly label: string; readonly note?: string }
@@ -28,6 +40,12 @@ export type DoctorDeps = {
   readonly fileExists: (path: string) => boolean;
   readonly env: Readonly<Record<string, string | undefined>>;
   readonly which: (cmd: string) => string | undefined;
+  /**
+   * Read a file as UTF-8. Optional — when undefined, checks that need file
+   * CONTENT (the memory-index wiring group) report themselves as skipped
+   * rather than failing, mirroring the execCommand convention below.
+   */
+  readonly readFile?: (path: string) => string;
   /**
    * Absolute path to the brain-mcp-proxy bin file (resolved by the caller
    * from @digital-me/brain-mcp-proxy's BIN_PATH export). The doctor checks
@@ -245,6 +263,7 @@ export function runDoctor(
   // takes over if the state-dir copy is ever removed, and the dist/extensions
   // one is a stale build artifact. Deploy ONLY to the state dir.
   if (enabledRuntimes.includes("openclaw")) {
+    checks.push(...runMemoryIndexChecks(deps));
     checks.push(...runOpenclawShadowCheck(deps));
   }
 
@@ -312,6 +331,200 @@ export function runOpenclawShadowCheck(deps: DoctorDeps): CheckResult[] {
       `~/.openclaw/extensions install. Remove it, then re-run ` +
       `'digital-me install --runtime openclaw'.`,
   }));
+}
+
+// ── Memory-index wiring checks ────────────────────────────────────────────
+//
+// "memory_search finds nothing" on a fresh install has three distinct causes,
+// each individually green under the file-existence checks above: the wiki +
+// tastes dirs don't exist yet (the gateway only indexes extraPaths dirs that
+// exist at startup), the dirs aren't in extraPaths at all, or the embedding
+// config can't build an index (openclaw defaults to the `openai` provider,
+// which needs an API key). One check per cause, so a red doctor names the
+// exact repair.
+
+const KNOWLEDGE_DIRS_LABEL = "openclaw: knowledge dirs";
+const MEMORY_PATHS_LABEL = "openclaw: memory_search extraPaths";
+const EMBEDDINGS_LABEL = "openclaw: memory embeddings";
+
+/** Coerce an unknown JSON node to an object, or {} when it isn't one. */
+function asObject(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === "object" ? (v as Record<string, unknown>) : {};
+}
+
+function asTrimmedString(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const t = v.trim();
+  return t === "" ? undefined : t;
+}
+
+/**
+ * Verify the memory index is actually wired end-to-end: knowledge dirs on
+ * disk, both dirs listed in `agents.defaults.memorySearch.extraPaths`, and
+ * an embedding config that can index without manual surgery. Pure/data-layer.
+ */
+export function runMemoryIndexChecks(deps: DoctorDeps): CheckResult[] {
+  const checks: CheckResult[] = [];
+  const home = deps.env.HOME ?? deps.env.USERPROFILE ?? "";
+  const configPath = resolveOpenclawConfigPath(home, deps.env);
+  const knowledgePaths = digitalMeKnowledgePaths(home, undefined, deps.env);
+
+  const missingDirs = knowledgePaths.filter((d) => !deps.fileExists(d));
+  if (missingDirs.length === 0) {
+    checks.push({
+      ok: true,
+      label: KNOWLEDGE_DIRS_LABEL,
+      note: knowledgePaths.join(", "),
+    });
+  } else {
+    checks.push({
+      ok: false,
+      label: KNOWLEDGE_DIRS_LABEL,
+      reason:
+        `Missing ${missingDirs.join(", ")} — run 'digital-me setup' (or ` +
+        `'digital-me install --runtime openclaw') to create them. The openclaw ` +
+        `gateway only indexes extraPaths dirs that exist at startup, so a dir ` +
+        `created later stays unindexed until the next gateway restart.`,
+    });
+  }
+
+  if (!deps.fileExists(configPath)) {
+    checks.push({
+      ok: false,
+      label: MEMORY_PATHS_LABEL,
+      reason:
+        `${configPath} not found — run 'digital-me install --runtime openclaw' ` +
+        `to wire the wiki + tastes index.`,
+    });
+    checks.push({
+      ok: true,
+      label: EMBEDDINGS_LABEL,
+      note: "(skipped — openclaw config not found)",
+    });
+    return checks;
+  }
+  if (!deps.readFile) {
+    checks.push({
+      ok: true,
+      label: MEMORY_PATHS_LABEL,
+      note: "(skipped — caller did not provide readFile)",
+    });
+    checks.push({
+      ok: true,
+      label: EMBEDDINGS_LABEL,
+      note: "(skipped — caller did not provide readFile)",
+    });
+    return checks;
+  }
+
+  let cfg: Record<string, unknown>;
+  try {
+    // openclaw parses this file as JSON5 (comments + trailing commas are
+    // legal there) — mirror its dialect so a hand-annotated config the
+    // gateway reads fine isn't reported broken here.
+    cfg = asObject(JSON5.parse(deps.readFile(configPath)));
+  } catch (err) {
+    checks.push({
+      ok: false,
+      label: MEMORY_PATHS_LABEL,
+      reason:
+        `${configPath} could not be read as JSON5 ` +
+        `(${err instanceof Error ? err.message : String(err)}). Fix it, then ` +
+        `re-run 'digital-me install --runtime openclaw'.`,
+    });
+    checks.push({
+      ok: true,
+      label: EMBEDDINGS_LABEL,
+      note: "(skipped — openclaw config unreadable)",
+    });
+    return checks;
+  }
+
+  const ms = asObject(asObject(asObject(cfg.agents).defaults).memorySearch);
+  const extraPaths = Array.isArray(ms.extraPaths)
+    ? ms.extraPaths.filter((x): x is string => typeof x === "string")
+    : [];
+  const missingPaths = knowledgePaths.filter((p) => !extraPaths.includes(p));
+  if (missingPaths.length === 0) {
+    checks.push({
+      ok: true,
+      label: MEMORY_PATHS_LABEL,
+      note: `wiki + tastes wired in ${configPath}`,
+    });
+  } else {
+    checks.push({
+      ok: false,
+      label: MEMORY_PATHS_LABEL,
+      reason:
+        `agents.defaults.memorySearch.extraPaths is missing ` +
+        `${missingPaths.join(", ")} — run 'digital-me install --runtime openclaw' ` +
+        `(idempotent), then restart the openclaw gateway.`,
+    });
+  }
+
+  checks.push(runEmbeddingsCheck(deps.env, ms));
+  return checks;
+}
+
+/**
+ * Effective-embeddings viability. openclaw defaults the memory embedding
+ * provider to `openai` (remote, key required): with that IMPLICIT default and
+ * no detectable key, the index silently never builds — that exact case FAILs.
+ * An explicit provider choice is trusted (openclaw's own `openclaw doctor`
+ * validates keys/endpoints end-to-end); key-optional providers (`local`,
+ * `ollama`, `lmstudio`) — as primary or fallback — always pass. Exported for
+ * direct unit testing.
+ */
+export function runEmbeddingsCheck(
+  env: Readonly<Record<string, string | undefined>>,
+  memorySearch: Readonly<Record<string, unknown>>,
+): CheckResult {
+  const provider = asTrimmedString(memorySearch.provider);
+  const fallback = asTrimmedString(memorySearch.fallback);
+  if (provider && KEY_OPTIONAL_EMBEDDING_PROVIDERS.has(provider)) {
+    return {
+      ok: true,
+      label: EMBEDDINGS_LABEL,
+      note: `provider=${provider} (runs without an API key)`,
+    };
+  }
+  if (fallback && KEY_OPTIONAL_EMBEDDING_PROVIDERS.has(fallback)) {
+    return {
+      ok: true,
+      label: EMBEDDINGS_LABEL,
+      note:
+        `provider=${provider ?? "openai (default)"}, fallback=${fallback} — ` +
+        `index builds even without an API key`,
+    };
+  }
+  if (provider) {
+    return {
+      ok: true,
+      label: EMBEDDINGS_LABEL,
+      note:
+        `provider=${provider} — key not verified here; ` +
+        `'openclaw doctor' validates embeddings end-to-end`,
+    };
+  }
+  const remoteApiKey = asTrimmedString(asObject(memorySearch.remote).apiKey);
+  if (remoteApiKey ?? asTrimmedString(env.OPENAI_API_KEY)) {
+    return {
+      ok: true,
+      label: EMBEDDINGS_LABEL,
+      note: "provider=openai (default), API key detected",
+    };
+  }
+  return {
+    ok: false,
+    label: EMBEDDINGS_LABEL,
+    reason:
+      "memory_search embeddings default to the 'openai' provider but no API key " +
+      "was found ($OPENAI_API_KEY / agents.defaults.memorySearch.remote.apiKey) — " +
+      "the wiki + tastes index will NOT build. Re-run 'digital-me install " +
+      "--runtime openclaw' (seeds the keyless fallback: 'local'), or set " +
+      "agents.defaults.memorySearch.provider + key. 'openclaw doctor' validates " +
+      "embeddings end-to-end.",
+  };
 }
 
 /**

--- a/packages/cli/src/openclaw-memory.test.ts
+++ b/packages/cli/src/openclaw-memory.test.ts
@@ -8,20 +8,28 @@ import {
   ensureOpenclawMemoryPaths,
   mergeMemoryExtraPaths,
   resolveOpenclawConfigPath,
+  seedKeylessEmbeddingFallback,
   type MemoryPathIO,
 } from "./openclaw-memory.js";
 
 /** In-memory IO so the wiring is tested without touching disk. */
-function memIO(initial: Record<string, string> = {}): MemoryPathIO & { files: Record<string, string> } {
+function memIO(initial: Record<string, string> = {}): MemoryPathIO & {
+  files: Record<string, string>;
+  mkdirps: string[];
+} {
   const files = { ...initial };
+  const mkdirps: string[] = [];
   return {
     files,
+    mkdirps,
     exists: (p) => p in files,
     read: (p) => files[p]!,
     write: (p, data) => {
       files[p] = data;
     },
-    mkdirp: () => {},
+    mkdirp: (p) => {
+      mkdirps.push(p);
+    },
   };
 }
 
@@ -76,17 +84,55 @@ describe("mergeMemoryExtraPaths", () => {
   });
 });
 
+describe("seedKeylessEmbeddingFallback", () => {
+  it("seeds fallback: 'local' when the config has no embedding intent", () => {
+    const { cfg } = mergeMemoryExtraPaths({}, ["/a/wiki"]);
+    expect(seedKeylessEmbeddingFallback(cfg)).toBe(true);
+    expect((cfg as any).agents.defaults.memorySearch.fallback).toBe("local");
+  });
+
+  it.each([
+    ["provider", { provider: "gemini" }],
+    ["fallback", { fallback: "none" }],
+    ["remote", { remote: { apiKey: "k" } }],
+  ] as const)("never touches a config with an explicit %s", (_name, ms) => {
+    const { cfg } = mergeMemoryExtraPaths(
+      { agents: { defaults: { memorySearch: { ...ms } } } },
+      ["/a/wiki"],
+    );
+    expect(seedKeylessEmbeddingFallback(cfg)).toBe(false);
+    expect((cfg as any).agents.defaults.memorySearch.fallback).toBe(
+      (ms as Record<string, unknown>).fallback,
+    );
+  });
+});
+
 describe("ensureOpenclawMemoryPaths", () => {
-  it("writes a fresh config when none exists", () => {
+  it("writes a fresh config when none exists (and seeds the keyless fallback)", () => {
     const io = memIO();
     const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
     expect(res.ok).toBe(true);
     expect(res.added).toEqual(["/home/u/digital-me/wiki", "/home/u/digital-me/tastes"]);
+    expect(res.seededLocalFallback).toBe(true);
+    expect(res.json5Rewritten).toBe(false);
     const written = JSON.parse(io.files["/home/u/.openclaw/openclaw.json"]!);
     expect(written.agents.defaults.memorySearch.extraPaths).toEqual([
       "/home/u/digital-me/wiki",
       "/home/u/digital-me/tastes",
     ]);
+    // No embedding config at all → openclaw would default to `openai` (key
+    // required) and index nothing on a keyless machine. The keyless bundled
+    // fallback keeps a fresh install's index alive.
+    expect(written.agents.defaults.memorySearch.fallback).toBe("local");
+  });
+
+  it("creates the knowledge dirs so the gateway can watch them from first start", () => {
+    const io = memIO();
+    ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    expect(io.mkdirps).toContain("/home/u/digital-me/wiki");
+    expect(io.mkdirps).toContain("/home/u/digital-me/tastes");
+    // Config parent dir too (fresh machine has no ~/.openclaw yet).
+    expect(io.mkdirps).toContain("/home/u/.openclaw");
   });
 
   it("is idempotent — a second run adds nothing and does not rewrite", () => {
@@ -96,6 +142,7 @@ describe("ensureOpenclawMemoryPaths", () => {
     const snapshot = io.files["/home/u/.openclaw/openclaw.json"];
     const second = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
     expect(second.added).toEqual([]);
+    expect(second.seededLocalFallback).toBeUndefined();
     expect(io.files["/home/u/.openclaw/openclaw.json"]).toBe(snapshot);
   });
 
@@ -114,6 +161,65 @@ describe("ensureOpenclawMemoryPaths", () => {
       "/home/u/digital-me/wiki",
       "/home/u/digital-me/tastes",
     ]);
+    // remote block present = embedding intent → never seed over it.
+    expect(res.seededLocalFallback).toBe(false);
+    expect(written.agents.defaults.memorySearch.fallback).toBeUndefined();
+  });
+
+  it("seeds the keyless fallback even when both paths are already wired", () => {
+    // Upgrade path: an install from before the seeding existed re-runs the
+    // installer — added=[] must not short-circuit the seed-write.
+    const cfgPath = "/home/u/.openclaw/openclaw.json";
+    const io = memIO({
+      [cfgPath]: JSON.stringify({
+        agents: {
+          defaults: {
+            memorySearch: {
+              extraPaths: ["/home/u/digital-me/wiki", "/home/u/digital-me/tastes"],
+            },
+          },
+        },
+      }),
+    });
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    expect(res.ok).toBe(true);
+    expect(res.added).toEqual([]);
+    expect(res.seededLocalFallback).toBe(true);
+    const written = JSON.parse(io.files[cfgPath]!);
+    expect(written.agents.defaults.memorySearch.fallback).toBe("local");
+  });
+
+  it("accepts a JSON5 config (comments, trailing commas) like openclaw itself", () => {
+    // openclaw parses openclaw.json with the `json5` package — a
+    // hand-annotated config is legal for the gateway and must not abort
+    // the wiring (it used to: strict JSON.parse threw, the installer
+    // printed a warning nobody read, and memory_search indexed nothing).
+    const cfgPath = "/home/u/.openclaw/openclaw.json";
+    const io = memIO({
+      [cfgPath]: `{
+        // my hand-tuned config
+        agents: {
+          defaults: {
+            memorySearch: {
+              provider: 'gemini',
+              extraPaths: ["/home/u/digital-me/wiki",],
+            },
+          },
+        },
+      }`,
+    });
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    expect(res.ok).toBe(true);
+    expect(res.added).toEqual(["/home/u/digital-me/tastes"]);
+    expect(res.json5Rewritten).toBe(true);
+    expect(res.seededLocalFallback).toBe(false); // provider present
+    // Rewritten as plain JSON — openclaw's own config writer does the same.
+    const written = JSON.parse(io.files[cfgPath]!);
+    expect(written.agents.defaults.memorySearch.provider).toBe("gemini");
+    expect(written.agents.defaults.memorySearch.extraPaths).toEqual([
+      "/home/u/digital-me/wiki",
+      "/home/u/digital-me/tastes",
+    ]);
   });
 
   it("reports a malformed config instead of clobbering it", () => {
@@ -123,6 +229,16 @@ describe("ensureOpenclawMemoryPaths", () => {
     expect(res.ok).toBe(false);
     expect(res.added).toEqual([]);
     expect(io.files[cfgPath]).toBe("{not json"); // untouched
+  });
+
+  it("treats a parseable non-object config as empty rather than crashing", () => {
+    const cfgPath = "/home/u/.openclaw/openclaw.json";
+    const io = memIO({ [cfgPath]: "null" });
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    expect(res.ok).toBe(true);
+    expect(res.added).toHaveLength(2);
+    const written = JSON.parse(io.files[cfgPath]!);
+    expect(written.agents.defaults.memorySearch.extraPaths).toHaveLength(2);
   });
 
   it("resolves the config path under OPENCLAW_HOME", () => {
@@ -155,11 +271,16 @@ describe("ensureOpenclawMemoryPaths (default disk IO)", () => {
     expect(first.configPath).toBe(cfgPath);
     expect(first.added).toEqual([path.join(tmp, "dm", "wiki"), path.join(tmp, "dm", "tastes")]);
     expect(existsSync(cfgPath)).toBe(true);
+    // The knowledge dirs are created for real, so the gateway's watcher
+    // picks them up on its first post-install restart.
+    expect(existsSync(path.join(tmp, "dm", "wiki"))).toBe(true);
+    expect(existsSync(path.join(tmp, "dm", "tastes"))).toBe(true);
     const written = JSON.parse(readFileSync(cfgPath, "utf-8"));
     expect(written.agents.defaults.memorySearch.extraPaths).toEqual([
       path.join(tmp, "dm", "wiki"),
       path.join(tmp, "dm", "tastes"),
     ]);
+    expect(written.agents.defaults.memorySearch.fallback).toBe("local");
 
     // Second run reads the file back from disk and adds nothing.
     const second = ensureOpenclawMemoryPaths("/home/u", path.join(tmp, "dm"), env);

--- a/packages/cli/src/openclaw-memory.ts
+++ b/packages/cli/src/openclaw-memory.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import JSON5 from "json5";
 
 /**
  * Install-time wiring that makes openclaw's `memory_search` auto-index the
@@ -11,6 +12,23 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
  * `agents.defaults.memorySearch.extraPaths` in its config (default
  * `~/.openclaw/openclaw.json`). The installer appends the two trees there
  * idempotently, preserving any other memorySearch settings (provider, key, …).
+ *
+ * Three fresh-install traps this module defuses (each one shipped as a
+ * "memory_search finds nothing" bug report before it was handled here):
+ *
+ *  1. openclaw parses its config as **JSON5** (src/config/io.ts uses the
+ *     `json5` package), so comments / trailing commas are legal there. We
+ *     must parse the same dialect or a hand-annotated config silently
+ *     aborts the wiring. Writes stay plain 2-space JSON — exactly what
+ *     openclaw's own `writeConfigFile` emits when *it* rewrites the config.
+ *  2. The gateway indexes + watches only extraPaths dirs that EXIST when it
+ *     starts; missing ones are skipped and never re-attached until the next
+ *     restart. So the wiki + tastes dirs are created here, before the user
+ *     restarts the gateway.
+ *  3. openclaw's default embedding provider is `openai` (remote, key
+ *     required). A fresh machine with no key would build no index at all —
+ *     so when the config expresses no embedding intent, we seed
+ *     `fallback: "local"` (openclaw's bundled keyless embedder).
  */
 
 /** Tiered openclaw config path:
@@ -35,6 +53,14 @@ export function digitalMeKnowledgePaths(
   const root = wikiRoot ?? env.DIGITAL_ME_WIKI_ROOT ?? path.join(home, "digital-me");
   return [path.join(root, "wiki"), path.join(root, "tastes")];
 }
+
+/** Embedding providers openclaw can run without an API key (mirrors
+ *  `isKeyOptionalMemoryProvider` in openclaw's doctor-memory-search). */
+export const KEY_OPTIONAL_EMBEDDING_PROVIDERS: ReadonlySet<string> = new Set([
+  "local",
+  "ollama",
+  "lmstudio",
+]);
 
 /** Pure merge: ensure `agents.defaults.memorySearch.extraPaths` contains every
  *  path in `paths` (deduped, append-only). Returns the mutated config and the
@@ -63,6 +89,24 @@ export function mergeMemoryExtraPaths(
   return { cfg: root, added };
 }
 
+/** Pure: when the config expresses NO embedding intent (no `provider`, no
+ *  `fallback`, no `remote` block under memorySearch), seed
+ *  `fallback: "local"` so a keyless fresh machine still builds an index —
+ *  openclaw's default provider is `openai`, which needs an API key. Never
+ *  touches an explicit choice (even `fallback: "none"`). Call after
+ *  `mergeMemoryExtraPaths` (the memorySearch object is guaranteed then).
+ *  Returns true when it seeded. */
+export function seedKeylessEmbeddingFallback(cfg: Record<string, unknown>): boolean {
+  const agents = cfg.agents as Record<string, unknown>;
+  const defaults = agents.defaults as Record<string, unknown>;
+  const ms = defaults.memorySearch as Record<string, unknown>;
+  if (ms.provider !== undefined || ms.fallback !== undefined || ms.remote !== undefined) {
+    return false;
+  }
+  ms.fallback = "local";
+  return true;
+}
+
 /** Injectable filesystem seam so the wiring is unit-testable without disk. */
 export interface MemoryPathIO {
   exists(p: string): boolean;
@@ -83,11 +127,19 @@ export interface EnsureMemoryResult {
   added: string[];
   ok: boolean;
   error?: string;
+  /** true when `fallback: "local"` was seeded because the config had no
+   *  embedding configuration at all (see seedKeylessEmbeddingFallback). */
+  seededLocalFallback?: boolean;
+  /** true when the existing config needed openclaw's JSON5 dialect to parse
+   *  (comments, trailing commas, …) and the rewrite flattened it to plain
+   *  JSON — the same normalization openclaw's own config writer applies. */
+  json5Rewritten?: boolean;
 }
 
 /** Read the openclaw config (or start fresh), append the wiki + tastes dirs to
- *  memorySearch.extraPaths, and write it back. Idempotent: a second run adds
- *  nothing. A malformed existing config is left untouched and reported. */
+ *  memorySearch.extraPaths, create those dirs, and write the config back.
+ *  Idempotent: a second run adds nothing. A malformed existing config is left
+ *  untouched and reported. */
 export function ensureOpenclawMemoryPaths(
   home: string,
   wikiRoot: string | undefined,
@@ -97,20 +149,43 @@ export function ensureOpenclawMemoryPaths(
   const configPath = resolveOpenclawConfigPath(home, env);
   const paths = digitalMeKnowledgePaths(home, wikiRoot, env);
 
+  // The gateway indexes + watches only dirs that exist at startup — missing
+  // extraPaths entries are silently skipped until the NEXT restart. Create
+  // both trees now so the restart right after install picks them up.
+  for (const p of paths) io.mkdirp(p);
+
   let cfg: Record<string, unknown> = {};
+  let json5Only = false;
   if (io.exists(configPath)) {
+    const raw = io.read(configPath);
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(io.read(configPath));
-      if (parsed && typeof parsed === "object") cfg = parsed as Record<string, unknown>;
-    } catch (e) {
-      return { configPath, added: [], ok: false, error: (e as Error).message };
+      parsed = JSON.parse(raw);
+    } catch {
+      // openclaw itself parses this file as JSON5 (comments, trailing
+      // commas, unquoted keys are all legal there) — accept the same
+      // dialect instead of aborting the wiring on a hand-annotated config.
+      try {
+        parsed = JSON5.parse(raw);
+        json5Only = true;
+      } catch (e) {
+        return { configPath, added: [], ok: false, error: (e as Error).message };
+      }
     }
+    if (parsed && typeof parsed === "object") cfg = parsed as Record<string, unknown>;
   }
 
   const { cfg: merged, added } = mergeMemoryExtraPaths(cfg, paths);
-  if (added.length === 0) return { configPath, added, ok: true };
+  const seeded = seedKeylessEmbeddingFallback(merged);
+  if (added.length === 0 && !seeded) return { configPath, added, ok: true };
 
   io.mkdirp(path.dirname(configPath));
   io.write(configPath, JSON.stringify(merged, null, 2) + "\n");
-  return { configPath, added, ok: true };
+  return {
+    configPath,
+    added,
+    ok: true,
+    seededLocalFallback: seeded,
+    json5Rewritten: json5Only,
+  };
 }

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -222,11 +222,15 @@ describe("renderStarterConfig", () => {
 });
 
 describe("planWikiInit", () => {
-  it("lists wiki/, inbox/, .cache/ + root dir", () => {
+  it("lists wiki/, tastes/, inbox/, .cache/ + root dir", () => {
     const plan = planWikiInit({ wikiRoot: "/wiki-root", aliases: {} });
+    // tastes/ must exist from day one: it's wired into openclaw's
+    // memorySearch.extraPaths, and the gateway only indexes extraPaths dirs
+    // that exist at startup.
     expect(plan.dirsToCreate).toEqual([
       "/wiki-root",
       "/wiki-root/wiki",
+      "/wiki-root/tastes",
       "/wiki-root/inbox",
       "/wiki-root/.cache",
     ]);
@@ -239,6 +243,7 @@ describe("planWikiInit", () => {
       "/r/config.example.yaml",
       "/r/config.yaml",
       "/r/inbox/.gitkeep",
+      "/r/tastes/.gitkeep",
       "/r/wiki/.gitkeep",
     ]);
   });

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -272,6 +272,11 @@ export function planWikiInit(opts: {
     dirsToCreate: [
       root,
       path.join(root, "wiki"),
+      // The tastes tree ships empty but MUST exist from day one: the
+      // installer wires it into openclaw's memorySearch.extraPaths, and the
+      // gateway only indexes + watches extraPaths dirs that exist when it
+      // starts — a dir born later stays invisible until the next restart.
+      path.join(root, "tastes"),
       path.join(root, "inbox"),
       path.join(root, ".cache"),
     ],
@@ -300,6 +305,10 @@ export function planWikiInit(opts: {
       },
       {
         path: path.join(root, "wiki", ".gitkeep"),
+        contents: "",
+      },
+      {
+        path: path.join(root, "tastes", ".gitkeep"),
         contents: "",
       },
       {

--- a/packages/runtimes/claude-code/skills/digital-me/SKILL.md
+++ b/packages/runtimes/claude-code/skills/digital-me/SKILL.md
@@ -25,7 +25,7 @@ Key paths:
 | Agent type | Access method |
 |---|---|
 | Claude Code | `Read`/`Write` tools on `~/digital-me/` + `memory_search`/`memory_get` via `openclaw-brain` MCP |
-| OpenClaw subagents | `memory_search`/`memory_get` tools (wiki is in `memorySearch.extraPaths`) |
+| OpenClaw subagents | `memory_search`/`memory_get` tools (wiki + tastes are in `memorySearch.extraPaths`) |
 | Hermes Agent | `memory_search`/`memory_get` via `openclaw-brain` MCP |
 | Antigravity | Direct filesystem access to `~/digital-me/` |
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
     devDependencies:
       '@types/node':
         specifier: ^22.0.0


### PR DESCRIPTION
## User feedback

> "When they installed the digital me, the index is not working — I think the openclaw-native index needs the wiki and taste paths appended into memorySearch extraPaths."

The hypothesis was in the right area, but the append itself already existed and usually ran. Thorough root-causing against openclaw's actual source found **four independent fresh-install gaps**, each invisible to the old doctor:

## Root causes → fixes

| # | Gap | Fix |
|---|-----|-----|
| 1 | **JSON5 config parity.** openclaw parses `openclaw.json` as JSON5 (`src/config/io.ts` uses the `json5` package) — comments/trailing commas are legal there. The installer used strict `JSON.parse`, so a hand-annotated config silently aborted the extraPaths append (one easily-missed WARN in a wall of setup output). | Parse with `json5` (openclaw's own dialect, pinned to the same 2.2.3 line). Writes stay plain 2-space JSON — identical normalization to openclaw's own `writeConfigFile` — with a printed note when a JSON5 file was flattened. |
| 2 | **`tastes/` never scaffolded.** `planWikiInit` created `wiki/`, `inbox/`, `.cache/` but not `tastes/`, while the installer appended `<root>/tastes` to extraPaths. The gateway only indexes+watches extraPaths dirs that **exist at startup** — missing ones are skipped and never re-attached until the next restart — so tastes stayed permanently invisible. | `setup` scaffolds `tastes/` (+ `.gitkeep`), and `ensureOpenclawMemoryPaths` now `mkdirp`s both trees so the standalone `install --runtime openclaw` path is covered too. |
| 3 | **Keyless embeddings.** openclaw's default memory embedding provider is **`openai` (remote, key required)** — a fresh machine with no OpenAI key builds no index at all, silently. This is the most likely cause of the reported feedback. | When the config expresses no embedding intent (no `provider`/`fallback`/`remote`), the installer seeds `fallback: "local"` (openclaw's bundled keyless node-llama-cpp embedder — key-optional per openclaw's own doctor-memory-search). Explicit choices — even `fallback: "none"` — are never touched. |
| 4 | **Doctor blindness.** The only openclaw-config check was file **existence** — "all green" said nothing about the index. | Three new checks: knowledge dirs exist on disk (with the startup-watch explanation), both trees present in `agents.defaults.memorySearch.extraPaths` (JSON5-parsed), and embeddings viable (the implicit keyless `openai` default FAILs with the exact repair; explicit provider choices are trusted and deferred to `openclaw doctor` — no false reds on working setups). |

## Verification

- `pnpm run ci` fully green — sanitize, build, typecheck, lint, knip, **100% coverage workspace-wide** (cli: 191 tests).
- Sandbox-HOME e2e: fresh-machine install → config + dirs + fallback seeded; JSON5 commented config → append succeeds, provider preserved, rewrite note printed; broken state → doctor shows 3 precise FAILs; post-install → 10/10 green.
- Read-only doctor against a live wired machine: 11/11, new checks read the real config correctly (`provider=gemini, fallback=local`) — no false FAILs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)