### PR TITLE
ci(deps): make the Dependabot queue drain itself instead of silting up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for GitHub's merge queue: the queue builds a candidate branch and
+  # waits for the required checks to report against it. Without this trigger the
+  # checks never run there and every queued PR hangs until it times out.
+  merge_group:
 
 jobs:
   sanitize:

--- a/.github/workflows/dependabot-maintenance.yml
+++ b/.github/workflows/dependabot-maintenance.yml
@@ -1,0 +1,82 @@
+name: Dependabot maintenance
+
+# Daily janitor for the Dependabot PR queue.
+#
+# This job deliberately does NOT decide whether anything is safe to merge. That
+# decision stays where it belongs:
+#   - dependabot-auto-merge.yml arms auto-merge using authoritative update-type
+#     metadata, which is only available on a `pull_request` event;
+#   - branch protection evaluates the gate at merge time, not on a timer.
+#
+# All this does is remove the friction that stops those two from reaching a
+# decision: nudge out-of-date branches so Dependabot rebases them, close PRs
+# that are permanently red on a required check, and report what needs a human.
+# It never merges, never force-pushes, and never touches a PR that Dependabot
+# did not open.
+
+on:
+  schedule:
+    # Daily. Branch protection requires up-to-date branches, so the queue drains
+    # roughly one PR per CI cycle — a weekly sweep would never catch up.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report what would happen without changing anything"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write # delete the branch of a closed PR
+  pull-requests: write # comment and close
+  issues: write # report a failing sweep
+
+concurrency:
+  group: dependabot-maintenance
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep the Dependabot queue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Sweep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # Scheduled runs act; manual runs report unless explicitly told not to.
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
+          # Only one PR can land per CI cycle anyway, so a low cap keeps a bad
+          # day from burning Actions minutes on rebases that immediately go
+          # stale again.
+          MAX_REBASES: "3"
+          STALE_DAYS: "30"
+          # Keep in sync with the required status checks on `main`. Drift here
+          # is fail-safe in the right direction: a check missing from this list
+          # means a PR is left open for a human, never wrongly closed.
+          REQUIRED_CHECKS: >-
+            ["Sanitize gate (forbidden-pattern scan)",
+             "Build, typecheck, lint, knip, test",
+             "dream-cycle (pytest + sdist + wheel)"]
+        run: bash scripts/dependabot-sweep.sh
+
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="Dependabot maintenance sweep is failing"
+          body="The scheduled Dependabot maintenance sweep failed. The Dependabot queue is not being maintained until this is fixed.
+
+          Run: ${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}"
+          existing=$(gh issue list --repo "$REPO" --state open --search "$title in:title" \
+            --json number --jq '.[0].number // ""')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+          else
+            gh issue create --repo "$REPO" --title "$title" --body "$body"
+          fi

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,20 @@ packages:
 allowBuilds:
   better-sqlite3: true
   esbuild: true
+# Supply-chain cooling-off. Refuse any version published less than 7 days ago.
+#
+# Dependabot patch/minor PRs merge unattended once CI is green, and a green test
+# suite is not a defense against a compromised release — an attacker publishing a
+# malicious patch to a legitimate package makes sure the tests still pass. What
+# actually protects us is not being among the first to install it: these
+# compromises are typically caught and yanked within hours to a couple of days.
+# This trades a week of latency on new versions for not being patient zero.
+#
+# Security advisories are unaffected in practice — by the time a CVE fix is
+# advertised the version is normally already older than this window. If a genuine
+# same-day emergency fix is ever needed, bump it manually rather than lowering
+# this floor.
+minimumReleaseAge: 10080 # minutes = 7 days
 # Security floors for transitive (lint-time) dev deps flagged by Dependabot.
 # brace-expansion GHSA-3jxr-9vmj-r5cp (<5.0.7) and js-yaml GHSA-h67p-54hq-rp68 (<=4.1.1).
 # Caret floors so Dependabot can still bump within the major.

--- a/scripts/dependabot-sweep.sh
+++ b/scripts/dependabot-sweep.sh
@@ -28,6 +28,13 @@ RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_
 summary() { printf '%s\n' "$*" >>"${GITHUB_STEP_SUMMARY:-/dev/stdout}"; }
 changing() { [ "$DRY_RUN" != "true" ]; }
 
+# Skip ledger. Every PR this run declines to act on gets a line here with the
+# reason. Without it a run that silently skipped everything is indistinguishable
+# from a run that had nothing to do — which is exactly how the auto-merge
+# workflow this replaces managed to fail on every PR for months unnoticed.
+ledger=""
+note() { ledger+="- ${1}"$'\n'; }
+
 if ! changing; then
   echo "DRY RUN — no pull request will be commented on or closed."
 fi
@@ -122,14 +129,16 @@ summary ""
 summary "### Rebase nudges"
 nudged=0
 while read -r pr; do
-  if [ "$nudged" -ge "$MAX_REBASES" ]; then
-    echo "Reached MAX_REBASES=${MAX_REBASES}; stopping."
-    break
-  fi
   number=$(jq -r '.number' <<<"$pr")
   sha=$(jq -r '.sha' <<<"$pr")
   state=$(jq -r '.state' <<<"$pr")
   marker="<!-- maintenance-sweep: ${sha} -->"
+
+  if [ "$nudged" -ge "$MAX_REBASES" ]; then
+    echo "#${number}: rebase cap reached; deferring."
+    note "#${number} — not nudged: hit \`MAX_REBASES=${MAX_REBASES}\` this run, deferred to the next"
+    continue
+  fi
 
   # Skip if this exact head has already been nudged. When Dependabot acts the
   # head SHA changes and the PR becomes eligible again, so this dedupes without
@@ -137,6 +146,7 @@ while read -r pr; do
   if gh pr view "$number" --repo "$REPO" --json comments \
     --jq '[.comments[].body] | join("\n")' | grep -qF "$marker"; then
     echo "#${number} already nudged at ${sha}; skipping."
+    note "#${number} — not nudged: already asked at head \`${sha:0:8}\`, waiting on Dependabot to act"
     continue
   fi
 
@@ -174,4 +184,56 @@ if [ -z "$unarmed" ]; then
   summary "_none_"
 else
   summary "$unarmed"
+fi
+
+# --- 4. The skip ledger ------------------------------------------------------
+# Reads from a process substitution, never a pipe: a pipe would run the loop in
+# a subshell and silently discard everything appended to $ledger.
+collect() {
+  while read -r line; do
+    if [ -n "$line" ]; then note "$line"; fi
+  done
+}
+
+# Out of date, but nothing is waiting to consume a rebase.
+collect < <(jq -r '
+  .[]
+  | select(.mergeStateStatus == "BEHIND" or .mergeStateStatus == "DIRTY")
+  | select(.autoMergeRequest == null)
+  | "#\(.number) — not nudged: `\(.mergeStateStatus)` but no auto-merge armed, so a rebase would buy nothing"
+  ' <<<"$prs")
+
+# Red on a required check, but not yet old enough to close.
+collect < <(jq -r --argjson req "$REQUIRED_CHECKS" --arg cutoff "$cutoff" '
+  .[]
+  | select(.createdAt >= $cutoff)
+  | . as $pr
+  | [ .statusCheckRollup[]?
+      | select(.conclusion == "FAILURE")
+      | select(.name as $n | $req | index($n))
+      | .name ] as $failing
+  | select($failing | length > 0)
+  | "#\($pr.number) — not closed: red on `\($failing | join("`, `"))`, but opened \($pr.createdAt[0:10]) and the close threshold is \($cutoff[0:10])"
+  ' <<<"$prs")
+
+# Drift signal. A failing check absent from REQUIRED_CHECKS can never count
+# toward a close, which is the fail-safe direction — but if branch protection
+# gained a check and this list did not, that silence is the bug. Say so.
+collect < <(jq -r --argjson req "$REQUIRED_CHECKS" '
+  .[]
+  | . as $pr
+  | [ .statusCheckRollup[]?
+      | select(.conclusion == "FAILURE")
+      | select(.name as $n | $req | index($n) | not)
+      | .name ] as $other
+  | select($other | length > 0)
+  | "#\($pr.number) — failing `\($other | join("`, `"))`, ignored: not in `REQUIRED_CHECKS`. If branch protection now requires it, update the list"
+  ' <<<"$prs")
+
+summary ""
+summary "### Skipped — and why"
+if [ -z "$ledger" ]; then
+  summary "_nothing was skipped_"
+else
+  summary "$ledger"
 fi

--- a/scripts/dependabot-sweep.sh
+++ b/scripts/dependabot-sweep.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Janitor for the Dependabot PR queue. Driven by
+# .github/workflows/dependabot-maintenance.yml — see that file for the rationale.
+#
+# This script never merges anything. Deciding that a bump is safe to land needs
+# Dependabot's update-type metadata (only available on a `pull_request` event)
+# and branch protection's merge-time evaluation; neither is available here, so
+# the decision is left entirely to dependabot-auto-merge.yml and to GitHub. All
+# this does is clear the friction that stops those two from reaching a decision.
+#
+# Environment:
+#   REPO             owner/name (required)
+#   GH_TOKEN         token for `gh` (required)
+#   DRY_RUN          "true" to report without changing anything (default true)
+#   MAX_REBASES      max branches to nudge per run (default 3)
+#   STALE_DAYS       close required-check failures older than this (default 30)
+#   REQUIRED_CHECKS  JSON array of required status check names (required)
+set -euo pipefail
+
+REPO="${REPO:?REPO must be set}"
+DRY_RUN="${DRY_RUN:-true}"
+MAX_REBASES="${MAX_REBASES:-3}"
+STALE_DAYS="${STALE_DAYS:-30}"
+REQUIRED_CHECKS="${REQUIRED_CHECKS:?REQUIRED_CHECKS must be a JSON array}"
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_RUN_ID:-manual}"
+
+summary() { printf '%s\n' "$*" >>"${GITHUB_STEP_SUMMARY:-/dev/stdout}"; }
+changing() { [ "$DRY_RUN" != "true" ]; }
+
+if ! changing; then
+  echo "DRY RUN — no pull request will be commented on or closed."
+fi
+
+prs=$(gh pr list --repo "$REPO" --state open --author "app/dependabot" --limit 100 \
+  --json number,title,createdAt,headRefOid,mergeStateStatus,autoMergeRequest,statusCheckRollup)
+
+total=$(jq 'length' <<<"$prs")
+echo "Open Dependabot PRs: $total"
+summary "## Dependabot maintenance"
+summary ""
+summary "Open Dependabot PRs: **$total**"
+if ! changing; then
+  summary ""
+  summary "_Dry run — nothing was changed._"
+fi
+
+if [ "$total" -eq 0 ]; then
+  exit 0
+fi
+
+# GNU date on the runner; the BSD form keeps this runnable on macOS for testing.
+cutoff=$(date -u -d "${STALE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+  date -u -v-"${STALE_DAYS}"d +%Y-%m-%dT%H:%M:%SZ)
+
+# --- 1. Close PRs that are permanently red on a required check ---------------
+# A dependency major that breaks the build never goes green on its own, and each
+# one left open eats into `open-pull-requests-limit` — which starves genuine
+# security updates from being opened at all.
+stale_red=$(jq -c --argjson req "$REQUIRED_CHECKS" --arg cutoff "$cutoff" '
+  [ .[]
+    | select(.createdAt < $cutoff)
+    | { number, title,
+        failing: [ .statusCheckRollup[]?
+                   | select(.conclusion == "FAILURE")
+                   | select(.name as $n | $req | index($n))
+                   | .name ] }
+    | select(.failing | length > 0) ]' <<<"$prs")
+
+summary ""
+summary "### Closed — red on a required check for >${STALE_DAYS}d"
+if [ "$(jq 'length' <<<"$stale_red")" -eq 0 ]; then
+  summary "_none_"
+fi
+
+while read -r pr; do
+  number=$(jq -r '.number' <<<"$pr")
+  title=$(jq -r '.title' <<<"$pr")
+  failing=$(jq -r '.failing | join("`, `")' <<<"$pr")
+  echo "Closing #${number} (${title}) — failing: ${failing}"
+  summary "- #${number} — failing \`${failing}\`"
+  changing || continue
+  gh pr close "$number" --repo "$REPO" --delete-branch --comment "$(
+    cat <<EOF
+Closing automatically: this has been red on the required check \`${failing}\` for
+more than ${STALE_DAYS} days, and a version bump alone will not turn it green —
+it needs migration work.
+
+Reopen it once that work is planned, or ignore this major in
+\`.github/dependabot.yml\` if the upgrade is off the table. Closing rather than
+leaving it open keeps the ecosystem under its \`open-pull-requests-limit\`, so
+security updates can still be opened.
+
+— [dependabot-maintenance](${RUN_URL})
+EOF
+  )"
+done < <(jq -c '.[]' <<<"$stale_red")
+
+# --- 2. Nudge out-of-date branches -------------------------------------------
+# `@dependabot rebase` rather than `gh pr update-branch`: pushing our own merge
+# commit onto a Dependabot branch makes Dependabot treat the PR as
+# human-modified and stop managing it. A rebase keeps it in charge, and keeps
+# the resulting history linear.
+#
+# Only PRs with auto-merge already armed are nudged. A rebase is only worth a
+# CI cycle if something is waiting to consume the result; rebasing a PR that
+# needs human review (every major) just burns minutes and goes stale again
+# before anyone looks. Those are reported in section 3 instead.
+#
+# BEHIND is an out-of-date branch; DIRTY is a conflict, which in a pnpm monorepo
+# is the common one — every landed bump rewrites the same lockfile and conflicts
+# whatever is queued behind it. `@dependabot rebase` regenerates the branch and
+# resolves both.
+behind=$(jq -c --argjson skip "$(jq '[.[].number]' <<<"$stale_red")" '
+  [ .[]
+    | select(.mergeStateStatus == "BEHIND" or .mergeStateStatus == "DIRTY")
+    | select(.autoMergeRequest != null)
+    | select(.number as $n | $skip | index($n) | not)
+    | { number, sha: .headRefOid, state: .mergeStateStatus } ]' <<<"$prs")
+
+summary ""
+summary "### Rebase nudges"
+nudged=0
+while read -r pr; do
+  if [ "$nudged" -ge "$MAX_REBASES" ]; then
+    echo "Reached MAX_REBASES=${MAX_REBASES}; stopping."
+    break
+  fi
+  number=$(jq -r '.number' <<<"$pr")
+  sha=$(jq -r '.sha' <<<"$pr")
+  state=$(jq -r '.state' <<<"$pr")
+  marker="<!-- maintenance-sweep: ${sha} -->"
+
+  # Skip if this exact head has already been nudged. When Dependabot acts the
+  # head SHA changes and the PR becomes eligible again, so this dedupes without
+  # storing any state — and without nagging the same PR every morning.
+  if gh pr view "$number" --repo "$REPO" --json comments \
+    --jq '[.comments[].body] | join("\n")' | grep -qF "$marker"; then
+    echo "#${number} already nudged at ${sha}; skipping."
+    continue
+  fi
+
+  echo "Nudging #${number} (${state}, head ${sha})"
+  summary "- #${number} — \`${state}\`"
+  nudged=$((nudged + 1))
+  changing || continue
+  gh pr comment "$number" --repo "$REPO" --body "$(
+    cat <<EOF
+@dependabot rebase
+
+${marker}
+EOF
+  )"
+done < <(jq -c '.[]' <<<"$behind")
+
+if [ "$nudged" -eq 0 ]; then
+  summary "_none_"
+fi
+
+# --- 3. Report, don't act ----------------------------------------------------
+# A green Dependabot PR with no auto-merge armed means the arming workflow
+# either did not run or deliberately declined (a major, which is meant to get a
+# human's attention). Either way this script must not guess: arming it here
+# would bypass the update-type metadata that makes that call safe.
+unarmed=$(jq -r '
+  [ .[]
+    | select(.autoMergeRequest == null)
+    | select(any(.statusCheckRollup[]?; .conclusion == "FAILURE") | not)
+    | "- #\(.number) — \(.title)" ] | join("\n")' <<<"$prs")
+
+summary ""
+summary "### Green, no auto-merge armed — needs a human decision"
+if [ -z "$unarmed" ]; then
+  summary "_none_"
+else
+  summary "$unarmed"
+fi


### PR DESCRIPTION
The auto-merge workflow has been erroring on **every** Dependabot PR since it was added:

```
GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)
```

`allow_auto_merge` was never turned on at the repo level. So nothing merged unattended, and 11 PRs piled up going back to June — enough to sit on the npm `open-pull-requests-limit: 10`, which silently stops Dependabot from opening **new** PRs, security updates included. That was the actual risk here: the backlog was not just untidy, it was suppressing security updates.

The setting is now enabled (done outside this PR — it is a repo setting, not a file). This PR adds the two pieces that keep it unblocked.

## 1. A daily janitor

`.github/workflows/dependabot-maintenance.yml` + `scripts/dependabot-sweep.sh`.

The design point worth reviewing: **the cron never decides that anything is safe to merge.** That call needs Dependabot's update-type metadata, which only exists on a `pull_request` event, plus branch protection's merge-time evaluation — neither is available to a scheduled job. So the sweep only clears the friction that stops those two from reaching a decision. It nudges stale branches, closes permanently-red PRs, and reports the rest.

That is the difference between a job you can leave running for a year and one you have to babysit.

Rails:

| Rail | Why |
|---|---|
| Never merges, never force-pushes, only touches `app/dependabot` PRs | The merge decision stays with branch protection |
| `@dependabot rebase`, not `gh pr update-branch` | Pushing our own merge commit onto a Dependabot branch makes Dependabot treat the PR as human-modified and **abandon** it |
| Only nudges PRs with auto-merge already armed | A rebase is only worth a CI cycle if something will consume it |
| Capped at 3 nudges/run | `strict: true` means only one can land per CI cycle anyway |
| Dedupes on head SHA via an HTML-comment marker | Nudged once per head, not every morning |
| `REQUIRED_CHECKS` drift is fail-safe | An unlisted check leaves a PR open for a human; it can never cause a wrongful close |
| Manual runs dry by default; failures open an issue | Reviewable before it ever acts, and never fails silently |

## 2. A `merge_group` trigger on CI

Prerequisite for the merge queue. `strict: true` on `main` is what serializes everything into one merge per CI cycle, and a merge queue is the real fix for that. But enabling the queue before required checks report against its candidate branch would hang every queued PR — so the trigger has to land first. **Suggested follow-up: turn the queue on after this merges.**

## Verification

Not just dry runs — the chain was proven end to end on the live queue:

- [#58](https://github.com/Amyssjj/digital-me/pull/58) (esbuild / typebox / mcp-sdk / recharts) **merged unattended**, the first Dependabot PR in this repo ever to do so.
- That merge conflicted [#34](https://github.com/Amyssjj/digital-me/pull/34)'s lockfile — which is exactly what caught the sweep missing `DIRTY`. In a pnpm monorepo `DIRTY` is *more* common than `BEHIND`, since every landed bump rewrites the same lockfile. Now handled.
- An earlier revision spent all three nudge slots rebasing majors that could never land without review; hence the auto-merge-armed filter.

## Also done outside this PR

Closed as permanently red on a required check — each needs migration work, not a bump:

- [#40](https://github.com/Amyssjj/digital-me/pull/40) tailwind 4 → tracked in #61
- [#36](https://github.com/Amyssjj/digital-me/pull/36) knip 6 → tracked in #62
- [#15](https://github.com/Amyssjj/digital-me/pull/15) typescript 7 → tracked in #63

Six green **majors** remain open and are intentionally untouched — they need a human decision, and the sweep reports rather than acts on them. Note that [#41](https://github.com/Amyssjj/digital-me/pull/41) (react 19) and [#37](https://github.com/Amyssjj/digital-me/pull/37) (react-dom 19) must land **together**; merging either alone leaves react and react-dom on mismatched majors, which CI would pass and the runtime would not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)