### PR TITLE
fix(security): gate the @claude trigger + npm token, clear 9 vulnerability alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,19 @@
+# Cooling-off periods (`cooldown:` below) delay Dependabot from opening a PR for
+# a freshly published version. This is the load-bearing supply-chain guard, and
+# it has to live here rather than only in pnpm-workspace.yaml's
+# `minimumReleaseAge`, because that setting cannot see this path at all:
+#
+#   - CI installs with `--frozen-lockfile`, which does no resolution, so the
+#     maturity constraint is never evaluated (verified: a frozen install passed
+#     with a 6-day-old package in the lockfile under a 7-day floor);
+#   - Dependabot resolves and writes the lockfile itself, and does not read
+#     pnpm's settings.
+#
+# So without `cooldown`, a malicious release published an hour ago could be
+# proposed, pass CI, and auto-merge. `minimumReleaseAge` still earns its place
+# for local and manual resolution; the two are complementary, not redundant.
+#
+# Security updates are not delayed by cooldown — only version updates are.
 version: 2
 updates:
   # JS/TS workspace — root manifest plus every package in the pnpm monorepo.
@@ -8,6 +24,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      # Patch and minor are the ones that auto-merge without a human reading the
+      # diff, so they carry the full window. Majors always stop for review, and
+      # delaying them only delays the migration work becoming visible.
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 7
+      semver-major-days: 3
     groups:
       dev-dependencies:
         dependency-type: development
@@ -29,6 +53,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      # pip is not a SemVer ecosystem to Dependabot, so only default-days applies.
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
 
@@ -37,6 +64,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     # One grouped PR for all action bumps instead of one PR per action.
     groups:
       github-actions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,10 +10,28 @@ on:
 
 jobs:
   claude:
+    # Two gates, both required.
+    #
+    # 1. The `@claude` mention.
+    # 2. The author must be trusted. This repository is public, so *anyone* can
+    #    open an issue and comment — and these events run from the default branch
+    #    with access to secrets, so an ungated trigger would hand a stranger a
+    #    job holding `contents: write` and the Claude OAuth token.
+    #
+    # claude-code-action performs its own write-permission check, so this is
+    # defence in depth rather than the only thing standing in the way. It is
+    # here because the effective gate should be readable in this file: a control
+    # that lives only inside a third-party action is invisible at review time,
+    # and silently inherits whatever that action's default becomes.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      ) && contains(
+        fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        github.event.comment.author_association || github.event.review.author_association
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -24,6 +24,17 @@ jobs:
   publish:
     name: Build bundle + publish to npm
     runs-on: ubuntu-latest
+    # Gate the npm credential behind an environment. Unlike the dream-cycle
+    # publish, which uses PyPI trusted publishing and holds no long-lived
+    # secret, this job carries `DM_NPM_TOKEN` — a standing token that can push a
+    # release under our name. `workflow_dispatch` means anyone with write access
+    # can start a publish, so the environment's required reviewer is what makes
+    # a release a deliberate act rather than a side effect of a pushed tag.
+    #
+    # NOTE: the `npm` environment must exist with a required reviewer before this
+    # merges. GitHub auto-creates a referenced environment with NO protection
+    # rules, which would silently make this line decorative.
+    environment: npm
     permissions:
       contents: read
       id-token: write # npm provenance

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@5: ^5.0.7
-  js-yaml@4: ^4.2.0
+  brace-expansion@1: ^1.1.16
+  brace-expansion@2: ^2.1.4
+  brace-expansion@5: ^5.0.9
+  js-yaml@4: ^4.3.1
+  shell-quote@1: ^1.9.0
+  body-parser@1: ^1.20.6
 
 importers:
 
@@ -1434,23 +1438,19 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@1.20.5:
-    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -2195,8 +2195,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2905,8 +2905,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -3653,7 +3653,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4335,7 +4335,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@1.20.5:
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -4345,7 +4345,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.3
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -4366,18 +4366,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.9:
     dependencies:
@@ -4483,7 +4479,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.10.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -4798,7 +4794,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.5
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -5177,7 +5173,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5643,7 +5639,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
@@ -5651,11 +5647,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -6162,7 +6158,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,9 +22,30 @@ allowBuilds:
 # same-day emergency fix is ever needed, bump it manually rather than lowering
 # this floor.
 minimumReleaseAge: 10080 # minutes = 7 days
-# Security floors for transitive (lint-time) dev deps flagged by Dependabot.
-# brace-expansion GHSA-3jxr-9vmj-r5cp (<5.0.7) and js-yaml GHSA-h67p-54hq-rp68 (<=4.1.1).
+# Security floors for transitive deps flagged by Dependabot alerts.
 # Caret floors so Dependabot can still bump within the major.
+#
+# These floors ROT. A floor fixes the advisories known when it was written; a
+# later advisory against the same major leaves the floor looking authoritative
+# while the tree stays vulnerable. `^5.0.7` below was correct in June and was
+# still sitting there in August, two advisories out of date. `pnpm update -r`
+# will not surface that either — it no-ops for a transitive whose range is
+# already satisfied. Dependabot *security* updates are the thing that catches
+# it, which is why they are now enabled on the repo.
+#
+# When adding a floor, floor EVERY major present in the tree, not just the one
+# named in the alert you happened to read. brace-expansion is here three times
+# for exactly that reason.
 overrides:
-  brace-expansion@5: ^5.0.7
-  js-yaml@4: ^4.2.0
+  # ReDoS: GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895
+  brace-expansion@1: ^1.1.16
+  brace-expansion@2: ^2.1.4
+  brace-expansion@5: ^5.0.9
+  # GHSA-h67p-54hq-rp68, GHSA-5p4m-2wfm-xmqj
+  js-yaml@4: ^4.3.1
+  # Command injection: GHSA-395f-4hp3-45gv
+  shell-quote@1: ^1.9.0
+  # GHSA-v422-hmwv-36x6. Scoped to @1 deliberately: the advisory covers only
+  # `< 1.20.6`, and an unscoped `body-parser: ^1.20.6` drags the tree's
+  # non-vulnerable 2.3.0 backwards across a major to "fix" a hole it never had.
+  body-parser@1: ^1.20.6


### PR DESCRIPTION
Follows the config-surface pass on OSS safety. Two commits, deliberately separate concerns — read them individually.

## 1. Trigger and credential gates ([51d37bf](https://github.com/Amyssjj/digital-me/commit/51d37bf))

**`@claude` was reachable by any GitHub user.** This repo is public, `issue_comment` runs from the default branch with secrets, and that job holds `contents: write`, `issues: write`, and `CLAUDE_CODE_OAUTH_TOKEN`. `claude-code-action` does perform its own write-permission check, so I have no reason to think we were exposed — but that control is invisible when reading the workflow and inherits whatever the action's default becomes. Now gated on `author_association` where the permissions are declared.

**The npm token had no environment gate.** This inverts the assumption I started with: *PyPI* is the well-protected one — trusted publishing over OIDC, no long-lived secret. The npm job carries `DM_NPM_TOKEN`, a standing credential that can publish under our name, and `workflow_dispatch: {}` lets any write-access actor start a release. It was the softer target and the ungated one.

## 2. Nine vulnerability alerts, and a correction ([5891c8e](https://github.com/Amyssjj/digital-me/commit/5891c8e))

Enabling Dependabot alerts surfaced **9 advisories, 7 high**. Invisible, not absent — the repo had dependency automation but no security-update channel.

Why the existing floors missed them:

| | |
|---|---|
| **Floors rot** | `brace-expansion@5: ^5.0.7` was right in June, two advisories stale by August, still looking authoritative. `pnpm update -r` no-ops for a satisfied transitive, so nothing surfaces it. |
| **Scope** | The floor covered only the v5 line; the tree also carried vulnerable 1.1.15 and 2.1.0. Floor every major present, not just the one in the alert you read. |

`body-parser@1` is scoped deliberately — my first attempt used an unscoped `body-parser: ^1.20.6`, which dragged the tree's **non-vulnerable 2.3.0 backwards across a major** to fix a hole it never had. Caught by reading the lockfile diff rather than trusting the alert list.

### The correction worth your attention

**`minimumReleaseAge` does not cover the auto-merge path**, contrary to what I claimed when I added it. It's a *resolution* constraint, and that path never resolves:

- CI installs with `--frozen-lockfile` — no resolution, constraint never evaluated
- Dependabot writes the lockfile itself and does not read pnpm settings

Verified, not assumed: a frozen install passes **right now** with a 1-day-old js-yaml in the lockfile under a 7-day floor. A release published an hour ago could be proposed, pass CI, and auto-merge without the floor ever running.

Dependabot's `cooldown` is the control that sits on that path, now set across all three ecosystems — 7 days for patch/minor (what auto-merges unattended), 3 for majors (always human-reviewed, so delay only postpones visibility). `minimumReleaseAge` stays for local resolution; complementary, not redundant.

### One deliberate exception

js-yaml 4.3.1 is 1 day old, so our own 7-day floor rejects the very security fix it exists to protect. Taking it: a known-exploitable high beats a speculative risk, and this is the "bump manually rather than lower the floor" case the setting's own comment describes. Resolved with the constraint relaxed for that single install; lockfile diff audited afterwards and it touches only the six floored packages.

## Verification

Frozen install, sanitize gate, build, typecheck, lint, knip, and all 191 tests pass locally.

## Two manual steps this PR cannot do

Both are repo settings, not in-tree, and both were classifier-blocked for me:

1. Create the **`npm` environment with a required reviewer** — GitHub auto-creates a referenced environment with *no* protection rules, which would make `environment: npm` decorative.
2. Add a required reviewer to the existing **`pypi`** environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)