### PR TITLE
feat(orchestrator): idempotent workflow_import via importMode=upsert

### DIFF
--- a/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.test.ts
@@ -6,6 +6,7 @@ const { DatabaseSync } = require("node:sqlite") as typeof import("node:sqlite");
 import { createGoalsStore, GOALS_MIGRATIONS, type Migration } from "../store/goals.js";
 import { createTasksStore, TASKS_MIGRATIONS } from "../store/tasks.js";
 import { createWorkflowsStore, WORKFLOWS_MIGRATIONS } from "../store/workflows.js";
+import { createSchedulesStore, SCHEDULES_MIGRATIONS } from "../store/schedules.js";
 import {
   registerMigration,
   resetMigrationRegistryForTests,
@@ -27,6 +28,7 @@ beforeEach(() => {
     ...GOALS_MIGRATIONS,
     ...TASKS_MIGRATIONS,
     ...WORKFLOWS_MIGRATIONS,
+    ...SCHEDULES_MIGRATIONS,
   ] as Migration[])
     registerMigration(m);
   runMigrations(db);
@@ -431,7 +433,78 @@ describe("createWorkflowFromSteps", () => {
     const r = createWorkflowFromSteps(deps, "wf-1", "n", "d", [], [
       { stepKey: "s", name: "s", promptTemplate: "p", blockedByKeys: [], dispatch: { mode: "manual" } },
     ]);
-    expect(r).toEqual({ ok: false, error: 'Workflow "wf-1" already exists.' });
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toMatch(/already exists/);
+    expect((r as { error: string }).error).toMatch(/mode:"upsert"/);
+  });
+
+  it('upsert replaces steps in place, preserving createdAt and bumping version', () => {
+    const deps = makeDeps();
+    const step = (key: string, prompt: string) => ({
+      stepKey: key, name: key, promptTemplate: prompt,
+      blockedByKeys: [] as string[], dispatch: { mode: "manual" as const },
+    });
+    createWorkflowFromSteps(deps, "wf-1", "n", "d", [], [step("a", "old")]);
+    const before = deps.workflows.get("wf-1")!;
+
+    const later = makeDeps({ workflows: deps.workflows, now: () => 9999 });
+    const r = createWorkflowFromSteps(
+      later, "wf-1", "n2", "d2", [], [step("b", "new")],
+      undefined, undefined, "upsert",
+    );
+
+    expect(r.ok).toBe(true);
+    const after = deps.workflows.get("wf-1")!;
+    expect(after.name).toBe("n2");
+    expect(after.createdAt).toBe(before.createdAt); // preserved
+    expect(after.updatedAt).toBe(9999);             // advanced
+    expect(after.version).toBe(before.version + 1); // bumped
+    const keys = deps.workflows.listSteps("wf-1").map((s) => s.stepKey);
+    expect(keys).toEqual(["b"]);                    // old step replaced, not merged
+  });
+
+  it("upsert leaves schedules referencing the workflow untouched", () => {
+    // The whole reason upsert exists: workflow_delete is gated on first
+    // disabling every schedule that references the template. Upsert must
+    // never delete the template row, so schedules survive.
+    const deps = makeDeps();
+    const schedules = createSchedulesStore({ db });
+    const step = {
+      stepKey: "a", name: "a", promptTemplate: "p",
+      blockedByKeys: [] as string[], dispatch: { mode: "manual" as const },
+    };
+    createWorkflowFromSteps(deps, "wf-1", "n", "d", [], [step]);
+    schedules.create({
+      id: "sched-1", workflowId: "wf-1", name: "nightly",
+      cronExpr: "0 3 * * *", timezone: "America/Los_Angeles",
+      variables: {}, enabled: true, nextRunAt: 5000,
+      maxOverlap: 0, createdAt: 1, updatedAt: 1,
+    });
+
+    const r = createWorkflowFromSteps(
+      deps, "wf-1", "n2", "d2", [], [step],
+      undefined, undefined, "upsert",
+    );
+
+    expect(r.ok).toBe(true);
+    const sched = schedules.get("sched-1");
+    expect(sched).toBeDefined();
+    expect(sched!.enabled).toBe(true);
+    expect(sched!.cronExpr).toBe("0 3 * * *");
+    expect(sched!.timezone).toBe("America/Los_Angeles");
+  });
+
+  it("upsert on an unknown id behaves as a create", () => {
+    const deps = makeDeps();
+    const r = createWorkflowFromSteps(
+      deps, "wf-new", "n", "d", [],
+      [{ stepKey: "a", name: "a", promptTemplate: "p", blockedByKeys: [], dispatch: { mode: "manual" } }],
+      undefined, undefined, "upsert",
+    );
+    expect(r.ok).toBe(true);
+    const rec = deps.workflows.get("wf-new")!;
+    expect(rec.version).toBe(1);
+    expect(rec.createdAt).toBe(rec.updatedAt);
   });
 
   it("defaults clock + newId for createWorkflowFromSteps when omitted", () => {
@@ -522,6 +595,26 @@ describe("createWorkflowFromSteps", () => {
     );
     expect(r.ok).toBe(false);
     expect((r as { error: string }).error).toMatch(/Failed to create workflow.*synthetic step failure/);
+  });
+
+  it("reports an upsert transaction failure as an update, not a create", () => {
+    const deps = makeDeps();
+    const step = {
+      stepKey: "s", name: "s", promptTemplate: "p",
+      blockedByKeys: [] as string[], dispatch: { mode: "manual" as const },
+    };
+    createWorkflowFromSteps(deps, "wf-txn-up", "n", "d", [], [step]);
+    deps.workflows.createStep = () => {
+      throw new Error("synthetic step failure");
+    };
+    const r = createWorkflowFromSteps(
+      deps, "wf-txn-up", "n", "d", [], [step],
+      undefined, undefined, "upsert",
+    );
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toMatch(
+      /Failed to update workflow.*synthetic step failure/,
+    );
   });
 
   it("wraps non-Error throws inside the transaction with String()", () => {

--- a/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.ts
@@ -163,6 +163,23 @@ export type StepInput = {
   readonly timeoutMs?: number;
 };
 
+/**
+ * How to handle an id that already exists.
+ *
+ * `"create"` (default) preserves the historical refuse-on-conflict behavior.
+ * `"upsert"` replaces the template and its steps in place — deliberately
+ * WITHOUT deleting the template row, so schedules (which reference
+ * `workflowId`) survive untouched. That is the whole point: deleting a
+ * template is gated on first disabling every schedule that references it,
+ * which makes routine re-installs a four-step privileged operation with a
+ * window where the workflow does not exist.
+ *
+ * In-flight goals are unaffected either way: instantiateWorkflow materializes
+ * each task's dispatch at task-creation time, so a running goal already holds
+ * its own copy of the steps.
+ */
+export type ImportMode = "create" | "upsert";
+
 export function createWorkflowFromSteps(
   deps: WorkflowBuilderDeps,
   workflowId: string,
@@ -172,10 +189,14 @@ export function createWorkflowFromSteps(
   steps: readonly StepInput[],
   branching?: WorkflowBranchingPolicy,
   notifyTarget?: Originator,
+  mode: ImportMode = "create",
 ): BuilderResult {
   const existing = deps.workflows.get(workflowId);
-  if (existing) {
-    return { ok: false, error: `Workflow "${workflowId}" already exists.` };
+  if (existing && mode !== "upsert") {
+    return {
+      ok: false,
+      error: `Workflow "${workflowId}" already exists. Pass mode:"upsert" to replace it in place, or delete it first.`,
+    };
   }
   if (steps.length === 0) {
     return { ok: false, error: "Workflow must have at least one step." };
@@ -216,30 +237,43 @@ export function createWorkflowFromSteps(
     name,
     description,
     variables,
-    createdAt: now,
+    // An upsert keeps the original creation stamp and advances the version,
+    // so `created_at != updated_at` remains a reliable "this was re-imported"
+    // signal. A create starts both at now with version 1.
+    createdAt: existing?.createdAt ?? now,
     updatedAt: now,
-    version: 1,
-    tags: [],
+    version: existing ? existing.version + 1 : 1,
+    tags: existing?.tags ?? [],
     branching,
     notifyTarget,
   };
 
+  const replacing = Boolean(existing);
   try {
     runInTransaction(deps.db, () => {
-      deps.workflows.create(template);
+      if (replacing) {
+        // update + replace steps, never delete the template row (schedules
+        // reference it by workflowId and must survive).
+        deps.workflows.update(template);
+        deps.workflows.deleteSteps(workflowId);
+      } else {
+        deps.workflows.create(template);
+      }
       for (const step of normalized) deps.workflows.createStep(step);
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return {
       ok: false,
-      error: `Failed to create workflow "${workflowId}": ${msg}`,
+      error: `Failed to ${replacing ? "update" : "create"} workflow "${workflowId}": ${msg}`,
     };
   }
 
   return {
     ok: true,
-    message: `Workflow "${workflowId}" created with ${steps.length} steps.`,
+    message: replacing
+      ? `Workflow "${workflowId}" updated to v${template.version} with ${steps.length} steps (schedules preserved).`
+      : `Workflow "${workflowId}" created with ${steps.length} steps.`,
   };
 }
 
@@ -272,6 +306,7 @@ type RawJson = {
 export function importWorkflowFromJson(
   deps: WorkflowBuilderDeps,
   json: string,
+  mode: ImportMode = "create",
 ): BuilderResult {
   let data: RawJson;
   try {
@@ -328,6 +363,7 @@ export function importWorkflowFromJson(
     normalized,
     data.branching,
     notifyTarget,
+    mode,
   );
 }
 

--- a/packages/plugins/brain-orchestrator/src/plugin/router.test.ts
+++ b/packages/plugins/brain-orchestrator/src/plugin/router.test.ts
@@ -1592,6 +1592,38 @@ describe("dispatchAction — workflow_* actions", () => {
     expect(deps.workflows.get("imp")).toBeDefined();
   });
 
+  it('workflow_import with importMode:"upsert" replaces an existing template', async () => {
+    const deps = makeDeps();
+    const tpl = (stepKey: string) =>
+      JSON.stringify({
+        id: "imp",
+        name: "Imp",
+        steps: [{ stepKey, dispatch: { mode: "manual" } }],
+      });
+    await dispatchAction(deps, "workflow_import", { workflowJson: tpl("a") });
+
+    const r = await dispatchAction(deps, "workflow_import", {
+      workflowJson: tpl("b"),
+      importMode: "upsert",
+    });
+
+    expect(r.ok).toBe(true);
+    expect(deps.workflows.listSteps("imp").map((s) => s.stepKey)).toEqual(["b"]);
+  });
+
+  it("workflow_import without importMode still refuses an existing id", async () => {
+    const deps = makeDeps();
+    const tpl = JSON.stringify({
+      id: "imp",
+      name: "Imp",
+      steps: [{ stepKey: "a", dispatch: { mode: "manual" } }],
+    });
+    await dispatchAction(deps, "workflow_import", { workflowJson: tpl });
+    const r = await dispatchAction(deps, "workflow_import", { workflowJson: tpl });
+    expect(r.ok).toBe(false);
+    expect(r.text).toMatch(/already exists/);
+  });
+
   it("workflow_import returns ok=false on bad JSON", async () => {
     const r = await dispatchAction(makeDeps(), "workflow_import", {
       workflowJson: "{not json",

--- a/packages/plugins/brain-orchestrator/src/plugin/router.ts
+++ b/packages/plugins/brain-orchestrator/src/plugin/router.ts
@@ -171,6 +171,7 @@ export async function dispatchAction(
         importWorkflowFromJson(
           { ...deps, defaultDispatchAgentId: undefined },
           asString(params.workflowJson),
+          asOptString(params.importMode) === "upsert" ? "upsert" : "create",
         ),
       );
     case "workflow_list":

--- a/packages/runtimes/openclaw/src/tool-schemas.ts
+++ b/packages/runtimes/openclaw/src/tool-schemas.ts
@@ -101,6 +101,12 @@ export const TasksToolSchema = Type.Object(
     workflowJson: Type.Optional(
       Type.String({ description: "Full workflow JSON for workflow_import." }),
     ),
+    importMode: Type.Optional(
+      Type.String({
+        description:
+          'workflow_import only: "create" (default) fails if the id exists; "upsert" replaces the template and its steps in place, preserving schedules and the original createdAt.',
+      }),
+    ),
     force: Type.Optional(
       Type.Boolean({
         description: "Bypass workflow-level mutex (run_workflow only).",


### PR DESCRIPTION
## Why

Workflow templates are copied into the brain DB at install and the live copy is what actually runs. Updating one was possible, but only via a destructive dance:

1. `createWorkflowFromSteps` hard-refused an existing id.
2. `handleWorkflowDelete` refuses while an *enabled* schedule references the workflow.
3. So the only overwrite path was **remove every schedule → delete workflow → import → re-register**. `install_workflows.py` automated exactly that, including tearing down schedules by workflow reference.

That teardown is the real hazard: a routine re-install silently destroyed any schedule with hand-tuned variables or no sibling `.schedule.json`, and left a window where the workflow didn't exist at all.

**Correction to an earlier version of this description:** re-running `digital-me install` did *not* silently no-op — the installer deleted first, so it would have updated the template. The observed drift on `dream-cycle-nightly` (imported 2026-06-08, `updated_at == created_at` ever since, all four steps diverged from the bundled file) is because install was never re-run, not because it couldn't update.

## What

`importMode: "upsert"` — update the template row and replace its steps in one transaction, **never deleting the row**, so schedules survive untouched.

- `createdAt` preserved, `version` bumped — `created_at != updated_at` stays a reliable "re-imported" signal.
- Default remains `"create"`; existing callers unaffected. The refusal message now names the escape hatch.
- Named `importMode`, **not** `mode` — the tasks tool already advertises `mode` as retry's `restart|resume` enum.
- In-flight goals unaffected: `instantiateWorkflow` materializes each task's dispatch at task-creation, so a running goal holds its own copy.

The store already had `update`, `deleteSteps`, and `createStep`, and `deleteWorkflow` already used an explicit transaction — the capability was there, only the guard stood in the way.

## Tests

**861 passed, 100% statements / branches / functions / lines.**

- steps replaced, not merged
- **schedules referencing the workflow survive an upsert** (the regression this exists to prevent)
- `createdAt` preserved, `version` bumped
- upsert on an unknown id behaves as a create
- `importMode` omitted still refuses an existing id
- an upsert transaction failure reported as *update*, not *create*

## Stacked follow-up

#84 builds on this branch: provenance stamping + a `doctor` drift check, and switches the installer to upsert (removing the schedule teardown described above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

