### PR TITLE
fix(pipeline): stop the nightly digest from silently discarding its own work

### DIFF
--- a/packages/runtimes/openclaw/src/dispatcher.test.ts
+++ b/packages/runtimes/openclaw/src/dispatcher.test.ts
@@ -293,6 +293,36 @@ describe("dispatchExecTask", () => {
     expect(stored.completedAt).toBe(1000);
   });
 
+  it("falls back to the task's timeoutMs when the dispatch has none", async () => {
+    // A workflow step that declares `timeoutMs` lands it on the task row, not
+    // inside the dispatch object — only alias resolution injects the latter.
+    // Without this fallback the runtime silently applied its own 300s default,
+    // so a step's declared budget never took effect.
+    const rt = makeRuntime();
+    const deps = makeDeps(rt);
+    seedGoal(deps);
+    const task = seedTask(deps, {
+      dispatch: { mode: "exec", command: ["echo", "hi"] },
+      timeoutMs: 900_000,
+    });
+    await createOpenClawDispatcher(deps).dispatchExecTask(task);
+    await flush();
+    expect(rt.execCalls[0]!.timeoutMs).toBe(900_000);
+  });
+
+  it("prefers the dispatch timeoutMs over the task's when both are set", async () => {
+    const rt = makeRuntime();
+    const deps = makeDeps(rt);
+    seedGoal(deps);
+    const task = seedTask(deps, {
+      dispatch: { mode: "exec", command: ["echo", "hi"], timeoutMs: 1000 },
+      timeoutMs: 900_000,
+    });
+    await createOpenClawDispatcher(deps).dispatchExecTask(task);
+    await flush();
+    expect(rt.execCalls[0]!.timeoutMs).toBe(1000);
+  });
+
   it("unblocks pending dependents after an exec task succeeds", async () => {
     const rt = makeRuntime();
     const deps = makeDeps(rt);

--- a/packages/runtimes/openclaw/src/dispatcher.ts
+++ b/packages/runtimes/openclaw/src/dispatcher.ts
@@ -189,7 +189,15 @@ async function dispatchExec(
     command: dispatch.command,
     cwd: dispatch.cwd,
     env: dispatch.env,
-    timeoutMs: dispatch.timeoutMs,
+    // Fall back to the task's own timeoutMs (carried from the workflow step
+    // template) when the dispatch object doesn't have one. Alias resolution
+    // injects dispatch.timeoutMs, but a plain exec step that declares
+    // `timeoutMs` in its workflow JSON only lands it on the task row — so
+    // without this the runtime silently applied its 300s default and the
+    // step's declared budget was a fiction. That killed dream-cycle's `apply`
+    // (declared 900s) at exactly 300s on 3 of 4 nights in Aug 2026, discarding
+    // the taste it had just distilled.
+    timeoutMs: dispatch.timeoutMs ?? task.timeoutMs,
   };
   const execRun = deps.runtime.execRun;
 

--- a/packages/services/digest/src/digest/daily_digest.py
+++ b/packages/services/digest/src/digest/daily_digest.py
@@ -39,6 +39,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+import time
 from collections import Counter
 from pathlib import Path
 from typing import Optional
@@ -224,8 +225,7 @@ def _confined_read(path: Path) -> Optional[str]:
     except (OSError, RuntimeError):
         return None
     if not resolved.is_relative_to(_PATHS.wiki_root):
-        print(f"[daily-digest] refusing to read outside wiki root: {path}",
-              file=sys.stderr)
+        print(f"[daily-digest] refusing to read outside wiki root: {path}")
         return None
     try:
         return resolved.read_text(encoding="utf-8")
@@ -338,6 +338,14 @@ _SKIP_PREFIXES = (
     "The following is the Codex agent history",
     "sourceSession=",
     "Conversation info (untrusted metadata)",
+    # Newer Codex builds inject a plugin catalogue as the first user turn, so
+    # every Codex session was reported as "reviewed a list of plugins" instead
+    # of the work the user actually asked for (2026-08 digest).
+    "<recommended_plugins>",
+    "<user_instructions>",
+    # OpenClaw prepends routing metadata to a dispatched turn; it describes how
+    # the reply is delivered, never what the agent was asked to do.
+    "OpenClaw delivery metadata:",
 )
 # Special-case tags that ARE meaningful (don't skip, but render cleanly)
 _TAG_TOPICS = {
@@ -490,10 +498,17 @@ def _get_engine():
         except Exception as e:
             _LLM_DISABLED = True
             print(f"[daily-digest] inline LLM engine unavailable ({e}); "
-                  "rendering deterministically", file=sys.stderr)
+                  "rendering deterministically")
             return None
     return _summarize_engine
 
+
+# NOTE ON DIAGNOSTICS: everything below reports degradation on STDOUT, not
+# stderr. The orchestrator captures a task's stdout into attempts.output_summary
+# in brain.db — bounded, queryable, retained — whereas the gateway service runs
+# with StandardErrorPath=/dev/null, so anything written to stderr is gone. That
+# is why the digest rendered raw truncated prompts for a week in Aug 2026
+# without a single trace of why.
 
 # --- LLM hang/circuit-breaker guards -----------------------------------------
 # OpenClawEngine.llm_call has NO network timeout: if the Gemini endpoint is
@@ -501,12 +516,22 @@ def _get_engine():
 # fires, and the whole digest render hangs (this is what silently killed the
 # digest — same failure class as the COO-spawn stall, different surface).
 # We bound every call with a hard wall-clock timeout and trip a circuit breaker
-# after a couple of consecutive failures so the run degrades to the regex
-# fallback instead of stalling.
-_LLM_TIMEOUT_S = int(os.environ.get("DIGEST_LLM_TIMEOUT_S", "8"))
-_LLM_MAX_CONSEC_FAILS = int(os.environ.get("DIGEST_LLM_MAX_FAILS", "2"))
+# so the run degrades to the regex fallback instead of stalling.
+#
+# The per-call budget must clear real p99 latency PLUS one backoff sleep, or the
+# breaker fires on healthy infrastructure. Measured gemini-3-flash latency is
+# 2.3-5.4s, and OpenClawEngine._urlopen_json sleeps 2-60s on a 429 — under the
+# old 8s alarm a single throttle guaranteed a timeout, and two in a row
+# permanently disabled summarization for the whole run. That is what rendered
+# the 2026-08-19 digest as raw truncated prompts on a night when the engine was
+# perfectly healthy. Worst-case wall clock is now bounded by an explicit
+# whole-run budget instead of by a hair-trigger per-call alarm.
+_LLM_TIMEOUT_S = int(os.environ.get("DIGEST_LLM_TIMEOUT_S", "30"))
+_LLM_MAX_CONSEC_FAILS = int(os.environ.get("DIGEST_LLM_MAX_FAILS", "4"))
+_LLM_BUDGET_S = float(os.environ.get("DIGEST_LLM_BUDGET_S", "240"))
 _LLM_DISABLED = os.environ.get("DIGEST_NO_LLM") == "1"
 _LLM_CONSEC_FAILS = 0
+_LLM_SPENT_S = 0.0
 
 
 class _LLMTimeout(Exception):
@@ -591,13 +616,20 @@ def _summarize_prompt(raw_prompt: str, cache: dict) -> str:
     key = hashlib.sha256(raw_prompt.encode("utf-8")).hexdigest()[:16]
     if key in cache:
         return cache[key]
-    # Circuit breaker: once the LLM has stalled/errored repeatedly, stop calling
-    # it for the rest of the run and summarize deterministically. Bounds the
-    # worst case to ~(_LLM_MAX_CONSEC_FAILS * _LLM_TIMEOUT_S) seconds instead of
-    # hanging forever or paying the timeout on every single prompt.
-    global _LLM_CONSEC_FAILS, _LLM_DISABLED
+    # Circuit breaker: once the LLM has stalled/errored repeatedly, or the run
+    # has spent its whole LLM budget, stop calling it and summarize
+    # deterministically. The budget is what bounds worst-case wall clock — the
+    # consecutive-fail counter only catches a hard outage, so it can afford to
+    # be forgiving of a transient throttle without risking an unbounded run.
+    global _LLM_CONSEC_FAILS, _LLM_DISABLED, _LLM_SPENT_S
     if _LLM_DISABLED:
         return _clean_prompt_fallback(raw_prompt)
+    if _LLM_SPENT_S >= _LLM_BUDGET_S:
+        _LLM_DISABLED = True
+        print(f"[daily-digest] LLM budget of {_LLM_BUDGET_S:.0f}s exhausted — "
+              "rendering remaining prompts deterministically")
+        return _clean_prompt_fallback(raw_prompt)
+    started = time.monotonic()
     try:
         eng = _get_engine()
         if eng is None:
@@ -615,12 +647,14 @@ def _summarize_prompt(raw_prompt: str, cache: dict) -> str:
         _LLM_CONSEC_FAILS += 1
         reason = "timed out" if isinstance(e, _LLMTimeout) else repr(e)
         print(f"[daily-digest] summarize {reason} "
-              f"({_LLM_CONSEC_FAILS}/{_LLM_MAX_CONSEC_FAILS})", file=sys.stderr)
+              f"({_LLM_CONSEC_FAILS}/{_LLM_MAX_CONSEC_FAILS})")
         if _LLM_CONSEC_FAILS >= _LLM_MAX_CONSEC_FAILS:
             _LLM_DISABLED = True
             print("[daily-digest] LLM summarizer disabled for this run — "
-                  "rendering remaining prompts deterministically", file=sys.stderr)
+                  "rendering remaining prompts deterministically")
         return _clean_prompt_fallback(raw_prompt)
+    finally:
+        _LLM_SPENT_S += time.monotonic() - started
 
 
 def _summarize_and_group(raw_prompts: list[str], cache: dict) -> list[tuple[str, int]]:
@@ -679,16 +713,19 @@ def _codex_state_db(sessions_root: Path) -> Optional[Path]:
     return dbs[-1] if dbs else None
 
 
-def _codex_sqlite_prompts(
-    start_ms: int, end_ms: int, sessions_root: Path, skip_rollout_paths: set[str],
-) -> list[str]:
-    """First-user-messages from codex's threads table, for sessions in window.
+def _codex_sqlite_rows(
+    start_ms: int, end_ms: int, sessions_root: Path,
+) -> list[tuple[str, str]]:
+    """`(rollout_path, first meaningful user message)` from codex's threads
+    table, for sessions in window. rollout_path is "" when the thread has none.
 
     Newer codex builds record threads in ~/.codex/state_*.sqlite and may not
     write rollout JSONLs at all, so reading only ~/.codex/sessions silently
     reports "no activity" (the 2026-07 codex gap: rollouts stopped 07-04).
-    Threads whose rollout file was already counted by the JSONL walk are
-    skipped via skip_rollout_paths.
+
+    Wrapper boilerplate is filtered here too. It used to be stripped only on
+    the JSONL path, so a review-harness thread ("The following is the Codex
+    agent history...") surfaced verbatim as a topic.
     """
     db = _codex_state_db(sessions_root)
     if db is None:
@@ -706,11 +743,13 @@ def _codex_sqlite_prompts(
         con.close()
     except (sqlite3.Error, OSError):
         return []
-    return [
-        first_msg or title
-        for rollout_path, first_msg, title in rows
-        if rollout_path not in skip_rollout_paths and (first_msg or title)
-    ]
+    out: list[tuple[str, str]] = []
+    for rollout_path, first_msg, title in rows:
+        text = (first_msg or title or "").strip()
+        if not text or text.startswith(_SKIP_PREFIXES):
+            continue
+        out.append((rollout_path, text))
+    return out
 
 
 def _codex_last_seen_iso(sessions_root: Path) -> Optional[str]:
@@ -749,8 +788,17 @@ def _codex_raw_prompts(start_ms: int, end_ms: int, root: Path) -> list[str]:
     """Flat list of first-user-prompts across all Codex sessions in window.
 
     Union of both local stores: legacy rollout JSONLs under sessions/ and
-    the threads table in state_*.sqlite (see _codex_sqlite_prompts).
+    the threads table in state_*.sqlite (see _codex_sqlite_rows).
+
+    The two stores describe the same sessions, so a thread is counted once —
+    but the JSONL is not authoritative. Its opening turns are often only
+    injected system wrappers, while the threads table records the real
+    `first_user_message`. Dropping the SQLite row purely because its rollout
+    file was walked is what reported Codex's 2026-08-19 work as "reviewed a
+    list of plugins". Prefer whichever store yields a meaningful prompt.
     """
+    sql_rows = _codex_sqlite_rows(start_ms, end_ms, root)
+    by_rollout = {path: text for path, text in sql_rows if path}
     raw: list[str] = []
     seen_rollouts: set[str] = set()
     if root.exists():
@@ -762,8 +810,10 @@ def _codex_raw_prompts(start_ms: int, end_ms: int, root: Path) -> list[str]:
             if not (start_ms <= mtime_ms < end_ms):
                 continue
             seen_rollouts.add(str(jsonl))
-            raw.append(_extract_first_user_prompt(jsonl))
-    raw.extend(_codex_sqlite_prompts(start_ms, end_ms, root, seen_rollouts))
+            raw.append(
+                _extract_first_user_prompt(jsonl) or by_rollout.get(str(jsonl), "")
+            )
+    raw.extend(text for path, text in sql_rows if path not in seen_rollouts)
     prompts: list[str] = []
     for prompt in raw:
         topic = _topic_from_prompt(prompt)
@@ -1866,7 +1916,7 @@ def load_coo_handoff() -> tuple[dict | None, str | None]:
         finally:
             con.close()
     except sqlite3.Error as e:
-        print(f"[daily-digest] brain.db read failed: {e}", file=sys.stderr)
+        print(f"[daily-digest] brain.db read failed: {e}")
         return None, None
     if not row or not row[0]:
         return None, None
@@ -1931,7 +1981,6 @@ def main(argv: list[str]) -> int:
                     print(
                         f"[daily-digest] {source}: contract violation "
                         f"({len(errs)}): {'; '.join(errs[:5])}",
-                        file=sys.stderr,
                     )
                 return None
             print(f"[daily-digest] using {source}")
@@ -1954,7 +2003,6 @@ def main(argv: list[str]) -> int:
             print(
                 "[daily-digest] no valid agent handoff — rendering "
                 "deterministically from staged data (regex, no LLM)",
-                file=sys.stderr,
             )
             full_md, structured = render_full(date_iso)
             presentation = _accept(render_components(structured), "deterministic regex render")
@@ -1966,7 +2014,6 @@ def main(argv: list[str]) -> int:
             print(
                 "[daily-digest] all sources empty — publishing minimal "
                 "'nothing to report' card (fail-open floor)",
-                file=sys.stderr,
             )
             presentation = _minimal_presentation(date_iso)
 

--- a/packages/services/digest/src/digest/workflows/digest.json
+++ b/packages/services/digest/src/digest/workflows/digest.json
@@ -85,7 +85,7 @@
       },
       "priority": "normal",
       "onUpstreamFailure": "continue",
-      "timeoutMs": 120000,
+      "timeoutMs": 600000,
       "sortOrder": 2
     }
   ]

--- a/packages/services/digest/tests/test_codex_sources.py
+++ b/packages/services/digest/tests/test_codex_sources.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from digest.daily_digest import (
     _codex_last_seen_iso,
     _codex_raw_prompts,
-    _codex_sqlite_prompts,
+    _codex_sqlite_rows,
 )
 
 WINDOW_START = 1_783_000_000_000  # arbitrary epoch-ms window
@@ -54,26 +54,76 @@ def test_sqlite_threads_counted_without_rollout_files(tmp_path):
     assert prompts == ["fix the video pipeline"]
 
 
+def _write_rollout(sessions: Path, name: str, body: str) -> Path:
+    import os
+    rollout = sessions / name
+    rollout.write_text(body)
+    mtime_s = (WINDOW_START + 1000) / 1000
+    os.utime(rollout, (mtime_s, mtime_s))
+    return rollout
+
+
 def test_rollout_already_counted_is_not_double_counted(tmp_path):
     sessions = tmp_path / "sessions"
     sessions.mkdir()
-    rollout = sessions / "rollout-c.jsonl"
-    rollout.write_text("")  # empty file: JSONL walk yields one (empty) prompt
-    mtime_s = (WINDOW_START + 1000) / 1000
-    import os
-    os.utime(rollout, (mtime_s, mtime_s))
+    rollout = _write_rollout(sessions, "rollout-c.jsonl", "")
+    mtime_s = int((WINDOW_START + 1000) / 1000)
 
     _make_state_db(tmp_path, [
-        ("t3", str(rollout), int(mtime_s), int(mtime_s),
-         "duplicate thread", "Dup"),
+        ("t3", str(rollout), mtime_s, mtime_s, "duplicate thread", "Dup"),
     ])
 
-    sqlite_only = _codex_sqlite_prompts(
-        WINDOW_START, WINDOW_END, sessions, {str(rollout)}
-    )
-    assert sqlite_only == []
-    # The union path counts the session exactly once (via the JSONL walk).
-    assert len(_codex_raw_prompts(WINDOW_START, WINDOW_END, sessions)) == 1
+    # The union path counts the session exactly once...
+    prompts = _codex_raw_prompts(WINDOW_START, WINDOW_END, sessions)
+    assert len(prompts) == 1
+    # ...and takes the threads-table text, because the JSONL had nothing usable.
+    assert prompts == ["duplicate thread"]
+
+
+def test_wrapper_only_rollout_falls_back_to_threads_table(tmp_path):
+    """Regression (2026-08-19): newer codex builds open a session with an
+    injected `<recommended_plugins>` turn. The JSONL walk returned that
+    boilerplate and the threads row holding the real prompt was discarded as a
+    duplicate, so every Codex session was reported as "reviewed a list of
+    plugins" instead of the work the user actually asked for."""
+    import json
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    wrapper = json.dumps({
+        "type": "response_item",
+        "payload": {
+            "role": "user",
+            "content": [{"type": "input_text",
+                         "text": "<recommended_plugins>\nAirtable, Apollo.io"}],
+        },
+    })
+    rollout = _write_rollout(sessions, "rollout-d.jsonl", wrapper + "\n")
+    mtime_s = int((WINDOW_START + 1000) / 1000)
+
+    _make_state_db(tmp_path, [
+        ("t4", str(rollout), mtime_s, mtime_s,
+         "analyze the Jeff Su channel", "Analyze Jeff Su"),
+    ])
+
+    assert _codex_raw_prompts(WINDOW_START, WINDOW_END, sessions) == [
+        "analyze the Jeff Su channel"
+    ]
+
+
+def test_threads_rows_that_are_only_wrappers_are_dropped(tmp_path):
+    """The threads table carries harness boilerplate too; it used to be
+    filtered on the JSONL path only, so it surfaced verbatim as a topic."""
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    in_window_s = (WINDOW_START + 3_600_000) // 1000
+    _make_state_db(tmp_path, [
+        ("t5", "", in_window_s, in_window_s,
+         "The following is the Codex agent history whose request action...", ""),
+        ("t6", "", in_window_s, in_window_s, "ship the release notes", "Ship"),
+    ])
+
+    rows = _codex_sqlite_rows(WINDOW_START, WINDOW_END, sessions)
+    assert [text for _, text in rows] == ["ship the release notes"]
 
 
 def test_last_seen_uses_max_across_stores(tmp_path):


### PR DESCRIPTION
## What happened

The 2026-08-19 digest reported **Taste distilled: 0** and rendered raw prompt boilerplate under "what each agent worked on":

> **Codex CLI:** "Here is a list of plugins that are available but not installed…"

What Codex actually did that day was analyze a YouTube channel's top posts — the work that produced three of the wiki entries the same digest listed.

The trigger was an expired `claude` CLI OAuth session (host-side, fixed by re-login), which killed all three agent-spawn steps: dream-cycle's `compile-extract` and `taste-distill`, and the digest's `summarize`. But every fallback meant to cover that also failed, each for its own reason. This PR fixes the fallbacks.

## The four defects

**1. Exec steps never received their declared timeout.** `dispatchExecTask` built `execArgs` from `dispatch.timeoutMs`, which only alias resolution ever populates — a workflow step's own `timeoutMs` lands on the task row. So every plain exec step silently ran under the runtime's 300s default:

```
2026-08-20 | timeout   | 300s   ← declared 900s
2026-08-19 | timeout   | 300s
2026-08-18 | completed | 148s
2026-08-17 | timeout   | 300s
2026-08-16 | completed | 290s   ← 10s of margin
```

Dream-cycle's `apply` runs the inline taste fallback. It was doing the work and then being killed before it could write. Now falls back to `task.timeoutMs`; two tests pin both precedence orders.

**2. The digest's LLM circuit breaker fired on healthy infrastructure.** An 8s per-call SIGALRM with a 2-consecutive-failure trip, against measured 2.3–5.4s latency and an engine that sleeps 2–60s on a 429. One throttle guaranteed a timeout; two in a row disabled summarization for the whole run. Raised to 30s / 4 fails, and worst-case wall clock is now bounded by an explicit whole-run budget (`DIGEST_LLM_BUDGET_S`, default 240s) rather than by a hair-trigger per-call alarm.

**3. Codex prompts were read from the wrong store.** Newer Codex builds inject a `<recommended_plugins>` catalogue as the opening user turn. The JSONL walk returned that, and then the threads-table row holding the real `first_user_message` was discarded as a duplicate. The stores now cooperate — prefer whichever yields a meaningful prompt — and wrapper filtering applies on both paths, with the missing wrappers added (`<recommended_plugins>`, `<user_instructions>`, OpenClaw's delivery-metadata preamble).

Verified against the real 2026-08-19 window:

| before | after |
|---|---|
| `<recommended_plugins>\nHere is a list of plugins…` | `I need you to analyze the youtube.com/@JeffSu latest top po…` |

**4. Degradation left no trace.** Every `[daily-digest] summarizer disabled` line went to stderr, and the gateway service runs with `StandardErrorPath=/dev/null`. These diagnostics now go to stdout, which the orchestrator captures into `attempts.output_summary` in brain.db — bounded, queryable, already retained. That is a better sink than repointing the plist: the old `gateway.err.log` had reached 1 GB, which is plausibly why it was silenced in the first place.

Also raises the publish step's declared timeout from 120s to 600s, since fix #1 makes that number binding for the first time.

## Testing

- `packages/runtimes/openclaw`: 275 tests pass (2 new), typecheck clean, eslint clean on changed files
- `packages/services/digest`: 50 tests pass (2 new, 1 rewritten for the corrected precedence)
- Codex extraction verified against live `~/.codex/state_5.sqlite` for the 08-19 window

## Not addressed here

Session windowing is by file mtime, so a session appended to after midnight leaves the previous day's window. Re-running the 08-19 digest today surfaces 3 coo sessions where the 07:00 run saw 6. Pre-existing and out of scope; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)