### PR TITLE
ci(claude): grant actions: read so Claude can see CI status

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,6 +20,11 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      # Lets the github_ci MCP server start so Claude can read CI status on
+      # the PR it is answering about. Without it the run logs "The github_ci
+      # MCP server requires 'actions: read' permission. Skipping CI server
+      # installation" and Claude answers blind to whether tests passed.
+      actions: read
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## What

Adds `actions: read` to the `claude.yml` job permissions.

## Why

The permissions block granted `contents` / `pull-requests` / `issues` / `id-token` but not `actions: read`. Without it the run logs:

> The github_ci MCP server requires 'actions: read' permission. Skipping CI server installation

so Claude answers `@claude` questions on a PR without being able to see whether that PR's tests actually passed.

This is a read-only scope — it does not widen what the job can mutate.

## Context

Found while verifying the newly-added `CLAUDE_CODE_OAUTH_TOKEN` secret. Two related facts worth recording:

- The workflow **is** correctly on the default branch, so `@claude` PR mentions do fire (GitHub only evaluates `issue_comment` triggers from the default branch).
- The action step had **never executed** — all eight most recent runs were `skipped` at the `if:` gate (Dependabot comments with no `@claude`), so the token has never been exercised. A smoke test on a real PR is the only way to confirm it, including the trailing-newline-in-secret failure mode (`API Error: Header '14' has invalid value`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)