### PR TITLE
fix(ci): use vulnerability-alerts permission for Dependabot alerts API

### DIFF
--- a/.github/workflows/dependabot-maintenance.yml
+++ b/.github/workflows/dependabot-maintenance.yml
@@ -30,7 +30,7 @@ permissions:
   contents: write # delete the branch of a closed PR
   pull-requests: write # comment and close
   issues: write # report a failing sweep, and standing override drift
-  security-events: read # read Dependabot alerts to audit the override floors
+  vulnerability-alerts: read # read Dependabot alerts to audit the override floors
 
 concurrency:
   group: dependabot-maintenance

--- a/scripts/check-override-floors.sh
+++ b/scripts/check-override-floors.sh
@@ -22,7 +22,7 @@
 #
 # Environment:
 #   REPO       owner/name (required)
-#   GH_TOKEN   token for `gh`, needs security-events: read (required)
+#   GH_TOKEN   token for `gh`, needs vulnerability-alerts: read (required)
 #   DRY_RUN    "true" to report without filing an issue (default true)
 #   WORKSPACE  path to the workspace file (default pnpm-workspace.yaml)
 set -euo pipefail


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

The scheduled Dependabot maintenance sweep was failing with HTTP 403 when trying to read Dependabot alerts. The workflow declared `security-events: read`, but as of April 2026, GitHub split that permission into two distinct scopes:
- `security-events: read` → code scanning alerts only
- `vulnerability-alerts: read` → Dependabot alerts (new, required)

The `check-override-floors.sh` script calls `gh api repos/{owner}/{repo}/dependabot/alerts` which now requires `vulnerability-alerts: read`.

Closes #85

## How I verified

**Evidence of the bug:**
- Run [#32558356224](https://github.com/Amyssjj/digital-me/actions/runs/32558356224) failed at line 149 with:
  ```
  gh: Resource not accessible by integration (HTTP 403)
  ```
- This occurred in `check-override-floors.sh` at line 88 when calling the Dependabot alerts API
- GitHub [introduced `vulnerability-alerts`](https://github.com/actions/runner/pull/4350) as a native GITHUB_TOKEN scope in April 2026, splitting it from `security-events`

**The fix:**
- Updated `.github/workflows/dependabot-maintenance.yml` to use `vulnerability-alerts: read` instead of `security-events: read`
- Updated the comment in `scripts/check-override-floors.sh` to document the correct permission

**Test plan:**
This fix will be verified when the workflow runs:
1. The next scheduled run (daily at 06:17 UTC) should succeed
2. Manual trigger with workflow_dispatch will also validate it
3. The `check-override-floors.sh` step should complete without HTTP 403 errors

## Checklist

- [x] ~~`pnpm ci` passes locally~~ (N/A - workflow-only change, no code to build/test)
- [x] ~~Tests added/updated~~ (N/A - workflow change has no unit tests)
- [x] ~~Docs updated~~ (N/A - no user-facing contract changed; inline comments updated)
- [x] No personal data, secrets, or machine-specific paths introduced
- [x] Conventional Commit title (`fix(ci): ...`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11002c7f-42e6-41e6-b05a-1c332234efac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11002c7f-42e6-41e6-b05a-1c332234efac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

