### PR TITLE
feat(doctor): stamp workflow provenance and detect template drift

### DIFF
--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -42,6 +42,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -71,7 +73,12 @@ import {
 } from "@digital-me/runtime-hermes";
 import { updateOpenclaw } from "@digital-me/runtime-openclaw";
 import { materializeOpenclawOverlay } from "../openclaw-overlay.js";
-import { runDoctor, formatReport, type RuntimeId } from "../doctor.js";
+import {
+  runDoctor,
+  formatReport,
+  type RuntimeId,
+  type WorkflowProvenance,
+} from "../doctor.js";
 import { resolveOpenclawExtensionsDir } from "../openclaw-paths.js";
 import { ensureOpenclawMemoryPaths } from "../openclaw-memory.js";
 import {
@@ -393,6 +400,45 @@ function linkCliGlobally(): void {
   }
 }
 
+/**
+ * Read each workflow template's provenance straight from the brain DB.
+ *
+ * Read-only and best-effort: doctor must never be the reason a machine
+ * looks broken. A missing DB, a pre-migration schema, or a locked file all
+ * degrade to "skipped", never to a failed check.
+ */
+function readWorkflowProvenance(): WorkflowProvenance[] {
+  const home = process.env.HOME ?? process.env.USERPROFILE;
+  if (!home) return [];
+  const dbPath = path.join(home, ".openclaw", "data", "brain.db");
+  if (!existsSync(dbPath)) return [];
+  const db = new DatabaseSync(`file:${dbPath}?mode=ro`, { open: true });
+  try {
+    const rows = db
+      .prepare(
+        "SELECT id, source_path, source_hash, created_at FROM workflow_templates",
+      )
+      .all() as Array<{
+      id: string;
+      source_path: string | null;
+      source_hash: string | null;
+      created_at: number;
+    }>;
+    return rows.map((r) => ({
+      id: r.id,
+      sourcePath: r.source_path ?? undefined,
+      sourceHash: r.source_hash ?? undefined,
+      importedAt: r.created_at,
+    }));
+  } catch {
+    // Pre-v301 schema has no source_* columns. Nothing is wrong, there is
+    // just nothing to verify yet.
+    return [];
+  } finally {
+    db.close();
+  }
+}
+
 function doctor(runtimes: RuntimeId[]): number {
   const report = runDoctor(
     {
@@ -403,6 +449,14 @@ function doctor(runtimes: RuntimeId[]): number {
       readFile: (p) => readFileSync(p, "utf-8"),
       brainMcpProxyBinPath: BRAIN_MCP_PROXY_BIN,
       repoRoot: resolveRepoRoot(),
+      workflowProvenance: readWorkflowProvenance,
+      hashFile: (p) => {
+        try {
+          return createHash("sha256").update(readFileSync(p)).digest("hex");
+        } catch {
+          return undefined;
+        }
+      },
     },
     runtimes.length > 0 ? runtimes : VALID_RUNTIMES,
   );

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -10,6 +10,7 @@ import {
   runLlmAuthCheck,
   runMemoryIndexChecks,
   runOpenclawShadowCheck,
+  runWorkflowDriftChecks,
   type DoctorDeps,
 } from "./doctor.js";
 
@@ -1083,5 +1084,116 @@ describe("runEmbeddingsCheck", () => {
       { provider: "  ", fallback: 42, remote: { apiKey: "" } },
     );
     expect(c.ok).toBe(false);
+  });
+});
+
+describe("runWorkflowDriftChecks", () => {
+  const base = {
+    fileExists: () => true,
+    env: {},
+    which: () => undefined,
+  };
+
+  it("skips when no brain reader is wired", () => {
+    const r = runWorkflowDriftChecks({ ...base });
+    expect(r).toHaveLength(1);
+    expect(r[0].ok).toBe(true);
+    expect((r[0] as { note: string }).note).toMatch(/skipped/);
+  });
+
+  it("passes when every stamped template matches its source", () => {
+    const r = runWorkflowDriftChecks({
+      ...base,
+      workflowProvenance: () => [
+        { id: "wf-a", sourcePath: "/w/a.json", sourceHash: "h1" },
+      ],
+      hashFile: () => "h1",
+    });
+    expect(r[0].ok).toBe(true);
+    expect((r[0] as { note: string }).note).toMatch(/1 template/);
+  });
+
+  it("fails and names the template when the source changed since import", () => {
+    const r = runWorkflowDriftChecks({
+      ...base,
+      workflowProvenance: () => [
+        { id: "dream-cycle-nightly", sourcePath: "/w/n.json", sourceHash: "old" },
+      ],
+      hashFile: () => "new",
+    });
+    expect(r[0].ok).toBe(false);
+    const reason = (r[0] as { reason: string }).reason;
+    expect(reason).toMatch(/dream-cycle-nightly/);
+    expect(reason).toMatch(/upsert/);
+  });
+
+  it("reports unstamped rows as unverifiable, not as drift", () => {
+    // Rows imported before the provenance migration are not known to be
+    // wrong — only unverifiable. Calling them drifted would cry wolf.
+    const r = runWorkflowDriftChecks({
+      ...base,
+      workflowProvenance: () => [{ id: "legacy" }],
+      hashFile: () => "h",
+    });
+    expect(r[0].ok).toBe(true);
+    expect((r[0] as { note: string }).note).toMatch(/no provenance/);
+  });
+
+  it("flags a stamped template whose source file has gone missing", () => {
+    const r = runWorkflowDriftChecks({
+      ...base,
+      fileExists: () => false,
+      workflowProvenance: () => [
+        { id: "wf-a", sourcePath: "/gone.json", sourceHash: "h1" },
+      ],
+      hashFile: () => "h1",
+    });
+    expect(r.some((c) => !c.ok)).toBe(true);
+    expect(JSON.stringify(r)).toMatch(/source gone/);
+  });
+
+  it("flags a stamped template whose source cannot be hashed", () => {
+    const r = runWorkflowDriftChecks({
+      ...base,
+      workflowProvenance: () => [
+        { id: "wf-a", sourcePath: "/locked.json", sourceHash: "h1" },
+      ],
+      hashFile: () => undefined,
+    });
+    expect(JSON.stringify(r)).toMatch(/unreadable/);
+  });
+
+  it("reports a reader failure instead of throwing", () => {
+    const r = runWorkflowDriftChecks({
+      ...base,
+      workflowProvenance: () => {
+        throw new Error("db locked");
+      },
+      hashFile: () => "h",
+    });
+    expect(r[0].ok).toBe(false);
+    expect((r[0] as { reason: string }).reason).toMatch(/db locked/);
+  });
+
+  it("stringifies a non-Error throw from the reader", () => {
+    const r = runWorkflowDriftChecks({
+      ...base,
+      workflowProvenance: () => {
+        throw "sqlite exploded";
+      },
+      hashFile: () => "h",
+    });
+    expect(r[0].ok).toBe(false);
+    expect((r[0] as { reason: string }).reason).toMatch(/sqlite exploded/);
+  });
+
+  it("passes when the brain holds no templates at all", () => {
+    const r = runWorkflowDriftChecks({
+      ...base,
+      workflowProvenance: () => [],
+      hashFile: () => "h",
+    });
+    expect(r[0].ok).toBe(true);
+    expect((r[0] as { note: string }).note).toMatch(/no workflow templates/);
   });
 });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -69,6 +69,25 @@ export type DoctorDeps = {
    * `<digital-me-os-repo>` placeholder.
    */
   readonly repoRoot?: string;
+  /**
+   * Provenance of every workflow template in the brain, for the
+   * template-drift check. Optional — when undefined the check reports
+   * itself as skipped, matching the execCommand/readFile convention.
+   *
+   * Kept as an injected reader rather than a DB handle so this module
+   * stays free of sqlite: the caller owns opening the brain.
+   */
+  readonly workflowProvenance?: () => readonly WorkflowProvenance[];
+  /** sha256 of a file's raw bytes; undefined when unreadable. */
+  readonly hashFile?: (path: string) => string | undefined;
+};
+
+/** One template's link back to the file it was imported from. */
+export type WorkflowProvenance = {
+  readonly id: string;
+  readonly sourcePath?: string;
+  readonly sourceHash?: string;
+  readonly importedAt?: number;
 };
 
 export type RuntimeId =
@@ -265,6 +284,10 @@ export function runDoctor(
   if (enabledRuntimes.includes("openclaw")) {
     checks.push(...runMemoryIndexChecks(deps));
     checks.push(...runOpenclawShadowCheck(deps));
+  }
+
+  if (enabledRuntimes.includes("dream-cycle")) {
+    checks.push(...runWorkflowDriftChecks(deps));
   }
 
   const passed = checks.filter((c) => c.ok).length;
@@ -819,4 +842,93 @@ export function runLlmAuthCheck(deps: DoctorDeps, python: string): CheckResult {
     label: "dream-cycle: LLM auth",
     reason: `engine=${engine}: $${envName} is not set. Export it before running dream-cycle.`,
   };
+}
+
+/**
+ * Workflow templates are copied into the brain at install and never re-read,
+ * so an edit to a bundled file leaves the live template behind without any
+ * error surfacing. The consequence is silent: a drifted prompt degrades the
+ * step's output rather than failing it, and a degraded night is
+ * indistinguishable from a quiet one in the digest.
+ *
+ * This compares the sha256 recorded at import against the file on disk now.
+ * Deliberately narrow — it answers "has the source changed since import",
+ * not "is the live template correct". A hand-edited live template with no
+ * provenance is reported as unstamped, not as drifted, because we cannot
+ * know what it should have been.
+ */
+export function runWorkflowDriftChecks(deps: DoctorDeps): CheckResult[] {
+  const label = "dream-cycle: workflow template drift";
+  if (!deps.workflowProvenance || !deps.hashFile) {
+    return [
+      { ok: true, label, note: "skipped (no brain reader wired)" },
+    ];
+  }
+
+  let rows: readonly WorkflowProvenance[];
+  try {
+    rows = deps.workflowProvenance();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return [{ ok: false, label, reason: `Could not read templates: ${msg}` }];
+  }
+
+  if (rows.length === 0) {
+    return [{ ok: true, label, note: "no workflow templates imported" }];
+  }
+
+  const stamped = rows.filter((r) => r.sourcePath && r.sourceHash);
+  if (stamped.length === 0) {
+    // Every row predates the provenance migration. Not a failure: nothing is
+    // known to be wrong, only unverifiable. Re-importing stamps them.
+    return [
+      {
+        ok: true,
+        label,
+        note: `${rows.length} template(s) carry no provenance — re-import to stamp them`,
+      },
+    ];
+  }
+
+  const drifted: string[] = [];
+  const missing: string[] = [];
+  for (const r of stamped) {
+    const path = r.sourcePath as string;
+    if (!deps.fileExists(path)) {
+      missing.push(`${r.id} (source gone: ${path})`);
+      continue;
+    }
+    const now = deps.hashFile(path);
+    if (now === undefined) {
+      missing.push(`${r.id} (source unreadable: ${path})`);
+      continue;
+    }
+    if (now !== r.sourceHash) drifted.push(r.id);
+  }
+
+  const out: CheckResult[] = [];
+  if (drifted.length > 0) {
+    out.push({
+      ok: false,
+      label,
+      reason:
+        `${drifted.join(", ")} differ(s) from the bundled file it was imported from. ` +
+        `The live template is what actually runs. Re-import with ` +
+        `importMode="upsert" to converge.`,
+    });
+  } else {
+    out.push({
+      ok: true,
+      label,
+      note: `${stamped.length} template(s) match their source`,
+    });
+  }
+  if (missing.length > 0) {
+    out.push({
+      ok: false,
+      label: `${label} (source file)`,
+      reason: missing.join("; "),
+    });
+  }
+  return out;
 }

--- a/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.test.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.test.ts
@@ -916,3 +916,76 @@ describe("importWorkflowFromJson", () => {
     expect(deps.workflows.listSteps("wf-def")[0]!.sortOrder).toBe(0);
   });
 });
+
+describe("importWorkflowFromJson provenance", () => {
+  const withSource = (source: unknown) =>
+    JSON.stringify({
+      id: "wf-src",
+      name: "S",
+      steps: [{ stepKey: "s", dispatch: { mode: "manual" } }],
+      source,
+    });
+
+  it("records a well-formed source stamp", () => {
+    const deps = makeDeps();
+    const r = importWorkflowFromJson(
+      deps,
+      withSource({ path: "/w/n.json", hash: "h1", version: "9.9.9" }),
+    );
+    expect(r.ok).toBe(true);
+    expect(deps.workflows.get("wf-src")!.source).toEqual({
+      path: "/w/n.json",
+      hash: "h1",
+      version: "9.9.9",
+    });
+  });
+
+  it.each([
+    ["not an object", "nope"],
+    ["null", null],
+    ["missing hash", { path: "/w/n.json" }],
+    ["missing path", { hash: "h1" }],
+    ["empty path", { path: "", hash: "h1" }],
+    ["empty hash", { path: "/w/n.json", hash: "" }],
+    ["non-string path", { path: 7, hash: "h1" }],
+  ])("ignores a malformed source stamp (%s)", (_label, source) => {
+    // A half-written stamp is worse than none: doctor would compare against
+    // a hash that never meant anything. Drop it rather than store it.
+    const deps = makeDeps();
+    const r = importWorkflowFromJson(deps, withSource(source));
+    expect(r.ok).toBe(true);
+    expect(deps.workflows.get("wf-src")!.source).toBeUndefined();
+  });
+
+  it("drops a non-string version but keeps the stamp", () => {
+    const deps = makeDeps();
+    importWorkflowFromJson(
+      deps,
+      withSource({ path: "/w/n.json", hash: "h1", version: 3 }),
+    );
+    expect(deps.workflows.get("wf-src")!.source).toEqual({
+      path: "/w/n.json",
+      hash: "h1",
+      version: undefined,
+    });
+  });
+
+  it("an upsert without a stamp preserves the previous one", () => {
+    const deps = makeDeps();
+    importWorkflowFromJson(
+      deps,
+      withSource({ path: "/w/n.json", hash: "h1" }),
+    );
+    const r = importWorkflowFromJson(
+      deps,
+      JSON.stringify({
+        id: "wf-src",
+        name: "S2",
+        steps: [{ stepKey: "s", dispatch: { mode: "manual" } }],
+      }),
+      "upsert",
+    );
+    expect(r.ok).toBe(true);
+    expect(deps.workflows.get("wf-src")!.source?.hash).toBe("h1");
+  });
+});

--- a/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.ts
+++ b/packages/plugins/brain-orchestrator/src/handlers/workflow-builder.ts
@@ -24,6 +24,7 @@ import type { TasksStore, TaskDispatch, TaskPriority, UpstreamFailurePolicy } fr
 import type {
   WorkflowBranchingPolicy,
   WorkflowStepTemplateRecord,
+  WorkflowSource,
   WorkflowTemplateRecord,
   WorkflowVariable,
   WorkflowsStore,
@@ -190,6 +191,7 @@ export function createWorkflowFromSteps(
   branching?: WorkflowBranchingPolicy,
   notifyTarget?: Originator,
   mode: ImportMode = "create",
+  source?: WorkflowSource,
 ): BuilderResult {
   const existing = deps.workflows.get(workflowId);
   if (existing && mode !== "upsert") {
@@ -246,6 +248,9 @@ export function createWorkflowFromSteps(
     tags: existing?.tags ?? [],
     branching,
     notifyTarget,
+    // A re-import that carries no provenance must not erase the stamp a
+    // previous import left behind.
+    source: source ?? existing?.source,
   };
 
   const replacing = Boolean(existing);
@@ -280,6 +285,7 @@ export function createWorkflowFromSteps(
 // ── importWorkflowFromJson ────────────────────────────────────────────────
 
 type RawJson = {
+  source?: unknown;
   id?: string;
   name?: string;
   description?: string;
@@ -364,7 +370,21 @@ export function importWorkflowFromJson(
     data.branching,
     notifyTarget,
     mode,
+    validateSource(data.source),
   );
+}
+
+/** Accept a provenance block only when it carries a non-empty path + hash. */
+function validateSource(raw: unknown): WorkflowSource | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as { path?: unknown; hash?: unknown; version?: unknown };
+  if (typeof r.path !== "string" || !r.path) return undefined;
+  if (typeof r.hash !== "string" || !r.hash) return undefined;
+  return {
+    path: r.path,
+    hash: r.hash,
+    version: typeof r.version === "string" ? r.version : undefined,
+  };
 }
 
 // ── Internals ─────────────────────────────────────────────────────────────

--- a/packages/plugins/brain-orchestrator/src/store/workflows.test.ts
+++ b/packages/plugins/brain-orchestrator/src/store/workflows.test.ts
@@ -397,10 +397,32 @@ describe("createWorkflowsStore — defensive JSON parsing", () => {
 });
 
 describe("WORKFLOWS_MIGRATIONS", () => {
-  it("registers both tables at a stable version", () => {
-    expect(WORKFLOWS_MIGRATIONS).toHaveLength(1);
-    expect(WORKFLOWS_MIGRATIONS[0]!.version).toBeGreaterThan(0);
-    expect(WORKFLOWS_MIGRATIONS[0]!.description).toMatch(/workflow/i);
+  it("registers its migrations at stable, strictly increasing versions", () => {
+    expect(WORKFLOWS_MIGRATIONS.length).toBeGreaterThan(0);
+    for (const m of WORKFLOWS_MIGRATIONS) {
+      expect(m.version).toBeGreaterThan(0);
+      expect(m.description).toMatch(/workflow/i);
+    }
+    const versions = WORKFLOWS_MIGRATIONS.map((m) => m.version);
+    expect([...versions].sort((a, b) => a - b)).toEqual(versions);
+    expect(new Set(versions).size).toBe(versions.length);
+  });
+
+  it("adds the provenance columns and is safe to re-run", () => {
+    const fresh = new DatabaseSync(":memory:");
+    for (const m of WORKFLOWS_MIGRATIONS) m.up(fresh);
+    // Re-running must not throw on the already-present columns: a partially
+    // migrated DB is a normal state, not an error.
+    for (const m of WORKFLOWS_MIGRATIONS) m.up(fresh);
+    const cols = (
+      fresh.prepare("PRAGMA table_info(workflow_templates)").all() as Array<{
+        name: string;
+      }>
+    ).map((c) => c.name);
+    expect(cols).toContain("source_path");
+    expect(cols).toContain("source_hash");
+    expect(cols).toContain("source_version");
+    fresh.close();
   });
 
   it("produces usable tables when applied to a fresh DB", () => {
@@ -419,5 +441,65 @@ describe("WORKFLOWS_MIGRATIONS", () => {
     expect(stepCols.map((c) => c.name)).toContain("dispatch");
     expect(stepCols.map((c) => c.name)).toContain("sort_order");
     fresh.close();
+  });
+});
+
+describe("workflow provenance round-trip", () => {
+  const base: WorkflowTemplateRecord = {
+    id: "wf-p",
+    name: "P",
+    description: "",
+    variables: [],
+    createdAt: 1,
+    updatedAt: 1,
+    version: 1,
+  };
+
+  it("persists and reads back a full source stamp", () => {
+    const store = createWorkflowsStore({ db });
+    store.create({
+      ...base,
+      source: { path: "/w/n.json", hash: "abc123", version: "1.2.3" },
+    });
+    expect(store.get("wf-p")!.source).toEqual({
+      path: "/w/n.json",
+      hash: "abc123",
+      version: "1.2.3",
+    });
+  });
+
+  it("omits source entirely when the template has no provenance", () => {
+    const store = createWorkflowsStore({ db });
+    store.create(base);
+    expect(store.get("wf-p")!.source).toBeUndefined();
+  });
+
+  it("tolerates a stamp with a path but no hash or version", () => {
+    // Not reachable through the validated import path, but a hand-written
+    // row must not crash the reader.
+    const store = createWorkflowsStore({ db });
+    store.create(base);
+    db.prepare(
+      "UPDATE workflow_templates SET source_path = ? WHERE id = ?",
+    ).run("/w/only-path.json", "wf-p");
+    expect(store.get("wf-p")!.source).toEqual({
+      path: "/w/only-path.json",
+      hash: "",
+      version: undefined,
+    });
+  });
+
+  it("carries the stamp through an update", () => {
+    const store = createWorkflowsStore({ db });
+    store.create({ ...base, source: { path: "/a.json", hash: "h1" } });
+    store.update({
+      ...base,
+      name: "P2",
+      version: 2,
+      source: { path: "/a.json", hash: "h2" },
+    });
+    const after = store.get("wf-p")!;
+    expect(after.name).toBe("P2");
+    expect(after.source).toEqual({ path: "/a.json", hash: "h2", version: undefined });
   });
 });

--- a/packages/plugins/brain-orchestrator/src/store/workflows.ts
+++ b/packages/plugins/brain-orchestrator/src/store/workflows.ts
@@ -51,6 +51,21 @@ export type WorkflowTemplateRecord = {
   readonly tags?: readonly string[];
   readonly branching?: WorkflowBranchingPolicy;
   readonly notifyTarget?: Originator;
+  /**
+   * Where this template was imported from, when it came from a file.
+   * Absent for hand-authored templates and for rows imported before the
+   * v301 migration. `hash` is the sha256 of the source file's raw bytes at
+   * import time — `digital-me doctor` re-hashes the file on disk and
+   * compares, which is how a drifted live template becomes visible.
+   */
+  readonly source?: WorkflowSource;
+};
+
+export type WorkflowSource = {
+  readonly path: string;
+  readonly hash: string;
+  /** Version of the package that shipped the file, when known. */
+  readonly version?: string;
 };
 
 export type WorkflowStepTemplateRecord = {
@@ -72,6 +87,7 @@ export type WorkflowStepTemplateRecord = {
 // ── Schema migration ──────────────────────────────────────────────────────
 
 const WORKFLOWS_VERSION = 300;
+const WORKFLOWS_PROVENANCE_VERSION = 301;
 
 export const WORKFLOWS_MIGRATIONS: readonly Migration[] = [
   {
@@ -111,6 +127,31 @@ export const WORKFLOWS_MIGRATIONS: readonly Migration[] = [
       `);
     },
   },
+  {
+    version: WORKFLOWS_PROVENANCE_VERSION,
+    description:
+      "v301: workflow_templates provenance (source_path/source_hash/source_version)",
+    up: (db: DatabaseSync) => {
+      // Templates are imported FROM a bundled file but kept no link back to
+      // it, so a drifted copy was undetectable. These columns record which
+      // file a template was imported from and what it hashed to at the time,
+      // which is what `digital-me doctor` compares against on disk.
+      // Nullable throughout: rows imported before this migration, and
+      // hand-authored templates with no file behind them, legitimately have
+      // no provenance.
+      for (const col of [
+        "source_path TEXT",
+        "source_hash TEXT",
+        "source_version TEXT",
+      ]) {
+        try {
+          db.exec(`ALTER TABLE workflow_templates ADD COLUMN ${col};`);
+        } catch {
+          // Column already present (re-run against a partially migrated DB).
+        }
+      }
+    },
+  },
 ];
 
 // ── Row mapping ────────────────────────────────────────────────────────────
@@ -126,6 +167,9 @@ type WorkflowRow = {
   tags: string;
   branching: string | null;
   notify_target: string | null;
+  source_path: string | null;
+  source_hash: string | null;
+  source_version: string | null;
 };
 
 type WorkflowStepRow = {
@@ -178,6 +222,13 @@ function rowToWorkflow(row: WorkflowRow): WorkflowTemplateRecord {
     tags: jsonParseOr<readonly string[]>(row.tags, []),
     branching: jsonParseOpt<WorkflowBranchingPolicy>(row.branching),
     notifyTarget: jsonParseOpt<Originator>(row.notify_target),
+    source: row.source_path
+      ? {
+          path: row.source_path,
+          hash: row.source_hash ?? "",
+          version: row.source_version ?? undefined,
+        }
+      : undefined,
   };
 }
 
@@ -224,8 +275,9 @@ export function createWorkflowsStore(deps: {
   const insertWorkflow = db.prepare(`
     INSERT INTO workflow_templates
       (id, name, description, variables, created_at, updated_at,
-       version, tags, branching, notify_target)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       version, tags, branching, notify_target,
+       source_path, source_hash, source_version)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const selectById = db.prepare(
     "SELECT * FROM workflow_templates WHERE id = ?",
@@ -236,7 +288,8 @@ export function createWorkflowsStore(deps: {
   const updateStmt = db.prepare(`
     UPDATE workflow_templates SET
       name = ?, description = ?, variables = ?, updated_at = ?, version = ?,
-      tags = ?, branching = ?, notify_target = ?
+      tags = ?, branching = ?, notify_target = ?,
+      source_path = ?, source_hash = ?, source_version = ?
     WHERE id = ?
   `);
   const deleteSteps = db.prepare(
@@ -269,6 +322,9 @@ export function createWorkflowsStore(deps: {
       JSON.stringify(template.tags ?? []),
       template.branching ? JSON.stringify(template.branching) : null,
       template.notifyTarget ? JSON.stringify(template.notifyTarget) : null,
+      template.source?.path ?? null,
+      template.source?.hash ?? null,
+      template.source?.version ?? null,
     );
   }
 
@@ -291,6 +347,9 @@ export function createWorkflowsStore(deps: {
       JSON.stringify(template.tags ?? []),
       template.branching ? JSON.stringify(template.branching) : null,
       template.notifyTarget ? JSON.stringify(template.notifyTarget) : null,
+      template.source?.path ?? null,
+      template.source?.hash ?? null,
+      template.source?.version ?? null,
       template.id,
     );
   }

--- a/packages/services/dream-cycle/src/dream_cycle/brain_client.py
+++ b/packages/services/dream-cycle/src/dream_cycle/brain_client.py
@@ -203,19 +203,32 @@ class BrainClient:
             args["force"] = True
         return self._invoke("tasks", args)
 
-    def import_workflow(self, template: dict[str, Any]) -> dict[str, Any]:
+    def import_workflow(
+        self, template: dict[str, Any], upsert: bool = False
+    ) -> dict[str, Any]:
         """Import a workflow template into the brain's `workflow_templates`
         table. The gateway's `workflow_import` action expects a stringified
         JSON blob in `workflowJson` (NOT a dict), so we serialize here.
 
         Returns the parsed gateway result on success. Raises BrainClientError
-        if the workflow id already exists or any validation fails — note
-        the brain rejects same-id imports rather than upserting, so callers
-        wanting overwrite semantics must `delete_workflow` first."""
-        return self._invoke(
-            "tasks",
-            {"action": "workflow_import", "workflowJson": json.dumps(template)},
-        )
+        on validation failure.
+
+        `upsert=True` replaces an existing template and its steps in place,
+        preserving schedules and the original createdAt. Without it the
+        brain refuses a same-id import, and the only other overwrite path is
+        `delete_workflow` first — which is gated on tearing down every
+        schedule that references the workflow.
+
+        Sends `importMode` (not `mode`) because the tasks tool already uses
+        `mode` for retry's restart|resume. Older gateways ignore the unknown
+        param and fall back to create semantics."""
+        params: dict[str, Any] = {
+            "action": "workflow_import",
+            "workflowJson": json.dumps(template),
+        }
+        if upsert:
+            params["importMode"] = "upsert"
+        return self._invoke("tasks", params)
 
     def delete_workflow(self, template_id: str) -> dict[str, Any]:
         """Delete a workflow template by id. Raises BrainClientError if

--- a/packages/services/dream-cycle/src/dream_cycle/install_workflows.py
+++ b/packages/services/dream-cycle/src/dream_cycle/install_workflows.py
@@ -21,6 +21,7 @@ Optional variables flow from CLI flags or kept at workflow defaults.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -95,6 +96,22 @@ def _apply_template_defaults(
     return merged
 
 
+def _hash_file(path: Path) -> str:
+    """sha256 of a file's raw bytes, as lowercase hex."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _package_version() -> Optional[str]:
+    """Installed dream-cycle version, when resolvable. Best-effort: a source
+    checkout that was never pip-installed has no distribution metadata."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("digital-me-dream-cycle")
+    except Exception:
+        return None
+
+
 def _sibling_schedule_path(wf_path: Path) -> Path:
     """Convention: workflows/foo.json's companion schedule lives at
     workflows/foo.schedule.json. Returns the expected path (may not exist)."""
@@ -139,6 +156,38 @@ def _register_sibling_schedule(
     # re-install. None → brain keeps its UTC default (unchanged behavior).
     tz_raw = sched.get("timezone")
     timezone = tz_raw if isinstance(tz_raw, str) and tz_raw.strip() else None
+
+    # Guard against creating a SECOND schedule for the same workflow.
+    #
+    # Install no longer tears down every schedule referencing the workflow
+    # (upsert made that unnecessary, and the teardown destroyed hand-tuned
+    # schedules). But that removes the accident that used to mask a rename:
+    # if the live schedule carries an id different from the bundled
+    # sibling's, a blind add would leave BOTH in place and the workflow
+    # would fire twice a night.
+    #
+    # So: if some other schedule already targets this workflow, leave it
+    # alone and say so. Destroying a live schedule and silently doubling one
+    # are both worse than declining and reporting.
+    try:
+        for sched in client.schedule_list():
+            if not isinstance(sched, dict):
+                continue
+            # MCP returns camelCase; be defensive.
+            ref = sched.get("workflowId") or sched.get("workflow_id")
+            if ref != wf_id:
+                continue
+            existing_id = sched.get("id") or sched.get("scheduleId")
+            if isinstance(existing_id, str) and existing_id != schedule_id:
+                return (
+                    f"schedule '{existing_id}' already targets this workflow "
+                    f"(bundled id is '{schedule_id}') — left as-is; "
+                    f"remove one to converge"
+                )
+    except BrainClientError:
+        # Can't enumerate: fall through to the id-scoped replace below,
+        # which is the pre-existing behavior.
+        pass
 
     # Idempotent install: drop any prior schedule with this id, then
     # re-create. Swallow not-found on first install.
@@ -188,46 +237,25 @@ def install_workflows(
             effective_vars = _apply_template_defaults(template, vars)
             materialized = materialize_workflow(template, effective_vars)
             wf_id = template.get("id", "?")
-            # workflow_import rejects same-id duplicates rather than
-            # upserting. For idempotent re-install (the common path:
-            # `digital-me install --runtime dream-cycle` re-run after an
-            # OS update), delete-first-then-import. The brain refuses to
-            # delete a workflow whose enabled schedule references it, so
-            # remove ANY schedule pointing at this workflow first.
-            #
-            # We enumerate schedule_list rather than guessing from the
-            # sibling .schedule.json's `scheduleId`: legacy installs may
-            # have renamed the schedule, so the only reliable cleanup is
-            # by workflow reference. Swallow not-found errors throughout
-            # since first-time install has nothing prior to delete.
-            try:
-                for sched in client.schedule_list():
-                    if not isinstance(sched, dict):
-                        continue
-                    # MCP returns camelCase fields; be defensive.
-                    sched_workflow_id = (
-                        sched.get("workflowId") or sched.get("workflow_id")
-                    )
-                    if sched_workflow_id != wf_id:
-                        continue
-                    sched_id = sched.get("id") or sched.get("scheduleId")
-                    if not isinstance(sched_id, str):
-                        continue
-                    try:
-                        client.schedule_remove(sched_id)
-                    except BrainClientError:
-                        pass
-            except BrainClientError:
-                # schedule_list itself failed — log nothing, let workflow_delete
-                # surface its own error if the schedule is still blocking.
-                pass
-            try:
-                client.delete_workflow(wf_id)
-            except BrainClientError:
-                # Either not-found (first install) or some other error;
-                # let the import try anyway and surface its own error.
-                pass
-            client.import_workflow(materialized)
+            # Stamp provenance so `digital-me doctor` can tell whether the
+            # live template still matches the file it came from. The hash is
+            # of the file's RAW bytes, pre-substitution: it answers "has the
+            # source changed since import", which is the question drift asks.
+            materialized["source"] = {
+                "path": str(wf_path.resolve()),
+                "hash": _hash_file(wf_path),
+                "version": _package_version(),
+            }
+            # Upsert replaces the template and its steps in place. The old
+            # path here was delete-then-import, which required first removing
+            # EVERY schedule referencing the workflow (the brain refuses to
+            # delete an workflow an enabled schedule points at) and then
+            # re-registering only what the sibling .schedule.json describes —
+            # so any live schedule with no sibling, or with hand-tuned
+            # variables, was silently destroyed by a routine re-install.
+            # Upsert keeps schedules untouched and removes the window where
+            # the workflow does not exist.
+            client.import_workflow(materialized, upsert=True)
         except (OSError, json.JSONDecodeError) as e:
             results.append((wf_path, False, f"failed to read/parse: {e}"))
             continue

--- a/packages/services/dream-cycle/tests/test_install_workflows.py
+++ b/packages/services/dream-cycle/tests/test_install_workflows.py
@@ -286,3 +286,122 @@ def test_install_workflows_handles_empty_input() -> None:
     results = install_workflows([], vars={"wiki_root": "/", "python_path": "/p"}, client=client)
     assert results == []
     client.import_workflow.assert_not_called()
+
+
+def test_install_stamps_provenance_and_upserts(tmp_path: Path) -> None:
+    """Every import carries a source stamp (path + sha256 of the RAW file)
+    and uses upsert, so `doctor` can detect drift and schedules survive."""
+    import hashlib
+
+    template = {
+        "id": "wf-prov",
+        "name": "Prov",
+        "steps": [{"stepKey": "s", "dispatch": {"mode": "manual"}}],
+    }
+    wf_path = _make_workflow_file(tmp_path, "wf-prov", template)
+
+    client = MagicMock()
+    client.import_workflow.return_value = {"ok": True}
+    results = install_workflows(
+        [wf_path],
+        vars={"wiki_root": "/tmp/w", "python_path": "/venv/bin/python"},
+        client=client,
+    )
+    assert results[0][1] is True
+
+    imported = client.import_workflow.call_args.args[0]
+    src = imported["source"]
+    assert src["path"] == str(wf_path.resolve())
+    # hash is of the raw bytes on disk, NOT the materialized dict
+    assert src["hash"] == hashlib.sha256(wf_path.read_bytes()).hexdigest()
+
+    assert client.import_workflow.call_args.kwargs.get("upsert") is True
+
+
+def test_install_no_longer_tears_down_schedules(tmp_path: Path) -> None:
+    """Regression: the old delete-then-import path removed every schedule
+    referencing the workflow, destroying any with hand-tuned variables or no
+    sibling .schedule.json. Upsert must touch neither."""
+    template = {
+        "id": "wf-keep",
+        "name": "Keep",
+        "steps": [{"stepKey": "s", "dispatch": {"mode": "manual"}}],
+    }
+    wf_path = _make_workflow_file(tmp_path, "wf-keep", template)
+
+    client = MagicMock()
+    client.import_workflow.return_value = {"ok": True}
+    install_workflows(
+        [wf_path],
+        vars={"wiki_root": "/tmp/w", "python_path": "/venv/bin/python"},
+        client=client,
+    )
+
+    client.delete_workflow.assert_not_called()
+    client.schedule_remove.assert_not_called()
+
+
+def test_sibling_schedule_declines_when_another_id_targets_the_workflow(
+    tmp_path: Path,
+) -> None:
+    """A live schedule under a different id must not be duplicated. Install
+    leaves it alone and reports, rather than double-firing the workflow."""
+    template = {
+        "id": "wf-sched",
+        "name": "Sched",
+        "steps": [{"stepKey": "s", "dispatch": {"mode": "manual"}}],
+    }
+    wf_path = _make_workflow_file(tmp_path, "wf-sched", template)
+    (tmp_path / "wf-sched.schedule.json").write_text(
+        json.dumps(
+            {"scheduleId": "bundled-id", "cronExpr": "0 3 * * *"}
+        ),
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+    client.import_workflow.return_value = {"ok": True}
+    client.schedule_list.return_value = [
+        {"id": "renamed-live-id", "workflowId": "wf-sched"}
+    ]
+
+    results = install_workflows(
+        [wf_path],
+        vars={"wiki_root": "/tmp/w", "python_path": "/venv/bin/python"},
+        client=client,
+    )
+
+    _, ok, msg = results[0]
+    assert ok is True
+    assert "renamed-live-id" in msg
+    assert "left as-is" in msg
+    client.schedule_add.assert_not_called()
+    client.schedule_remove.assert_not_called()
+
+
+def test_sibling_schedule_replaces_when_id_matches(tmp_path: Path) -> None:
+    """The ordinary re-install path still replaces the schedule in place."""
+    template = {
+        "id": "wf-sched2",
+        "name": "Sched2",
+        "steps": [{"stepKey": "s", "dispatch": {"mode": "manual"}}],
+    }
+    wf_path = _make_workflow_file(tmp_path, "wf-sched2", template)
+    (tmp_path / "wf-sched2.schedule.json").write_text(
+        json.dumps({"scheduleId": "same-id", "cronExpr": "0 3 * * *"}),
+        encoding="utf-8",
+    )
+
+    client = MagicMock()
+    client.import_workflow.return_value = {"ok": True}
+    client.schedule_list.return_value = [
+        {"id": "same-id", "workflowId": "wf-sched2"}
+    ]
+
+    results = install_workflows(
+        [wf_path],
+        vars={"wiki_root": "/tmp/w", "python_path": "/venv/bin/python"},
+        client=client,
+    )
+    assert results[0][1] is True
+    client.schedule_add.assert_called_once()


### PR DESCRIPTION
Builds on #82 (merged).

## Why

Templates are imported *from* a bundled file but kept no link back to it, so a live template that no longer matched its source was undetectable by any tool.

The failure mode is silent by construction: a drifted prompt **degrades** a step's output rather than failing it. Concretely — `dream-cycle-nightly` ran every night since 2026-06-08 on a template whose `taste-distill` prompt had diverged from the bundled file. The classifier reported *"fully blind classification"* and defaulted transcripts to NEITHER; the digest rendered "no taste distilled", which is indistinguishable from a genuinely quiet night. Nothing errored. Nobody could have known.

## What

**Provenance** — `source_path` / `source_hash` / `source_version` on `workflow_templates` (migration v301, nullable, safe to re-run against a partially migrated DB). `install_workflows.py` stamps the sha256 of the bundled file's **raw bytes**, pre-substitution, because the question drift asks is *"has the source changed since import"*.

**Drift check** — `digital-me doctor` re-hashes each stamped file and names any template that no longer matches. Deliberately narrow: it answers "has the source changed", **not** "is the live template correct". A hand-edited template with no stamp is reported as *unverifiable*, never as drifted — calling every pre-migration row "drift" would cry wolf and train you to ignore the check.

The check is a pure function with an injected reader (`workflowProvenance` + `hashFile`), matching doctor's existing `readFile` / `execCommand` convention, so `doctor.ts` stays free of sqlite. The DB read in `bin/` is read-only and best-effort: a missing DB, pre-v301 schema, or locked file degrades to "skipped", never to a failed check — doctor must not be the reason a machine looks broken.

**Installer switched to upsert** — removes a hazard, not just boilerplate. The old delete-then-import path had to tear down *every* schedule referencing the workflow first, so a routine re-install silently destroyed any schedule with hand-tuned variables or no sibling `.schedule.json`.

**Duplicate-schedule guard** — removing that teardown exposed a latent bug it had been masking. If the live schedule carries an id different from the bundled sibling's (a rename), a blind `add` would now leave **both** in place and the workflow would fire twice a night. `_register_sibling_schedule` now declines and reports when another id already targets the workflow. Destroying a live schedule and silently doubling one are both worse than saying so and letting the operator choose.

## Tests

**100% statements / branches / functions / lines** — 876 orchestrator + 200 cli. 159 Python tests pass.

- provenance round-trips through create *and* update; absent when unstamped; tolerates a path-only row without crashing
- malformed stamps (7 cases: non-object, null, missing/empty path or hash, non-string path) are dropped, not half-stored — a stamp with a meaningless hash is worse than none
- an upsert carrying no stamp preserves the previous one
- drift: matches / differs / unstamped / source missing / source unreadable / reader throws (Error and non-Error) / no templates
- installer stamps the raw-bytes hash and calls `upsert=True`
- **regression: install no longer calls `delete_workflow` or `schedule_remove`**
- duplicate guard: declines on an id mismatch, still replaces on a match

## Still open (deliberately not here)

**spawn vs exec as the shipped default** — a product decision, not a bug. The bundled file and the live template disagree on dispatch topology, and converging them means choosing which is correct for new installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)