### PR TITLE
ci(deps): consolidate Dependabot groups and cover the unmonitored Python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,13 +58,32 @@ updates:
           - major
           - minor
           - patch
-      dev-dependencies:
-        dependency-type: development
+      # Same version-lock argument as react, and the same deadlock in practice:
+      # @vitest/coverage-v8 peer-depends on an exactly matching vitest, so the
+      # two arrived as #73 / #74 and could never both be current at once.
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
         update-types:
+          - major
           - minor
           - patch
-      production-minor-patch:
-        dependency-type: production
+      # One group for everything that auto-merges, rather than the previous
+      # dev / production split.
+      #
+      # The split cost a PR without buying a decision: both halves were
+      # minor+patch, both auto-merged on green, so nothing was ever reviewed
+      # differently because of which one it landed in. What it did buy was a
+      # second CI cycle every week — and in a pnpm monorepo the second PR does
+      # not merely go stale, it goes DIRTY, because the first one rewrote
+      # pnpm-lock.yaml. Halving the count halves that conflict cascade.
+      #
+      # Declared last: react and vitest above claim their members first, so this
+      # catch-all never splits either family apart.
+      minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
@@ -72,12 +91,26 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
 
-  # Python dream-cycle service.
+  # Python services. All three are listed explicitly rather than by glob: the
+  # dashboard intake package sits deeper than the others, and a glob that missed
+  # it would fail silently — which is exactly how digest and intake went
+  # unmonitored while both were building and testing in CI.
   - package-ecosystem: pip
-    directory: "/packages/services/dream-cycle"
+    directories:
+      - "/packages/services/dream-cycle"
+      - "/packages/services/digest"
+      - "/packages/services/dashboard/src/intake"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Grouped including majors, matching the github-actions treatment rather
+    # than the npm one. The whole Python surface is pyyaml plus pytest, so
+    # per-package PRs would be three-way noise for a two-package tree, and a
+    # major here is a test-runner bump rather than a migration.
+    groups:
+      python:
+        patterns:
+          - "*"
     cooldown:
       # pip is not a SemVer ecosystem to Dependabot, so only default-days applies.
       default-days: 7
@@ -101,7 +134,11 @@ updates:
 
 # Note on major version updates: they are intentionally left ungrouped so each
 # arrives as its own PR for deliberate review — majors often need migration work
-# (e.g. vitest 4, typescript 6). The dependabot-auto-merge workflow only
-# auto-merges patch/minor, so a major never lands unattended. Majors are NOT
+# (e.g. vitest 4, typescript 6). The exception is a version-locked family
+# (react, vitest): those must move together or not at all, so grouping them is
+# what makes review possible rather than what skips it.
+#
+# The dependabot-auto-merge workflow only auto-merges patch/minor, so a major
+# never lands unattended. Majors are NOT
 # ignored here on purpose: that would also suppress security fixes that are only
 # available in a new major (e.g. the vitest 2 → 3 CVE patch, GHSA-5xrq-8626-4rwp).


### PR DESCRIPTION
Follow-up to #75. With a merge queue [unavailable on a user-owned repo](https://github.com/Amyssjj/digital-me/pull/75), PR **count** is the only throughput lever left — and in this pnpm monorepo each extra PR costs more than a CI cycle, because every landed bump rewrites `pnpm-lock.yaml` and sends the next one `DIRTY` rather than merely `BEHIND`.

## Collapse the dev / production split

`dev-dependencies` + `production-minor-patch` → one `minor-and-patch` group.

The split cost a PR without buying a decision: both halves were minor+patch, both auto-merged on green, so nothing was ever reviewed differently for having landed in one rather than the other. What it did buy was a second CI cycle every week, plus the lockfile conflict behind it.

## Group the vitest family

`@vitest/coverage-v8` peer-depends on an exactly matching `vitest` (both `^3.2.6` in `packages/cli`), so **#73 and #74 are the same deadlock react hit in #37 / #41** — landing either makes the other stale, and neither can be current at once.

The standing note on majors now records the exception explicitly: for a version-locked family, grouping is what makes review *possible*, not what skips it. Everything else stays ungrouped per the existing policy.

## Cover the Python packages nobody was watching

Only `dream-cycle` was listed under `pip`. Both of these were building and testing in CI with **no dependency monitoring at all**:

- `packages/services/digest` — has its own required CI check
- `packages/services/dashboard/src/intake`

All three are now listed explicitly rather than by glob: intake sits deeper than the others, and a glob that missed it would fail silently — which is precisely how this went unnoticed. Grouped including majors, matching the `github-actions` treatment rather than the npm one, because the entire Python surface is `pyyaml` plus `pytest`.

## Notes

**Group order is load-bearing.** `react` and `vitest` are declared *before* the `*` catch-all, because [a dependency joins the first group it matches](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference). If the catch-all moved up, it would split both families apart. Worth knowing there are open upstream reports of group order occasionally not being honored ([dependabot-core#9372](https://github.com/dependabot/dependabot-core/issues/9372)), so if react or vitest ever arrive split again, that's the first thing to check rather than a config error here.

**Expect a burst.** Adding two previously-unmonitored pip directories will open PRs for them on the next run. Small — `pyyaml` and `pytest` — and grouped, but not zero.

**No cooldown changes.** I checked all three ecosystems; every one already had a cooldown block.

## Verification

YAML parses; groups resolve as `npm -> [minor-and-patch, react, vitest]`, `pip -> [python]`, `github-actions -> [github-actions]`. Sanitize gate clean. Config-only change — no behavior to test beyond Dependabot's next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)