### PR TITLE
ci(deps): drop the redundant /packages/** Dependabot directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,27 @@ version: 2
 updates:
   # JS/TS workspace — root manifest plus every package in the pnpm monorepo.
   - package-ecosystem: npm
+    # ONLY "/". Not "/packages/**", which looks like it adds per-package
+    # coverage and in fact adds nothing but breakage.
+    #
+    # pnpm keeps ONE lockfile, at the root. The "/" job understands that: it
+    # edits whichever workspace member's package.json needs the bump AND
+    # regenerates the root pnpm-lock.yaml alongside it (e.g. #80 touched
+    # packages/services/dashboard/package.json + pnpm-lock.yaml).
+    #
+    # A "/packages/**" job is scoped to its own directory, so it rewrites the
+    # nested package.json and never touches the root lockfile. Every PR it
+    # opens is therefore born failing `pnpm install --frozen-lockfile` with
+    # ERR_PNPM_OUTDATED_LOCKFILE, and no rebase can fix it — the job will
+    # regenerate the same broken diff forever.
+    #
+    # The record, before this change: per-directory jobs produced 12 PRs and
+    # merged 0 (9 closed unmerged, 3 open and unmergeable). Root-directory
+    # jobs merged normally. The dead PRs also consumed the 10-slot
+    # open-pull-requests-limit, which starved the queue — including security
+    # updates and the grouped react PR that could never open.
     directories:
       - "/"
-      - "/packages/**"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10


### PR DESCRIPTION
## The finding

Dependabot's npm block listed `directories: ["/", "/packages/**"]`. The second entry looks like it adds per-package coverage. It adds only breakage, and it is why the queue jammed.

**pnpm keeps one lockfile, at the root.** The `/` job understands that — it edits whichever workspace member needs the bump *and* regenerates the root `pnpm-lock.yaml` alongside it. #80 is the proof: a root-job branch that touched `packages/services/dashboard/package.json` **+ `pnpm-lock.yaml`**.

A `/packages/**` job is scoped to its own directory, so it rewrites the nested `package.json` and never touches the root lockfile. Every PR it opens is born failing:

```
ERR_PNPM_OUTDATED_LOCKFILE
specifiers in the lockfile don't match specifiers in package.json:
  - typescript (lockfile: ^5.6.0, manifest: ^7.0.2)
```

No rebase can fix it. I rebased all three and they came back identically broken — the job regenerates the same lock-less diff every time.

## The evidence

The correlation is perfect, with no exceptions:

| branch | lockfile in diff | state |
|---|---|---|
| `npm_and_yarn/react-markdown-10.1.0` | ✅ | CLEAN |
| `npm_and_yarn/framer-motion-13.1.0` | ✅ | CLEAN |
| `npm_and_yarn/vite-8.2.1` | ✅ | CLEAN |
| `npm_and_yarn/packages/cli/typescript-7.0.2` | ❌ | BLOCKED |
| `npm_and_yarn/packages/cli/types/node-26.2.0` | ❌ | BLOCKED |
| `npm_and_yarn/packages/cli/vitest-03a3299ce5` | ❌ | BLOCKED |

And over the repo's history:

- per-directory jobs: **12 PRs opened, 0 merged** (9 closed unmerged, 3 open and unmergeable)
- root-directory jobs: merged normally

## Why it starved the whole queue

Those dead PRs still occupy slots against `open-pull-requests-limit: 10`. The npm queue was sitting at exactly 10, so Dependabot could not open anything new — **including security updates**, and including the grouped `react` PR this config was written to produce. The react group has never appeared for want of a free slot.

## The change

`directories: ["/"]`. `packages/cli` is a declared pnpm workspace member, so the root job already covers it — this removes duplicate coverage, not coverage.

## Follow-up

#68, #70 and #81 cannot be salvaged and should be closed once this merges; Dependabot will re-open them from the root job with a correct lockfile. I left them open pending review of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)