### PR TITLE
fix(dream-cycle): bind agent steps to a detected CLI worker, never a silent no-op

### DIFF
--- a/packages/services/dream-cycle/src/dream_cycle/install_workflows.py
+++ b/packages/services/dream-cycle/src/dream_cycle/install_workflows.py
@@ -30,6 +30,7 @@ from typing import Any, Iterable, Optional
 
 from dream_cycle.brain_client import BrainClient, BrainClientError
 from dream_cycle.config import resolve_wiki_root
+from dream_cycle.workers import WORKER_AGENT_PREFERENCE, detect_worker_agent_id
 from dream_cycle.via_agents import materialize_workflow
 
 
@@ -295,7 +296,13 @@ def _build_parser() -> argparse.ArgumentParser:
         "--classifier-agent-id",
         type=str,
         default=None,
-        help="Override the spawn agentId for the taste-distill step (workflow's default applies otherwise).",
+        help="Override the agentId for the taste-distill step (detected worker applies otherwise).",
+    )
+    parser.add_argument(
+        "--compiler-agent-id",
+        type=str,
+        default=None,
+        help="Override the agentId for the compile-extract step (detected worker applies otherwise).",
     )
     parser.add_argument(
         "--dashboard-db",
@@ -318,8 +325,39 @@ def main(argv: Optional[list[str]] = None) -> int:
     overrides: dict[str, str] = {}
     if args.classifier_agent_id:
         overrides["classifier_agent_id"] = args.classifier_agent_id
+    if args.compiler_agent_id:
+        overrides["compiler_agent_id"] = args.compiler_agent_id
     if args.dashboard_db:
         overrides["dashboard_db"] = str(args.dashboard_db)
+
+    # Bind the agent steps to a worker that actually exists on this machine.
+    # Explicit flags win; otherwise detect. Failing loudly here beats importing
+    # a workflow whose agent steps cannot run: an unresolvable exec alias falls
+    # through to the step's placeholder command, and a placeholder that exits 0
+    # would make the nightly report success while doing nothing.
+    detected = detect_worker_agent_id(wiki_root)
+    explicit = bool(args.classifier_agent_id and args.compiler_agent_id)
+    if detected is None and not explicit:
+        print(
+            "install-workflows: no CLI worker alias configured.\n"
+            f"  Looked for {' or '.join(WORKER_AGENT_PREFERENCE)} under "
+            f"cli_exec_aliases in {wiki_root / 'config.yaml'}.\n"
+            "  The agent steps (wiki extraction, taste distillation) cannot run "
+            "without one.\n"
+            "  Fix: install the Claude Code CLI or the Codex CLI and re-run "
+            "`digital-me setup`, which registers the alias.\n"
+            "  Override: pass --classifier-agent-id / --compiler-agent-id "
+            "to name a worker explicitly.",
+            file=sys.stderr,
+        )
+        return 4
+    if detected is not None:
+        overrides.setdefault("classifier_agent_id", detected)
+        overrides.setdefault("compiler_agent_id", detected)
+        print(
+            f"install-workflows: worker agent = {detected} (detected)",
+            file=sys.stderr,
+        )
 
     vars = _build_install_vars(wiki_root, python_path, overrides)
     paths = discover_bundled_workflows(args.workflows_dir)

--- a/packages/services/dream-cycle/src/dream_cycle/via_agents.py
+++ b/packages/services/dream-cycle/src/dream_cycle/via_agents.py
@@ -32,6 +32,7 @@ from typing import Any, Optional
 
 from dream_cycle.brain_client import BrainClient, BrainClientError
 from dream_cycle.config import resolve_wiki_root
+from dream_cycle.workers import WORKER_AGENT_PREFERENCE, detect_worker_agent_id
 
 
 _VAR_RE = re.compile(r"\{\{(\w+)\}\}")
@@ -197,6 +198,24 @@ def run(args: argparse.Namespace, client: Optional[BrainClient] = None) -> int:
         "dry_run": "true" if args.dry_run else "false",
         "python_path": python_path,
     })
+
+    # The agent steps carry no default agentId on purpose (a default would
+    # resurrect the bare `claude-code` spawn agent, which has no tools and
+    # stalls). Detect the same way install_workflows does so a direct run and
+    # an installed run bind to the same worker.
+    worker = detect_worker_agent_id(wiki_root)
+    if worker is not None:
+        for name in ("compiler_agent_id", "classifier_agent_id"):
+            vars.setdefault(name, worker)
+        print(f"worker:      {worker} (detected)", file=sys.stderr)
+    else:
+        print(
+            "worker:      NONE — no "
+            f"{' or '.join(WORKER_AGENT_PREFERENCE)} in "
+            f"{wiki_root / 'config.yaml'}; the agent steps will fail loudly "
+            "(exit 78) rather than silently no-op.",
+            file=sys.stderr,
+        )
 
     materialized = materialize_workflow(template, vars)
     template_id = args.template_id or materialized["id"]

--- a/packages/services/dream-cycle/src/dream_cycle/workers.py
+++ b/packages/services/dream-cycle/src/dream_cycle/workers.py
@@ -1,0 +1,53 @@
+"""Which CLI-exec worker runs the workflow's agent steps.
+
+Lives in its own module because both entry points need it and they already
+import each other: `install_workflows` imports `materialize_workflow` from
+`via_agents`, so `via_agents` cannot import back from `install_workflows`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+import yaml
+
+# Preference order for the CLI-exec worker that runs the agent steps.
+#
+# claude-code-cli first: runs on a local Claude subscription, has full file
+# tools + the openclaw-brain MCP, and is proven end-to-end for these steps.
+#
+# codex-cli second, deliberately: Codex-CLI on ChatGPT Plus has produced
+# multi-day quota blackouts on critical cron paths, and a rate-limited
+# dispatcher cannot always report its own failure. Fine as a fallback, never
+# the first choice for a nightly.
+#
+# NOT in this list: the bare in-gateway `claude-code` spawn agent. It has no
+# exec tools and no brain MCP, so it can neither read the staging file nor
+# call tasks.handoff — it stalls silently until the watchdog fires. It was the
+# shipped default until this change, and it is why this module exists.
+WORKER_AGENT_PREFERENCE: tuple[str, ...] = ("claude-code-cli", "codex-cli")
+
+
+def detect_worker_agent_id(
+    wiki_root: Path,
+    preference: Iterable[str] = WORKER_AGENT_PREFERENCE,
+) -> Optional[str]:
+    """Return the first configured cli_exec_alias from `preference`, else None.
+
+    Reads `<wiki_root>/config.yaml`. Missing, unreadable, or malformed all mean
+    "nothing configured" — the caller decides whether that is fatal.
+    """
+    try:
+        raw = yaml.safe_load((wiki_root / "config.yaml").read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    aliases = raw.get("cli_exec_aliases")
+    if not isinstance(aliases, dict):
+        return None
+    for candidate in preference:
+        if isinstance(aliases.get(candidate), dict):
+            return candidate
+    return None

--- a/packages/services/dream-cycle/src/dream_cycle/workflows/nightly.json
+++ b/packages/services/dream-cycle/src/dream_cycle/workflows/nightly.json
@@ -19,9 +19,8 @@
     },
     {
       "name": "classifier_agent_id",
-      "description": "agentId that the spawn dispatcher uses for the taste-distill step. Should be an agent configured with the openclaw-brain MCP so it can read + write the staging file. Defaults to claude-code; users who route classification through a specialized ops agent (e.g. coo) override here.",
-      "required": false,
-      "defaultValue": "claude-code"
+      "description": "CLI-exec worker alias for this step (e.g. claude-code-cli, codex-cli). Injected by install_workflows from the aliases configured in config.yaml; no default \u2014 an unconfigured install must fail loudly, not silently no-op.",
+      "required": false
     },
     {
       "name": "compile_limit",
@@ -55,9 +54,8 @@
     },
     {
       "name": "compiler_agent_id",
-      "description": "agentId for the compile-extract spawn step. Should be an agent with the openclaw-brain MCP so it can read+write the compile staging file. Defaults to claude-code; this is what makes wiki extraction agent-driven instead of the legacy inline Gemini engine.",
-      "required": false,
-      "defaultValue": "claude-code"
+      "description": "CLI-exec worker alias for this step (e.g. claude-code-cli, codex-cli). Injected by install_workflows from the aliases configured in config.yaml; no default \u2014 an unconfigured install must fail loudly, not silently no-op.",
+      "required": false
     }
   ],
   "steps": [
@@ -102,8 +100,14 @@
         "stage"
       ],
       "dispatch": {
-        "mode": "spawn",
-        "agentId": "{{compiler_agent_id}}"
+        "mode": "exec",
+        "agentId": "{{compiler_agent_id}}",
+        "command": [
+          "/bin/sh",
+          "-c",
+          "echo 'dream-cycle: step \"'\"$0\"'\" needs a CLI worker (cli_exec_alias), but none is registered \u2014 the alias resolver declined and this placeholder ran instead. The step did NO work. Fix: install the Claude Code CLI or the Codex CLI, run `digital-me setup` to register the alias, then re-run `python -m dream_cycle.install_workflows`.' >&2; exit 78",
+          "compile-extract"
+        ]
       },
       "priority": "normal",
       "onUpstreamFailure": "wait",
@@ -118,8 +122,14 @@
         "stage"
       ],
       "dispatch": {
-        "mode": "spawn",
-        "agentId": "{{classifier_agent_id}}"
+        "mode": "exec",
+        "agentId": "{{classifier_agent_id}}",
+        "command": [
+          "/bin/sh",
+          "-c",
+          "echo 'dream-cycle: step \"'\"$0\"'\" needs a CLI worker (cli_exec_alias), but none is registered \u2014 the alias resolver declined and this placeholder ran instead. The step did NO work. Fix: install the Claude Code CLI or the Codex CLI, run `digital-me setup` to register the alias, then re-run `python -m dream_cycle.install_workflows`.' >&2; exit 78",
+          "taste-distill"
+        ]
       },
       "priority": "normal",
       "onUpstreamFailure": "wait",

--- a/packages/services/dream-cycle/tests/test_agent_driven_compile.py
+++ b/packages/services/dream-cycle/tests/test_agent_driven_compile.py
@@ -107,8 +107,13 @@ def test_nightly_workflow_is_agent_driven() -> None:
     assert nightly["version"] >= 2
     steps = {s["stepKey"]: s for s in nightly["steps"]}
     assert set(steps) == {"stage", "compile-extract", "taste-distill", "apply"}
-    # compile extraction is now a spawn, not inline
-    assert steps["compile-extract"]["dispatch"]["mode"] == "spawn"
+    # Compile extraction is agent-driven, not inline. It dispatches via a
+    # CLI-exec alias (mode=exec + agentId), NOT mode=spawn: the bare in-gateway
+    # spawn agent has no exec tools and no brain MCP, so it can neither read the
+    # staging file nor call tasks.handoff, and stalls until the watchdog fires.
+    compile_dispatch = steps["compile-extract"]["dispatch"]
+    assert compile_dispatch["mode"] == "exec"
+    assert compile_dispatch["agentId"] == "{{compiler_agent_id}}"
     # apply waits on BOTH spawns and runs even if one fails
     assert set(steps["apply"]["blockedByKeys"]) == {"compile-extract", "taste-distill"}
     assert steps["apply"]["onUpstreamFailure"] == "continue"

--- a/packages/services/dream-cycle/tests/test_install_workflows.py
+++ b/packages/services/dream-cycle/tests/test_install_workflows.py
@@ -15,7 +15,9 @@ from dream_cycle.install_workflows import (
     _register_sibling_schedule,
     discover_bundled_workflows,
     install_workflows,
+    main,
 )
+from dream_cycle.workers import WORKER_AGENT_PREFERENCE, detect_worker_agent_id
 
 
 # ── _register_sibling_schedule: timezone forwarding ──────────────────────────
@@ -405,3 +407,125 @@ def test_sibling_schedule_replaces_when_id_matches(tmp_path: Path) -> None:
     )
     assert results[0][1] is True
     client.schedule_add.assert_called_once()
+
+
+# ── worker agent detection ───────────────────────────────────────────────────
+
+
+def _write_config(tmp_path: Path, aliases: object) -> Path:
+    import yaml as _yaml
+
+    (tmp_path / "config.yaml").write_text(
+        _yaml.safe_dump({"cli_exec_aliases": aliases}), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_detect_prefers_claude_code_cli_over_codex(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"codex-cli": {"binary": "codex"}, "claude-code-cli": {"binary": "claude"}})
+    assert detect_worker_agent_id(tmp_path) == "claude-code-cli"
+
+
+def test_detect_falls_back_to_codex_when_claude_absent(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"codex-cli": {"binary": "codex"}})
+    assert detect_worker_agent_id(tmp_path) == "codex-cli"
+
+
+def test_detect_ignores_the_bare_claude_code_spawn_agent(tmp_path: Path) -> None:
+    """`claude-code` is the known-broken bare spawn agent — never selectable."""
+    assert "claude-code" not in WORKER_AGENT_PREFERENCE
+    _write_config(tmp_path, {"claude-code": {"binary": "claude"}})
+    assert detect_worker_agent_id(tmp_path) is None
+
+
+def test_detect_returns_none_when_no_config_file(tmp_path: Path) -> None:
+    assert detect_worker_agent_id(tmp_path) is None
+
+
+def test_detect_returns_none_on_malformed_yaml(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("cli_exec_aliases: [oops\n", encoding="utf-8")
+    assert detect_worker_agent_id(tmp_path) is None
+
+
+def test_detect_returns_none_when_aliases_not_a_mapping(tmp_path: Path) -> None:
+    _write_config(tmp_path, ["claude-code-cli"])
+    assert detect_worker_agent_id(tmp_path) is None
+
+
+def test_detect_ignores_non_mapping_alias_entry(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"claude-code-cli": "not-a-mapping"})
+    assert detect_worker_agent_id(tmp_path) is None
+
+
+def test_main_fails_loudly_when_no_worker_configured(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exit 4 + actionable guidance beats importing a workflow that cannot run."""
+    rc = main(["--wiki-root", str(tmp_path)])
+    assert rc == 4
+    err = capsys.readouterr().err
+    assert "no CLI worker alias configured" in err
+    assert "claude-code-cli or codex-cli" in err
+    assert "digital-me setup" in err
+
+
+# ── bundled template: the agent steps must not silently no-op ────────────────
+
+
+def test_bundled_agent_steps_use_a_loudly_failing_placeholder() -> None:
+    """Regression guard for the ["true"] placeholder.
+
+    The alias resolver replaces `command` wholesale when the alias resolves; the
+    placeholder only survives when the alias is MISSING. A placeholder that
+    exits 0 turns an unconfigured install into a green run that did no work.
+    """
+    import subprocess
+
+    nightly = next(
+        p for p in discover_bundled_workflows() if p.name == "nightly.json"
+    )
+    steps = json.loads(nightly.read_text())["steps"]
+    agent_steps = [s for s in steps if s["stepKey"] in ("compile-extract", "taste-distill")]
+    assert len(agent_steps) == 2
+
+    for step in agent_steps:
+        dispatch = step["dispatch"]
+        assert dispatch["mode"] == "exec"
+        assert dispatch["command"] != ["true"]
+        result = subprocess.run(dispatch["command"], capture_output=True, text=True)
+        assert result.returncode != 0, f"{step['stepKey']} placeholder exited 0"
+        assert "did NO work" in (result.stdout + result.stderr)
+
+
+def test_bundled_agent_ids_have_no_default() -> None:
+    """A default would silently resurrect the broken bare spawn agent."""
+    nightly = next(
+        p for p in discover_bundled_workflows() if p.name == "nightly.json"
+    )
+    variables = json.loads(nightly.read_text()).get("variables", [])
+    for name in ("compiler_agent_id", "classifier_agent_id"):
+        var = next(v for v in variables if v["name"] == name)
+        assert "defaultValue" not in var, f"{name} must not carry a default"
+
+
+def test_main_skips_detection_when_both_agent_ids_given(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Explicit overrides are an escape hatch for machines we can't detect."""
+    rc = main([
+        "--wiki-root", str(tmp_path),
+        "--classifier-agent-id", "my-worker",
+        "--compiler-agent-id", "my-worker",
+        "--workflows-dir", str(tmp_path / "empty"),
+    ])
+    assert rc != 4
+    assert "no CLI worker alias configured" not in capsys.readouterr().err
+
+
+def test_main_still_fails_when_only_one_agent_id_given(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A half-configured override would leave the other step unrunnable."""
+    rc = main(["--wiki-root", str(tmp_path), "--classifier-agent-id", "my-worker"])
+    assert rc == 4
+    assert "no CLI worker alias configured" in capsys.readouterr().err


### PR DESCRIPTION
## Why

The bundled `nightly.json` shipped its two agent steps as `mode: spawn` with `agentId` defaulting to **`claude-code`** — the bare in-gateway agent. It has no exec tools and no openclaw-brain MCP, so it can neither read the staging file nor call `tasks.handoff`; it stalls silently until the watchdog fires. That is the documented cause of the 2026-06-08 nightly outage. The working configuration — `exec` via the `claude-code-cli` alias — was only ever applied to one live DB and never came back to the repo, so every fresh install still got the broken one.

The exec placeholder made it worse. `alias-resolver.ts:116` returns `undefined` for an unregistered `agentId` and leaves the dispatch untouched, and the stored command was `["true"]`. On a machine without the alias the step ran `/usr/bin/true`, exited 0, and the nightly reported a **green run having done nothing** — silence indistinguishable from success, the same failure shape as the outage this is meant to prevent.

## What

**`workers.detect_worker_agent_id`** — prefers `claude-code-cli`, falls back to `codex-cli`, reading `cli_exec_aliases` from `config.yaml`. It lives in its own module because `install_workflows` already imports `materialize_workflow` from `via_agents`, so `via_agents` cannot import back without a cycle.

`codex-cli` is second **on purpose**: Codex-CLI on ChatGPT Plus has produced multi-day quota blackouts on critical cron paths, and a rate-limited dispatcher cannot always report its own failure. Acceptable as a fallback, never the first choice for a nightly.

- **Both entry points detect**, so a direct run (`dream_cycle.run`) and an installed run bind to the same worker.
- **Fails loudly**: install exits `4` with actionable guidance naming both candidates, the config path, and the fix. `--classifier-agent-id` + `--compiler-agent-id` **together** are the escape hatch; half-configured is rejected, since it would leave the other step unrunnable.
- **The agent-id variables lose their `defaultValue`.** Any default resurrects the broken bare spawn agent.
- **The placeholder now exits 78** (`EX_CONFIG`) naming the step and the remedy, instead of exiting 0.

## Tests — 171 passing

Preference order; codex fallback; `claude-code` explicitly **not** selectable; missing / malformed / non-mapping config; exit-4 guidance; the both-overrides escape hatch and its half-configured rejection.

The one worth calling out **executes the bundled placeholder** and asserts it exits non-zero — a direct regression guard on the `["true"]` bug rather than a string comparison that could drift.

Two existing tests changed, both deliberately:
- `test_nightly_workflow_is_agent_driven` asserted `mode == "spawn"`. Rewritten to assert the durable intent — agent-driven via `exec` + `agentId`, with the reason spawn is wrong in a comment.
- `test_run_returns_0_when_goal_completes` caught a real defect in my first draft: the guard embedded `{{compiler_agent_id}}` in argv, leaving an unsubstituted variable. Fixed by dropping it — the agentId already lives in `dispatch.agentId`.

## Open, for you

`spawn` + a tool-capable gateway agent (e.g. `coo`) is still not offered as a tier. It is the only option that needs no local CLI, but your wiki records `coo` hitting 401s and stalling the digest, so I did not add it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)