### PR TITLE
feat(openclaw): survive the 2026.8.1 host cutover

### DIFF
--- a/health-sweep/STATE-LOG.md
+++ b/health-sweep/STATE-LOG.md
@@ -1633,3 +1633,19 @@
 - **regression vs baseline:** 🟢 none
 - **critiques:** 🟢 cleared · **stories:** 🟢
 - **EXIT:** ✅ SHIP
+
+## 2026-09-01T00:36:31.298Z · update · 129e5c5
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+- **note:** post-update gate (digital-me update)
+
+## 2026-09-01T00:40:50.079Z · update · 129e5c5
+- **gates:** 🟢 all green
+- **delivery:** 🟢 deploy check off
+- **regression vs baseline:** 🟢 none
+- **critiques:** — (no critique lane for this profile)
+- **EXIT:** ✅ SHIP
+- **note:** post-update gate (digital-me update)

--- a/health-sweep/profiles/runtime.json
+++ b/health-sweep/profiles/runtime.json
@@ -20,6 +20,14 @@
       "timeoutSec": 60,
       "required": false,
       "note": "advisory: --require-all also fails on an IDLE runtime (surfaced==0 in the window). Worth seeing, not worth blocking \u2014 idle is not broken."
+    },
+    {
+      "id": "openclaw-memory-index",
+      "runtime": "openclaw",
+      "cmd": "bash scripts/verify_openclaw_memory_index.sh",
+      "parse": "exitCode",
+      "timeoutSec": 60,
+      "note": "Orphaned reindex databases + full-reindex livelock. Recurs on its own schedule, not only after an update, so it is checked here as ongoing health as well as in the update gate."
     }
   ],
   "artifactPins": [

--- a/health-sweep/profiles/runtime.json
+++ b/health-sweep/profiles/runtime.json
@@ -36,6 +36,14 @@
       "parse": "exitCode",
       "timeoutSec": 30,
       "note": "Static invariant over the gateway seam; catches a new caller that omits agentId before it ships."
+    },
+    {
+      "id": "m1-recall-liveness",
+      "runtime": "all",
+      "cmd": "python3 scripts/verify_m1_application.py --days 7 --stale-hours 24",
+      "parse": "exitCode",
+      "timeoutSec": 60,
+      "note": "OUTCOME check, not a component check. Fails when a runtime that surfaced knowledge during the 7d baseline has surfaced NOTHING in 24h \u2014 i.e. it was working and stopped. This is the only gate here that catches a cause nobody has thought of yet: it asks whether recall still happens, not whether any particular component reports healthy. On 2026-09-01 recall was dead across claude-code, codex and hermes for ~18h while `plugins inspect` said loaded, the gateway probe passed, and coverage was 100%. The existing --days-only check could not see it, because a runtime that worked for six days and died today still shows surfaced>0 and acked>0."
     }
   ],
   "artifactPins": [

--- a/health-sweep/profiles/runtime.json
+++ b/health-sweep/profiles/runtime.json
@@ -28,6 +28,14 @@
       "parse": "exitCode",
       "timeoutSec": 60,
       "note": "Orphaned reindex databases + full-reindex livelock. Recurs on its own schedule, not only after an update, so it is checked here as ongoing health as well as in the update gate."
+    },
+    {
+      "id": "gateway-callers",
+      "runtime": "openclaw",
+      "cmd": "bash scripts/verify_gateway_callers.sh",
+      "parse": "exitCode",
+      "timeoutSec": 30,
+      "note": "Static invariant over the gateway seam; catches a new caller that omits agentId before it ships."
     }
   ],
   "artifactPins": [

--- a/health-sweep/profiles/update.json
+++ b/health-sweep/profiles/update.json
@@ -19,6 +19,12 @@
       "cmd": "bash scripts/verify_openclaw_memory_index.sh",
       "timeoutSec": 60,
       "note": "openclaw's full reindex builds into <agent>.sqlite.memory-reindex-<uuid> and does NOT delete it when the build aborts on a revision race, so every failed attempt strands a copy of the whole index (observed: 5.1 GiB in one afternoon). Invisible to every other signal \u2014 `memory status` still reports Dirty:no and search keeps working. Upstream defect (memory-core-host-engine-storage); this is the detect-and-notify half we own."
+    },
+    {
+      "id": "gateway-callers",
+      "cmd": "bash scripts/verify_gateway_callers.sh",
+      "timeoutSec": 30,
+      "note": "Every /tools/invoke caller must send an owning agent. One upstream change (2026.8.1) had SIX call sites across TS/Python/Bash; two were found only by enumeration, with no reported symptom. This is that enumeration made permanent."
     }
   ],
   "contractChecks": [

--- a/health-sweep/profiles/update.json
+++ b/health-sweep/profiles/update.json
@@ -7,6 +7,12 @@
       "id": "digest-smoke",
       "cmd": "PYTHONPATH=packages/services/digest/src python3 -m digest.smoke",
       "timeoutSec": 120
+    },
+    {
+      "id": "openclaw-hooks-not-blocked",
+      "cmd": "bash scripts/verify_openclaw_hooks.sh",
+      "timeoutSec": 60,
+      "note": "openclaw silently DROPS a conversation typed hook when a non-bundled plugin lacks hooks.allowConversationAccess=true — warn diagnostic, early return, plugin still loads and still looks healthy. 2026.8.1 added before_prompt_build to that gated set, i.e. the entire wiki-recall path. Nothing else in this profile can see it: the overlay smoke is `node --check` (syntax only), the gateway probe passes, and digest-smoke is unaffected. This is the gate for that class."
     }
   ],
   "contractChecks": [

--- a/health-sweep/profiles/update.json
+++ b/health-sweep/profiles/update.json
@@ -12,7 +12,13 @@
       "id": "openclaw-hooks-not-blocked",
       "cmd": "bash scripts/verify_openclaw_hooks.sh",
       "timeoutSec": 60,
-      "note": "openclaw silently DROPS a conversation typed hook when a non-bundled plugin lacks hooks.allowConversationAccess=true — warn diagnostic, early return, plugin still loads and still looks healthy. 2026.8.1 added before_prompt_build to that gated set, i.e. the entire wiki-recall path. Nothing else in this profile can see it: the overlay smoke is `node --check` (syntax only), the gateway probe passes, and digest-smoke is unaffected. This is the gate for that class."
+      "note": "openclaw silently DROPS a conversation typed hook when a non-bundled plugin lacks hooks.allowConversationAccess=true \u2014 warn diagnostic, early return, plugin still loads and still looks healthy. 2026.8.1 added before_prompt_build to that gated set, i.e. the entire wiki-recall path. Nothing else in this profile can see it: the overlay smoke is `node --check` (syntax only), the gateway probe passes, and digest-smoke is unaffected. This is the gate for that class."
+    },
+    {
+      "id": "openclaw-memory-index",
+      "cmd": "bash scripts/verify_openclaw_memory_index.sh",
+      "timeoutSec": 60,
+      "note": "openclaw's full reindex builds into <agent>.sqlite.memory-reindex-<uuid> and does NOT delete it when the build aborts on a revision race, so every failed attempt strands a copy of the whole index (observed: 5.1 GiB in one afternoon). Invisible to every other signal \u2014 `memory status` still reports Dirty:no and search keeps working. Upstream defect (memory-core-host-engine-storage); this is the detect-and-notify half we own."
     }
   ],
   "contractChecks": [

--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -81,7 +81,11 @@ import {
   type WorkflowProvenance,
 } from "../doctor.js";
 import { resolveOpenclawExtensionsDir } from "../openclaw-paths.js";
-import { ensureOpenclawMemoryPaths } from "../openclaw-memory.js";
+import JSON5 from "json5";
+import {
+  ensureOpenclawMemoryPaths,
+  resolveOpenclawConfigPath,
+} from "../openclaw-memory.js";
 import {
   DASHBOARD_SERVICE_LABEL,
   buildDashboardServiceUnit,
@@ -102,6 +106,7 @@ import {
   parseAheadBehind,
   parseRecallAckMode,
   planDeployRuntimes,
+  expectedRecallAckMode,
 } from "../deploy.js";
 import {
   buildDefaultAliases,
@@ -1433,8 +1438,10 @@ async function installOpenclaw(
   if (!mem.ok) {
     console.error(
       `install openclaw: could not update memory paths (${mem.error}). ` +
-        `Add the wiki + tastes dirs to agents.defaults.memorySearch.extraPaths ` +
-        `in ${mem.configPath} manually.`,
+        `Add the wiki + tastes dirs to the memory-search block's extraPaths ` +
+        `in ${mem.configPath} manually (memory.search on openclaw >= 2026.7.1, ` +
+        `agents.defaults.memorySearch before — the schemas are strict, so the ` +
+        `wrong one is rejected).`,
     );
   } else if (mem.added.length > 0) {
     console.log(
@@ -1448,7 +1455,8 @@ async function installOpenclaw(
     console.log(
       `[OK] memory_search embeddings: no provider configured — seeded ` +
         `fallback: "local" (openclaw's keyless bundled embedder) so the index ` +
-        `builds without an API key. Override under agents.defaults.memorySearch ` +
+        `builds without an API key. Override under ` +
+        `${mem.layout === "namespaced" ? "memory.search" : "agents.defaults.memorySearch"} ` +
         `in ${mem.configPath}.`,
     );
   }
@@ -2337,15 +2345,19 @@ async function restartAndVerifyOpenclaw(home: string): Promise<boolean> {
     return false;
   }
   spawnSync("openclaw", ["gateway", "restart"], { stdio: "inherit" });
-  // Expected fingerprint = the marker baked into the just-deployed bundle.
-  const recallEntry = path.join(
-    resolveOpenclawExtensionsDir(home, process.env, undefined),
-    "digital-me-recall",
-    "index.mjs",
-  );
-  const expected = existsSync(recallEntry)
-    ? readFileSync(recallEntry, "utf-8").match(/assistant_ack=([^,"`)\s]+)/)?.[1] ?? null
-    : null;
+  // Expected marker = what this host's config entitles the plugin to register.
+  // Derived from the same grant the plugin reads, so a missing
+  // allowConversationAccess shows up here as a divergence rather than as a
+  // recall outage nobody notices.
+  const expected = ((): string | null => {
+    const cfgPath = resolveOpenclawConfigPath(home, process.env);
+    if (!existsSync(cfgPath)) return null;
+    try {
+      return expectedRecallAckMode(JSON5.parse(readFileSync(cfgPath, "utf-8")));
+    } catch {
+      return null;
+    }
+  })();
   const logPath = path.join(home, "Library", "Logs", "openclaw", "gateway.log");
   const deadline = Date.now() + 30000;
   while (Date.now() < deadline) {
@@ -2357,7 +2369,11 @@ async function restartAndVerifyOpenclaw(home: string): Promise<boolean> {
           return true;
         }
         console.error(
-          `deploy openclaw: DIVERGENCE — live marker (${live}) != deployed (${expected}).`,
+          `deploy openclaw: DIVERGENCE — live marker (${live}) != expected (${expected}). ` +
+            `The host registered a different set of ack hooks than the config entitles. ` +
+            `If 'agent_end' is missing live, plugins.entries.digital-me-recall.hooks` +
+            `.allowConversationAccess is not being honoured — run ` +
+            `scripts/verify_openclaw_hooks.sh.`,
         );
         return false;
       }

--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -107,6 +107,7 @@ import {
   parseRecallAckMode,
   planDeployRuntimes,
   expectedRecallAckMode,
+  resolveGatewayLog,
 } from "../deploy.js";
 import {
   buildDefaultAliases,
@@ -2358,7 +2359,14 @@ async function restartAndVerifyOpenclaw(home: string): Promise<boolean> {
       return null;
     }
   })();
-  const logPath = path.join(home, "Library", "Logs", "openclaw", "gateway.log");
+  const logPath = resolveGatewayLog(process.env, home);
+  if (!logPath) {
+    console.log(
+      "deploy openclaw: no gateway log found — restart succeeded but cannot verify the live marker yet. " +
+        "Marker will confirm on the first agent turn after the gateway emits its log.",
+    );
+    return true;
+  }
   const deadline = Date.now() + 30000;
   while (Date.now() < deadline) {
     if (existsSync(logPath)) {

--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -63,6 +63,7 @@ import {
   mergeMcpServer,
 } from "@digital-me/runtime-codex";
 import { BIN_PATH as BRAIN_MCP_PROXY_BIN } from "@digital-me/brain-mcp-proxy";
+import { stabilizeRegistration } from "../stable-registration.js";
 import {
   SOUL_MD_TEMPLATE,
   mergeSoulMd,
@@ -587,9 +588,15 @@ function installCodex(home: string): void {
   // openclaw.json from this path to discover the gateway port + auth token.
   const openclawHome =
     process.env.OPENCLAW_HOME ?? path.join(home, ".openclaw");
+  // ~/.codex/config.toml is persistent user config — same hardening as the
+  // other two clients (see stable-registration.ts).
+  const codexStable = stabilizeRegistration(process.execPath, BRAIN_MCP_PROXY_BIN);
+  for (const note of codexStable.notes) {
+    console.log(`     codex MCP: ${note}`);
+  }
   const tomlFragment = buildCodexMcpConfig({
-    nodeBin: process.execPath,
-    proxyBinPath: BRAIN_MCP_PROXY_BIN,
+    nodeBin: codexStable.nodePath,
+    proxyBinPath: codexStable.binPath,
     openclawHome,
     agentId: "codex",
   });
@@ -622,7 +629,7 @@ function installCodex(home: string): void {
   writeFileSync(hooksJsonPath, JSON.stringify(mergedHooks, null, 2) + "\n", "utf-8");
   console.log(
     `[OK] installed codex: CODEX.md + config.toml merged ` +
-      `(mcp openclaw-brain → ${BRAIN_MCP_PROXY_BIN}); ` +
+      `(mcp openclaw-brain → ${codexStable.binPath}); ` +
       `${CODEX_HOOK_NAMES.length} hooks + hooks.json wired`,
   );
 }
@@ -664,7 +671,13 @@ function installClaudeCodeMcp(): void {
   for (const [k, v] of Object.entries(env)) {
     args.push("-e", `${k}=${v}`);
   }
-  args.push("--", process.execPath, BRAIN_MCP_PROXY_BIN);
+  // Never bake a worktree path or a version-pinned interpreter into
+  // ~/.claude.json — it outlives this process (see stable-registration.ts).
+  const stable = stabilizeRegistration(process.execPath, BRAIN_MCP_PROXY_BIN);
+  for (const note of stable.notes) {
+    console.log(`     claude-code MCP: ${note}`);
+  }
+  args.push("--", stable.nodePath, stable.binPath);
   const r = spawnSync("claude", args, {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
@@ -677,7 +690,7 @@ function installClaudeCodeMcp(): void {
     return;
   }
   console.log(
-    `[OK] claude-code MCP: registered openclaw-brain → ${BRAIN_MCP_PROXY_BIN}`,
+    `[OK] claude-code MCP: registered openclaw-brain → ${stable.binPath}`,
   );
 }
 
@@ -1311,14 +1324,21 @@ function installHermesMcp(home: string): void {
   });
   const openclawHome =
     process.env.OPENCLAW_HOME ?? path.join(home, ".openclaw");
+  // ~/.hermes/config.yaml is persistent user config: harden the same way as
+  // claude-code. Hermes was found in 2026-09 still pointing at a worktree
+  // deleted months earlier, pinned to a since-broken Cellar node.
+  const hermesStable = stabilizeRegistration(process.execPath, BRAIN_MCP_PROXY_BIN);
+  for (const note of hermesStable.notes) {
+    console.log(`     hermes MCP: ${note}`);
+  }
   const args = [
     "mcp",
     "add",
     "openclaw-brain",
     "--command",
-    process.execPath,
+    hermesStable.nodePath,
     "--args",
-    BRAIN_MCP_PROXY_BIN,
+    hermesStable.binPath,
     "--env",
     `OPENCLAW_HOME=${openclawHome}`,
     `OPENCLAW_AGENT_ID=hermes`,

--- a/packages/cli/src/bin/digital-me.ts
+++ b/packages/cli/src/bin/digital-me.ts
@@ -1337,11 +1337,16 @@ function installHermesMcp(home: string): void {
     "openclaw-brain",
     "--command",
     hermesStable.nodePath,
-    "--args",
-    hermesStable.binPath,
+    // `hermes mcp add --help`: "--args ... must be the last option". With
+    // --args before --env, argparse's REMAINDER swallowed the env flags into
+    // the args list, so the proxy was launched with `--env OPENCLAW_HOME=...`
+    // as positional arguments and NO environment at all (config showed
+    // `env: None`). Keep --env first and --args strictly last.
     "--env",
     `OPENCLAW_HOME=${openclawHome}`,
     `OPENCLAW_AGENT_ID=hermes`,
+    "--args",
+    hermesStable.binPath,
   ];
   // hermes mcp add probes the server, prints its tool list, then prompts
   // "Enable all N tools? [Y/n/select]:". From a non-TTY parent the prompt
@@ -1359,7 +1364,7 @@ function installHermesMcp(home: string): void {
     return;
   }
   console.log(
-    `[OK] hermes MCP: registered openclaw-brain → ${BRAIN_MCP_PROXY_BIN}`,
+    `[OK] hermes MCP: registered openclaw-brain → ${hermesStable.binPath}`,
   );
 }
 

--- a/packages/cli/src/deploy.test.ts
+++ b/packages/cli/src/deploy.test.ts
@@ -3,6 +3,7 @@ import {
   DEPLOYABLE_RUNTIMES,
   analyzeDeployPreflight,
   parseAheadBehind,
+  expectedRecallAckMode,
   parseRecallAckMode,
   planDeployRuntimes,
 } from "./deploy.js";
@@ -83,5 +84,42 @@ describe("planDeployRuntimes", () => {
 
   it("only openclaw + dashboard are deployable", () => {
     expect([...DEPLOYABLE_RUNTIMES]).toEqual(["openclaw", "dashboard"]);
+  });
+});
+
+describe("expectedRecallAckMode", () => {
+  it("includes agent_end only when the conversation-hook grant is present", () => {
+    expect(
+      expectedRecallAckMode({
+        plugins: { entries: { "digital-me-recall": { hooks: { allowConversationAccess: true } } } },
+      }),
+    ).toBe("agent_end+before_message_write");
+  });
+
+  it("drops agent_end when the grant is absent — the host will refuse that hook", () => {
+    expect(expectedRecallAckMode({})).toBe("before_message_write");
+    expect(expectedRecallAckMode({ plugins: { entries: {} } })).toBe("before_message_write");
+    expect(
+      expectedRecallAckMode({ plugins: { entries: { "digital-me-recall": { enabled: true } } } }),
+    ).toBe("before_message_write");
+  });
+
+  it("treats an explicit false as ungranted", () => {
+    expect(
+      expectedRecallAckMode({
+        plugins: { entries: { "digital-me-recall": { hooks: { allowConversationAccess: false } } } },
+      }),
+    ).toBe("before_message_write");
+  });
+
+  it("agrees with what parseRecallAckMode reads off a real registration line", () => {
+    // The two halves of the deploy check must speak the same vocabulary.
+    const line =
+      "[plugins] digital-me-recall: registered hooks (boot=on, conversation_hooks=granted, assistant_ack=agent_end+before_message_write, app_rate=on)";
+    expect(parseRecallAckMode(line)).toBe(
+      expectedRecallAckMode({
+        plugins: { entries: { "digital-me-recall": { hooks: { allowConversationAccess: true } } } },
+      }),
+    );
   });
 });

--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -80,6 +80,33 @@ export function parseRecallAckMode(logText: string): string | null {
 }
 
 /**
+ * The `assistant_ack=` marker digital-me-recall SHOULD log on this host,
+ * derived from the openclaw config the same way the plugin derives it.
+ *
+ * The plugin emits `agent_end` and `before_message_write` as ack sources,
+ * minus any the host will refuse. openclaw drops a conversation hook from a
+ * non-bundled plugin unless `plugins.entries.digital-me-recall.hooks
+ * .allowConversationAccess` is true — and `agent_end` is in that gated set,
+ * `before_message_write` is not. So the marker is a function of the grant.
+ *
+ * This replaced a regex over the deployed bundle's SOURCE. That worked only
+ * while the marker was a string literal; once it became a template
+ * expression the grep captured `${ackSources.join(` and every deploy reported
+ * a false divergence. Fingerprinting the build was never the point —
+ * comparing what the host actually registered against what it should have
+ * registered is, and that also turns a missing grant into a deploy failure
+ * instead of a silent recall outage.
+ */
+export function expectedRecallAckMode(cfg: Readonly<Record<string, unknown>>): string {
+  const plugins = cfg.plugins as Record<string, unknown> | undefined;
+  const entries = plugins?.entries as Record<string, unknown> | undefined;
+  const recall = entries?.["digital-me-recall"] as Record<string, unknown> | undefined;
+  const hooks = recall?.hooks as Record<string, unknown> | undefined;
+  const granted = hooks?.allowConversationAccess === true;
+  return granted ? "agent_end+before_message_write" : "before_message_write";
+}
+
+/**
  * Which runtimes to deploy: the explicit `--runtime` set (filtered to the
  * deployable ones), else every deployable runtime detected as installed.
  */

--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -9,6 +9,69 @@
  * skipped. deploy runs them all, then verifies the live fingerprint matches.
  */
 
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Resolve the gateway log path the RUNNING openclaw gateway actually writes to.
+ * Mirrors `resolve_gateway_log` in scripts/verify_openclaw_hooks.sh. Picks the
+ * NEWEST candidate (by mtime) so we never read a frozen log that predates the
+ * service's StandardOutPath move.
+ */
+export function resolveGatewayLog(env: NodeJS.ProcessEnv, home: string): string | null {
+  const openclawHome = env.OPENCLAW_HOME ?? path.join(home, ".openclaw");
+  
+  if (env.OPENCLAW_GATEWAY_LOG) {
+    return env.OPENCLAW_GATEWAY_LOG;
+  }
+
+  // Candidates in priority order (newest file wins)
+  const candidates = [
+    // Debug file log (what `openclaw logs` tails)
+    ...findNewestTmpLog(),
+    path.join(home, "Library", "Logs", "openclaw", "gateway.log"),  // Mac launchd
+    path.join(openclawHome, "logs", "gateway.log"),                  // legacy
+    path.join(env.XDG_STATE_HOME ?? path.join(home, ".local", "state"), "openclaw", "gateway.log"),  // Linux systemd
+  ];
+
+  let newest: string | null = null;
+  let newestMtime = 0;
+  for (const c of candidates) {
+    if (!c || !existsSync(c)) continue;
+    try {
+      const mtime = statSync(c).mtimeMs;
+      if (!newest || mtime > newestMtime) {
+        newest = c;
+        newestMtime = mtime;
+      }
+    } catch {
+      // skip unreadable
+    }
+  }
+  return newest;
+}
+
+function findNewestTmpLog(): string[] {
+  const tmpDir = "/tmp/openclaw";
+  if (!existsSync(tmpDir)) return [];
+  try {
+    const files = readdirSync(tmpDir)
+      .filter((f) => f.startsWith("openclaw-") && f.endsWith(".log"))
+      .map((f) => path.join(tmpDir, f));
+    // Sort by mtime descending, return the newest
+    files.sort((a, b) => {
+      try {
+        return statSync(b).mtimeMs - statSync(a).mtimeMs;
+      } catch {
+        return 0;
+      }
+    });
+    return files.length > 0 ? [files[0]!] : [];
+  } catch {
+    return [];
+  }
+}
+
 /** Runtimes that have a *running system* to redeploy + verify (a daemon/service). */
 export type DeployRuntime = "openclaw" | "dashboard";
 export const DEPLOYABLE_RUNTIMES: readonly DeployRuntime[] = ["openclaw", "dashboard"];

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -878,12 +878,24 @@ describe("runMemoryIndexChecks", () => {
   const DIRS = "openclaw: knowledge dirs";
   const PATHS = "openclaw: memory_search extraPaths";
   const EMB = "openclaw: memory embeddings";
+  const HOOKS = "openclaw: conversation-hook access";
+  // The grant is part of a healthy config: without it openclaw silently drops
+  // digital-me-recall's before_prompt_build / agent_end hooks.
+  const hookGrant = {
+    plugins: { entries: { "digital-me-recall": { hooks: { allowConversationAccess: true } } } },
+  };
   const goodCfg = JSON.stringify({
     agents: {
       defaults: {
         memorySearch: { fallback: "local", extraPaths: [wiki, tastes] },
       },
     },
+    ...hookGrant,
+  });
+  /** Same config on openclaw >= 2026.7.1's `memory.search` layout. */
+  const goodCfgNamespaced = JSON.stringify({
+    memory: { search: { fallback: "local", extraPaths: [wiki, tastes] } },
+    ...hookGrant,
   });
   const find = (checks: ReturnType<typeof runMemoryIndexChecks>, label: string) =>
     checks.find((c) => c.label === label)!;
@@ -892,10 +904,77 @@ describe("runMemoryIndexChecks", () => {
     const checks = runMemoryIndexChecks(
       makeDeps({ fileExists: () => true, readFile: () => goodCfg }),
     );
-    expect(checks).toHaveLength(3);
+    expect(checks).toHaveLength(4);
     expect(checks.every((c) => c.ok)).toBe(true);
     const paths = find(checks, PATHS);
     if (paths.ok) expect(paths.note).toContain(cfgPath);
+  });
+
+  it("reads the openclaw >= 2026.7.1 memory.search layout and names it", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({ fileExists: () => true, readFile: () => goodCfgNamespaced }),
+    );
+    expect(checks.every((c) => c.ok)).toBe(true);
+    const paths = find(checks, PATHS);
+    // The repair hint must name a key that exists on THIS host, so the note
+    // tracks the layout rather than hard-coding the legacy path.
+    if (paths.ok) expect(paths.note).toContain("memory.search");
+  });
+
+  it("names the legacy key when the config still uses it", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({
+        fileExists: () => true,
+        readFile: () =>
+          JSON.stringify({
+            agents: { defaults: { memorySearch: { fallback: "local", extraPaths: [wiki] } } },
+            ...hookGrant,
+          }),
+      }),
+    );
+    const paths = find(checks, PATHS);
+    expect(paths.ok).toBe(false);
+    if (!paths.ok) {
+      expect(paths.reason).toContain("agents.defaults.memorySearch.extraPaths");
+      expect(paths.reason).toContain(tastes);
+    }
+  });
+
+  it("FAILs the hook-grant check when allowConversationAccess is missing", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({
+        fileExists: () => true,
+        readFile: () =>
+          JSON.stringify({
+            agents: { defaults: { memorySearch: { fallback: "local", extraPaths: [wiki, tastes] } } },
+          }),
+      }),
+    );
+    const hooks = find(checks, HOOKS);
+    expect(hooks.ok).toBe(false);
+    if (!hooks.ok) {
+      expect(hooks.reason).toContain("digital-me-recall");
+      expect(hooks.reason).toMatch(/silently drops/);
+    }
+    // The paths + embeddings checks stay green: this failure is invisible to them.
+    expect(find(checks, PATHS).ok).toBe(true);
+    expect(find(checks, EMB).ok).toBe(true);
+  });
+
+  it("FAILs the hook-grant check on an explicit false (deliberate opt-out is still a broken recall)", () => {
+    const checks = runMemoryIndexChecks(
+      makeDeps({
+        fileExists: () => true,
+        readFile: () =>
+          JSON.stringify({
+            agents: { defaults: { memorySearch: { fallback: "local", extraPaths: [wiki, tastes] } } },
+            plugins: {
+              entries: { "digital-me-recall": { hooks: { allowConversationAccess: false } } },
+            },
+          }),
+      }),
+    );
+    expect(find(checks, HOOKS).ok).toBe(false);
   });
 
   it("flags missing knowledge dirs with the startup-watch explanation", () => {
@@ -973,6 +1052,9 @@ describe("runMemoryIndexChecks", () => {
             agents: { defaults: { memorySearch: {
               fallback: 'local',
               extraPaths: ['${wiki}', '${tastes}',],
+            } } },
+            plugins: { entries: { 'digital-me-recall': {
+              hooks: { allowConversationAccess: true },
             } } },
           }`,
       }),

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -18,7 +18,9 @@
 
 import JSON5 from "json5";
 import {
+  CONVERSATION_HOOK_PLUGIN_IDS,
   KEY_OPTIONAL_EMBEDDING_PROVIDERS,
+  detectMemorySearchLayout,
   digitalMeKnowledgePaths,
   resolveOpenclawConfigPath,
 } from "./openclaw-memory.js";
@@ -369,6 +371,44 @@ export function runOpenclawShadowCheck(deps: DoctorDeps): CheckResult[] {
 const KNOWLEDGE_DIRS_LABEL = "openclaw: knowledge dirs";
 const MEMORY_PATHS_LABEL = "openclaw: memory_search extraPaths";
 const EMBEDDINGS_LABEL = "openclaw: memory embeddings";
+const HOOK_GRANT_LABEL = "openclaw: conversation-hook access";
+
+/**
+ * The failure this check exists for is invisible everywhere else: openclaw
+ * silently DROPS a conversation typed hook when a non-bundled plugin has not
+ * set `hooks.allowConversationAccess: true` — a warn diagnostic and an early
+ * return, so the plugin still loads, still registers its tools, and still
+ * reports healthy. Only the hooks are gone. On openclaw >= 2026.8.1 that set
+ * includes `before_prompt_build`, i.e. the whole wiki-recall path; `agent_end`
+ * (the M1 application-ack) has been gated for longer.
+ *
+ * Exported for direct unit testing.
+ */
+export function runConversationHookGrantCheck(
+  cfg: Record<string, unknown>,
+  configPath: string,
+): CheckResult {
+  const entries = asObject(asObject(cfg.plugins).entries);
+  const ungranted = CONVERSATION_HOOK_PLUGIN_IDS.filter(
+    (id) => asObject(asObject(entries[id]).hooks).allowConversationAccess !== true,
+  );
+  if (ungranted.length === 0) {
+    return {
+      ok: true,
+      label: HOOK_GRANT_LABEL,
+      note: `granted for ${CONVERSATION_HOOK_PLUGIN_IDS.join(", ")}`,
+    };
+  }
+  return {
+    ok: false,
+    label: HOOK_GRANT_LABEL,
+    reason:
+      `${ungranted.join(", ")} lack plugins.entries.<id>.hooks.allowConversationAccess=true ` +
+      `in ${configPath}. openclaw silently drops their before_prompt_build / agent_end ` +
+      `hooks — recall injection and the M1 ack go to zero with no error. Run ` +
+      `'digital-me install --runtime openclaw' (idempotent), then restart the gateway.`,
+  };
+}
 
 /** Coerce an unknown JSON node to an object, or {} when it isn't one. */
 function asObject(v: unknown): Record<string, unknown> {
@@ -463,7 +503,17 @@ export function runMemoryIndexChecks(deps: DoctorDeps): CheckResult[] {
     return checks;
   }
 
-  const ms = asObject(asObject(asObject(cfg.agents).defaults).memorySearch);
+  // openclaw moved this block from `agents.defaults.memorySearch` to
+  // `memory.search` in 2026.7.1. Read whichever layout the config uses and
+  // name that one in any failure, so the repair hint points at a key that
+  // actually exists on this host.
+  const layout = detectMemorySearchLayout(cfg) ?? "legacy";
+  const msKey =
+    layout === "namespaced" ? "memory.search" : "agents.defaults.memorySearch";
+  const ms =
+    layout === "namespaced"
+      ? asObject(asObject(cfg.memory).search)
+      : asObject(asObject(asObject(cfg.agents).defaults).memorySearch);
   const extraPaths = Array.isArray(ms.extraPaths)
     ? ms.extraPaths.filter((x): x is string => typeof x === "string")
     : [];
@@ -472,18 +522,20 @@ export function runMemoryIndexChecks(deps: DoctorDeps): CheckResult[] {
     checks.push({
       ok: true,
       label: MEMORY_PATHS_LABEL,
-      note: `wiki + tastes wired in ${configPath}`,
+      note: `wiki + tastes wired in ${configPath} (${msKey})`,
     });
   } else {
     checks.push({
       ok: false,
       label: MEMORY_PATHS_LABEL,
       reason:
-        `agents.defaults.memorySearch.extraPaths is missing ` +
+        `${msKey}.extraPaths is missing ` +
         `${missingPaths.join(", ")} — run 'digital-me install --runtime openclaw' ` +
         `(idempotent), then restart the openclaw gateway.`,
     });
   }
+
+  checks.push(runConversationHookGrantCheck(cfg, configPath));
 
   checks.push(runEmbeddingsCheck(deps.env, ms));
   return checks;

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -10,7 +10,8 @@
  *   3. Each enabled runtime has its hook scripts / templates installed.
  *   4. The brain MCP proxy is on PATH.
  *   5. The memory index is actually wired: the wiki + tastes dirs exist, both
- *      sit in openclaw's `agents.defaults.memorySearch.extraPaths`, and the
+ *      sit in openclaw's memory-search `extraPaths` (`memory.search` on
+ *      >= 2026.7.1, `agents.defaults.memorySearch` before), and the
  *      embedding config can build an index on this machine (openclaw's
  *      default provider is `openai`, which silently indexes nothing without
  *      an API key — the #1 "memory_search finds nothing" fresh-install trap).
@@ -423,7 +424,8 @@ function asTrimmedString(v: unknown): string | undefined {
 
 /**
  * Verify the memory index is actually wired end-to-end: knowledge dirs on
- * disk, both dirs listed in `agents.defaults.memorySearch.extraPaths`, and
+ * disk, both dirs listed in the memory-search block's `extraPaths` (whichever
+ * layout this host uses), and
  * an embedding config that can index without manual surgery. Pure/data-layer.
  */
 export function runMemoryIndexChecks(deps: DoctorDeps): CheckResult[] {
@@ -537,7 +539,7 @@ export function runMemoryIndexChecks(deps: DoctorDeps): CheckResult[] {
 
   checks.push(runConversationHookGrantCheck(cfg, configPath));
 
-  checks.push(runEmbeddingsCheck(deps.env, ms));
+  checks.push(runEmbeddingsCheck(deps.env, ms, msKey));
   return checks;
 }
 
@@ -553,6 +555,8 @@ export function runMemoryIndexChecks(deps: DoctorDeps): CheckResult[] {
 export function runEmbeddingsCheck(
   env: Readonly<Record<string, string | undefined>>,
   memorySearch: Readonly<Record<string, unknown>>,
+  /** Config key the block lives under on THIS host, for the repair hint. */
+  msKey: string = "agents.defaults.memorySearch",
 ): CheckResult {
   const provider = asTrimmedString(memorySearch.provider);
   const fallback = asTrimmedString(memorySearch.fallback);
@@ -594,10 +598,10 @@ export function runEmbeddingsCheck(
     label: EMBEDDINGS_LABEL,
     reason:
       "memory_search embeddings default to the 'openai' provider but no API key " +
-      "was found ($OPENAI_API_KEY / agents.defaults.memorySearch.remote.apiKey) — " +
+      `was found ($OPENAI_API_KEY / ${msKey}.remote.apiKey) — ` +
       "the wiki + tastes index will NOT build. Re-run 'digital-me install " +
       "--runtime openclaw' (seeds the keyless fallback: 'local'), or set " +
-      "agents.defaults.memorySearch.provider + key. 'openclaw doctor' validates " +
+      `${msKey}.provider + key. 'openclaw doctor' validates ` +
       "embeddings end-to-end.",
   };
 }

--- a/packages/cli/src/openclaw-memory.test.ts
+++ b/packages/cli/src/openclaw-memory.test.ts
@@ -4,13 +4,28 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  CONVERSATION_HOOK_PLUGIN_IDS,
+  detectMemorySearchLayout,
+  detectOpenclawHostVersion,
   digitalMeKnowledgePaths,
   ensureOpenclawMemoryPaths,
+  mergeHookGrants,
   mergeMemoryExtraPaths,
+  migrateMemorySearchLayout,
+  parseOpenclawVersionOutput,
+  probeOpenclawVersion,
+  resolveMemorySearchLayout,
   resolveOpenclawConfigPath,
   seedKeylessEmbeddingFallback,
   type MemoryPathIO,
 } from "./openclaw-memory.js";
+
+/** Deterministic `openclaw --version` probes. Without these the suite would
+ *  read the HOST's installed openclaw and pick a config layout from it — the
+ *  tests would then pass or fail depending on the machine. */
+const OC_6_11 = () => "OpenClaw 2026.6.11 (e085fa1)";
+const OC_8_1 = () => "OpenClaw 2026.8.1 (4d37fc4)";
+const OC_UNKNOWN = () => undefined;
 
 /** In-memory IO so the wiring is tested without touching disk. */
 function memIO(initial: Record<string, string> = {}): MemoryPathIO & {
@@ -110,7 +125,7 @@ describe("seedKeylessEmbeddingFallback", () => {
 describe("ensureOpenclawMemoryPaths", () => {
   it("writes a fresh config when none exists (and seeds the keyless fallback)", () => {
     const io = memIO();
-    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(res.ok).toBe(true);
     expect(res.added).toEqual(["/home/u/digital-me/wiki", "/home/u/digital-me/tastes"]);
     expect(res.seededLocalFallback).toBe(true);
@@ -128,7 +143,7 @@ describe("ensureOpenclawMemoryPaths", () => {
 
   it("creates the knowledge dirs so the gateway can watch them from first start", () => {
     const io = memIO();
-    ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(io.mkdirps).toContain("/home/u/digital-me/wiki");
     expect(io.mkdirps).toContain("/home/u/digital-me/tastes");
     // Config parent dir too (fresh machine has no ~/.openclaw yet).
@@ -137,10 +152,10 @@ describe("ensureOpenclawMemoryPaths", () => {
 
   it("is idempotent — a second run adds nothing and does not rewrite", () => {
     const io = memIO();
-    const first = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const first = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(first.added).toHaveLength(2);
     const snapshot = io.files["/home/u/.openclaw/openclaw.json"];
-    const second = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const second = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(second.added).toEqual([]);
     expect(second.seededLocalFallback).toBeUndefined();
     expect(io.files["/home/u/.openclaw/openclaw.json"]).toBe(snapshot);
@@ -153,7 +168,7 @@ describe("ensureOpenclawMemoryPaths", () => {
         agents: { defaults: { memorySearch: { remote: { apiKey: "secret" }, extraPaths: ["/home/u/digital-me/wiki"] } } },
       }),
     });
-    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(res.added).toEqual(["/home/u/digital-me/tastes"]);
     const written = JSON.parse(io.files[cfgPath]!);
     expect(written.agents.defaults.memorySearch.remote.apiKey).toBe("secret");
@@ -181,7 +196,7 @@ describe("ensureOpenclawMemoryPaths", () => {
         },
       }),
     });
-    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(res.ok).toBe(true);
     expect(res.added).toEqual([]);
     expect(res.seededLocalFallback).toBe(true);
@@ -208,7 +223,7 @@ describe("ensureOpenclawMemoryPaths", () => {
         },
       }`,
     });
-    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(res.ok).toBe(true);
     expect(res.added).toEqual(["/home/u/digital-me/tastes"]);
     expect(res.json5Rewritten).toBe(true);
@@ -225,7 +240,7 @@ describe("ensureOpenclawMemoryPaths", () => {
   it("reports a malformed config instead of clobbering it", () => {
     const cfgPath = "/home/u/.openclaw/openclaw.json";
     const io = memIO({ [cfgPath]: "{not json" });
-    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(res.ok).toBe(false);
     expect(res.added).toEqual([]);
     expect(io.files[cfgPath]).toBe("{not json"); // untouched
@@ -234,7 +249,7 @@ describe("ensureOpenclawMemoryPaths", () => {
   it("treats a parseable non-object config as empty rather than crashing", () => {
     const cfgPath = "/home/u/.openclaw/openclaw.json";
     const io = memIO({ [cfgPath]: "null" });
-    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io);
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
     expect(res.ok).toBe(true);
     expect(res.added).toHaveLength(2);
     const written = JSON.parse(io.files[cfgPath]!);
@@ -243,7 +258,7 @@ describe("ensureOpenclawMemoryPaths", () => {
 
   it("resolves the config path under OPENCLAW_HOME", () => {
     const io = memIO();
-    const res = ensureOpenclawMemoryPaths("/home/u", "/data/dm", { OPENCLAW_HOME: "/oc" }, io);
+    const res = ensureOpenclawMemoryPaths("/home/u", "/data/dm", { OPENCLAW_HOME: "/oc" }, io, OC_6_11);
     expect(res.configPath).toBe(path.join("/oc", "openclaw.json"));
     expect(io.files["/oc/openclaw.json"]).toBeDefined();
   });
@@ -266,7 +281,7 @@ describe("ensureOpenclawMemoryPaths (default disk IO)", () => {
     const cfgPath = path.join(tmp, "state", "openclaw.json");
     const env = { DIGITAL_ME_OPENCLAW_CONFIG: cfgPath };
 
-    const first = ensureOpenclawMemoryPaths("/home/u", path.join(tmp, "dm"), env);
+    const first = ensureOpenclawMemoryPaths("/home/u", path.join(tmp, "dm"), env, undefined, OC_6_11);
     expect(first.ok).toBe(true);
     expect(first.configPath).toBe(cfgPath);
     expect(first.added).toEqual([path.join(tmp, "dm", "wiki"), path.join(tmp, "dm", "tastes")]);
@@ -283,8 +298,335 @@ describe("ensureOpenclawMemoryPaths (default disk IO)", () => {
     expect(written.agents.defaults.memorySearch.fallback).toBe("local");
 
     // Second run reads the file back from disk and adds nothing.
-    const second = ensureOpenclawMemoryPaths("/home/u", path.join(tmp, "dm"), env);
+    const second = ensureOpenclawMemoryPaths("/home/u", path.join(tmp, "dm"), env, undefined, OC_6_11);
     expect(second.ok).toBe(true);
     expect(second.added).toEqual([]);
+  });
+});
+
+// ── openclaw 2026.7.1 memory-search namespace cutover ──────────────────────
+//
+// openclaw moved this block from `agents.defaults.memorySearch` to root
+// `memory.search` in 2026.7.1. Both schemas are `.strict()` and the loader
+// THROWS on an unknown key, so writing the wrong layout does not merely leave
+// the corpus unindexed — it stops the gateway from starting. These tests pin
+// that we always write exactly one layout, and the one the host accepts.
+
+describe("detectMemorySearchLayout", () => {
+  it("identifies each layout and reports neither for an empty config", () => {
+    expect(detectMemorySearchLayout({ agents: { defaults: { memorySearch: {} } } })).toBe("legacy");
+    expect(detectMemorySearchLayout({ memory: { search: {} } })).toBe("namespaced");
+    expect(detectMemorySearchLayout({})).toBeUndefined();
+    expect(detectMemorySearchLayout({ agents: { defaults: {} } })).toBeUndefined();
+  });
+});
+
+describe("resolveMemorySearchLayout", () => {
+  it("lets an existing block win over the host version", () => {
+    // Moving a block is a migration, never a side effect of wiring paths.
+    const legacyCfg = { agents: { defaults: { memorySearch: {} } } };
+    expect(resolveMemorySearchLayout(legacyCfg, "2026.8.1")).toBe("legacy");
+    const nsCfg = { memory: { search: {} } };
+    expect(resolveMemorySearchLayout(nsCfg, "2026.6.11")).toBe("namespaced");
+  });
+
+  it("picks by host version when the config has no block", () => {
+    expect(resolveMemorySearchLayout({}, "2026.6.11")).toBe("legacy");
+    expect(resolveMemorySearchLayout({}, "2026.7.1")).toBe("namespaced");
+    expect(resolveMemorySearchLayout({}, "2026.8.1")).toBe("namespaced");
+  });
+
+  it("defaults to the current namespace when the host version is unknown", () => {
+    expect(resolveMemorySearchLayout({}, undefined)).toBe("namespaced");
+  });
+});
+
+describe("migrateMemorySearchLayout", () => {
+  it("moves the block to the new namespace, preserving every sub-key", () => {
+    const cfg: Record<string, unknown> = {
+      agents: { defaults: { memorySearch: { enabled: true, extraPaths: ["/w"], provider: "gemini", remote: { apiKey: "${K}" } } } },
+    };
+    const { migrated, from } = migrateMemorySearchLayout(cfg, "namespaced");
+    expect(migrated).toBe(true);
+    expect(from).toBe("legacy");
+    expect(cfg.memory).toEqual({
+      search: { enabled: true, extraPaths: ["/w"], provider: "gemini", remote: { apiKey: "${K}" } },
+    });
+    // The legacy key MUST be gone: leaving it makes openclaw >= 2026.7.1
+    // reject the whole config, not just ignore the stale key.
+    expect((cfg.agents as Record<string, Record<string, unknown>>).defaults.memorySearch).toBeUndefined();
+  });
+
+  it("moves back to the legacy layout for an older host", () => {
+    const cfg: Record<string, unknown> = { memory: { search: { extraPaths: ["/w"] } } };
+    const { migrated } = migrateMemorySearchLayout(cfg, "legacy");
+    expect(migrated).toBe(true);
+    expect((cfg.agents as Record<string, Record<string, unknown>>).defaults.memorySearch).toEqual({
+      extraPaths: ["/w"],
+    });
+    // An emptied `memory` wrapper is dropped rather than left as noise.
+    expect(cfg.memory).toBeUndefined();
+  });
+
+  it("keeps a sibling memory key when only search moves out", () => {
+    const cfg: Record<string, unknown> = { memory: { citations: "on", search: { extraPaths: [] } } };
+    migrateMemorySearchLayout(cfg, "legacy");
+    expect(cfg.memory).toEqual({ citations: "on" });
+  });
+
+  it("is a no-op when already on target or when there is no block", () => {
+    expect(migrateMemorySearchLayout({ memory: { search: {} } }, "namespaced").migrated).toBe(false);
+    expect(migrateMemorySearchLayout({}, "namespaced").migrated).toBe(false);
+  });
+});
+
+describe("mergeMemoryExtraPaths (layout-aware)", () => {
+  it("writes to memory.search and leaves the legacy key absent", () => {
+    const { cfg } = mergeMemoryExtraPaths({}, ["/w", "/t"], "namespaced");
+    expect(cfg).toEqual({ memory: { search: { extraPaths: ["/w", "/t"] } } });
+    expect(cfg.agents).toBeUndefined();
+  });
+
+  it("preserves foreign {path, pattern} entries openclaw >= 2026.7.1 allows", () => {
+    const cfg: Record<string, unknown> = {
+      memory: { search: { extraPaths: [{ path: "/notes", pattern: "*.md" }, "/w"] } },
+    };
+    const { added } = mergeMemoryExtraPaths(cfg, ["/w", "/t"], "namespaced");
+    expect(added).toEqual(["/t"]);
+    expect((cfg.memory as Record<string, Record<string, unknown>>).search.extraPaths).toEqual([
+      { path: "/notes", pattern: "*.md" },
+      "/w",
+      "/t",
+    ]);
+  });
+});
+
+describe("mergeHookGrants", () => {
+  it("grants conversation access to digital-me-recall only", () => {
+    const cfg: Record<string, unknown> = {};
+    const { granted } = mergeHookGrants(cfg, CONVERSATION_HOOK_PLUGIN_IDS);
+    expect(granted).toEqual(["digital-me-recall"]);
+    expect(cfg.plugins).toEqual({
+      entries: { "digital-me-recall": { hooks: { allowConversationAccess: true } } },
+    });
+    // digital-me-brain registers tools and no hooks — granting it would hand
+    // out a capability it never uses.
+    expect(CONVERSATION_HOOK_PLUGIN_IDS).not.toContain("digital-me-brain");
+  });
+
+  it("preserves an existing entry's other settings", () => {
+    const cfg: Record<string, unknown> = {
+      plugins: { entries: { "digital-me-recall": { enabled: true, config: { debug: true } } } },
+    };
+    mergeHookGrants(cfg, ["digital-me-recall"]);
+    const entry = (cfg.plugins as Record<string, Record<string, Record<string, unknown>>>).entries[
+      "digital-me-recall"
+    ]!;
+    expect(entry.enabled).toBe(true);
+    expect(entry.config).toEqual({ debug: true });
+    expect((entry.hooks as Record<string, unknown>).allowConversationAccess).toBe(true);
+  });
+
+  it("never overrides a deliberate opt-out", () => {
+    const cfg: Record<string, unknown> = {
+      plugins: { entries: { "digital-me-recall": { hooks: { allowConversationAccess: false } } } },
+    };
+    const { granted } = mergeHookGrants(cfg, ["digital-me-recall"]);
+    expect(granted).toEqual([]);
+    const entry = (cfg.plugins as Record<string, Record<string, Record<string, unknown>>>).entries[
+      "digital-me-recall"
+    ]!;
+    expect((entry.hooks as Record<string, unknown>).allowConversationAccess).toBe(false);
+  });
+
+  it("is idempotent", () => {
+    const cfg: Record<string, unknown> = {};
+    mergeHookGrants(cfg, ["digital-me-recall"]);
+    expect(mergeHookGrants(cfg, ["digital-me-recall"]).granted).toEqual([]);
+  });
+});
+
+describe("parseOpenclawVersionOutput", () => {
+  it("extracts the calendar version from the CLI banner", () => {
+    expect(parseOpenclawVersionOutput("OpenClaw 2026.8.1 (4d37fc4)")).toBe("2026.8.1");
+    expect(parseOpenclawVersionOutput("2026.6.11\n")).toBe("2026.6.11");
+    expect(parseOpenclawVersionOutput("OpenClaw 2026.9.1-beta.1")).toBe("2026.9.1-beta.1");
+  });
+
+  it("returns undefined for output with no version", () => {
+    expect(parseOpenclawVersionOutput("command not found")).toBeUndefined();
+    expect(parseOpenclawVersionOutput(undefined)).toBeUndefined();
+  });
+});
+
+describe("detectOpenclawHostVersion", () => {
+  it("prefers the source checkout — it is the binary the shim runs", () => {
+    // Mid-update the checkout is already on the new tag while the config
+    // stamp still says the old one; the checkout is the truth.
+    const io = memIO({ "/home/u/openclaw/package.json": JSON.stringify({ version: "2026.8.1" }) });
+    expect(
+      detectOpenclawHostVersion("/home/u", { meta: { lastTouchedVersion: "2026.6.11" } }, {}, io, OC_6_11),
+    ).toBe("2026.8.1");
+  });
+
+  it("falls back to the CLI probe, then to the config stamp", () => {
+    const io = memIO();
+    expect(detectOpenclawHostVersion("/home/u", {}, {}, io, OC_8_1)).toBe("2026.8.1");
+    expect(
+      detectOpenclawHostVersion("/home/u", { meta: { lastTouchedVersion: "2026.6.11" } }, {}, io, OC_UNKNOWN),
+    ).toBe("2026.6.11");
+    expect(detectOpenclawHostVersion("/home/u", {}, {}, io, OC_UNKNOWN)).toBeUndefined();
+  });
+
+  it("honors $OPENCLAW_REPO for a non-default checkout location", () => {
+    const io = memIO({ "/srv/oc/package.json": JSON.stringify({ version: "2026.7.1" }) });
+    expect(detectOpenclawHostVersion("/home/u", {}, { OPENCLAW_REPO: "/srv/oc" }, io, OC_UNKNOWN)).toBe(
+      "2026.7.1",
+    );
+  });
+
+  it("ignores an unreadable checkout package.json instead of throwing", () => {
+    const io = memIO({ "/home/u/openclaw/package.json": "{ not json" });
+    expect(detectOpenclawHostVersion("/home/u", {}, {}, io, OC_8_1)).toBe("2026.8.1");
+  });
+});
+
+describe("ensureOpenclawMemoryPaths (host-version aware)", () => {
+  it("writes memory.search and grants the recall hook on a 2026.8.1 host", () => {
+    const io = memIO();
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_8_1);
+    expect(res.ok).toBe(true);
+    expect(res.layout).toBe("namespaced");
+    expect(res.hookGrants).toEqual(["digital-me-recall"]);
+    const written = JSON.parse(io.files["/home/u/.openclaw/openclaw.json"]!);
+    expect(written.memory.search.extraPaths).toEqual([
+      "/home/u/digital-me/wiki",
+      "/home/u/digital-me/tastes",
+    ]);
+    expect(written.agents?.defaults?.memorySearch).toBeUndefined();
+    expect(written.plugins.entries["digital-me-recall"].hooks.allowConversationAccess).toBe(true);
+  });
+
+  it("migrates a legacy config forward when the host has crossed the cutover", () => {
+    // This is the update path: the config was written by 2026.6.x and the
+    // binary is now 2026.8.1. Left alone, openclaw rejects it and the gateway
+    // will not start.
+    const io = memIO({
+      "/home/u/.openclaw/openclaw.json": JSON.stringify({
+        agents: {
+          defaults: {
+            memorySearch: { extraPaths: ["/home/u/digital-me/wiki"], provider: "gemini" },
+          },
+        },
+      }),
+    });
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_8_1);
+    expect(res.migratedLayoutFrom).toBe("legacy");
+    const written = JSON.parse(io.files["/home/u/.openclaw/openclaw.json"]!);
+    expect(written.memory.search.provider).toBe("gemini");
+    expect(written.memory.search.extraPaths).toEqual([
+      "/home/u/digital-me/wiki",
+      "/home/u/digital-me/tastes",
+    ]);
+    expect(written.agents.defaults.memorySearch).toBeUndefined();
+  });
+
+  it("migrates BACK when the host is rolled back below the cutover", () => {
+    const io = memIO({
+      "/home/u/.openclaw/openclaw.json": JSON.stringify({
+        memory: { search: { extraPaths: ["/home/u/digital-me/wiki"] } },
+      }),
+    });
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
+    expect(res.layout).toBe("legacy");
+    expect(res.migratedLayoutFrom).toBe("namespaced");
+    const written = JSON.parse(io.files["/home/u/.openclaw/openclaw.json"]!);
+    expect(written.agents.defaults.memorySearch.extraPaths).toHaveLength(2);
+    expect(written.memory).toBeUndefined();
+  });
+
+  it("writes the grant even when every path is already wired", () => {
+    // The paths were wired by an older digital-me that knew nothing about the
+    // hook policy; the run must still repair the grant rather than no-op.
+    const io = memIO({
+      "/home/u/.openclaw/openclaw.json": JSON.stringify({
+        agents: {
+          defaults: {
+            memorySearch: {
+              fallback: "local",
+              extraPaths: ["/home/u/digital-me/wiki", "/home/u/digital-me/tastes"],
+            },
+          },
+        },
+      }),
+    });
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_6_11);
+    expect(res.added).toEqual([]);
+    expect(res.hookGrants).toEqual(["digital-me-recall"]);
+    const written = JSON.parse(io.files["/home/u/.openclaw/openclaw.json"]!);
+    expect(written.plugins.entries["digital-me-recall"].hooks.allowConversationAccess).toBe(true);
+  });
+
+  it("is idempotent on a fully-wired 2026.8.1 config", () => {
+    const io = memIO();
+    ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_8_1);
+    const before = io.files["/home/u/.openclaw/openclaw.json"];
+    const second = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_8_1);
+    expect(second.added).toEqual([]);
+    expect(second.hookGrants).toEqual([]);
+    expect(second.migratedLayoutFrom).toBeUndefined();
+    expect(io.files["/home/u/.openclaw/openclaw.json"]).toBe(before);
+  });
+});
+
+describe("probeOpenclawVersion", () => {
+  const opts = { encoding: "utf-8" as const, timeout: 20_000 };
+
+  it("returns stdout on a clean exit", () => {
+    const calls: unknown[][] = [];
+    const out = probeOpenclawVersion((cmd, args, o) => {
+      calls.push([cmd, args, o]);
+      return { status: 0, stdout: "OpenClaw 2026.8.1 (4d37fc4)\n" };
+    });
+    expect(out).toBe("OpenClaw 2026.8.1 (4d37fc4)\n");
+    expect(calls[0]).toEqual(["openclaw", ["--version"], opts]);
+  });
+
+  it("returns undefined on a non-zero exit or a signal kill", () => {
+    expect(probeOpenclawVersion(() => ({ status: 1, stdout: "nope" }))).toBeUndefined();
+    // A timeout kill surfaces as status null, not a throw.
+    expect(probeOpenclawVersion(() => ({ status: null }))).toBeUndefined();
+  });
+
+  it("swallows a throwing spawn — a missing binary must not fail the install", () => {
+    expect(
+      probeOpenclawVersion(() => {
+        throw new Error("ENOENT");
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("ensureOpenclawMemoryPaths (unknown host version)", () => {
+  it("falls back to the config's own layout rather than guessing", () => {
+    // No checkout, no CLI, no stamp — but the config already says which
+    // layout this machine's openclaw speaks. Trust it over any default.
+    const io = memIO({
+      "/home/u/.openclaw/openclaw.json": JSON.stringify({
+        agents: { defaults: { memorySearch: { extraPaths: [] } } },
+      }),
+    });
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_UNKNOWN);
+    expect(res.layout).toBe("legacy");
+    expect(res.migratedLayoutFrom).toBeUndefined();
+    const written = JSON.parse(io.files["/home/u/.openclaw/openclaw.json"]!);
+    expect(written.agents.defaults.memorySearch.extraPaths).toHaveLength(2);
+    expect(written.memory).toBeUndefined();
+  });
+
+  it("defaults a blank config to the current namespace", () => {
+    const io = memIO();
+    const res = ensureOpenclawMemoryPaths("/home/u", "/home/u/digital-me", {}, io, OC_UNKNOWN);
+    expect(res.layout).toBe("namespaced");
   });
 });

--- a/packages/cli/src/openclaw-memory.ts
+++ b/packages/cli/src/openclaw-memory.ts
@@ -1,6 +1,11 @@
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import JSON5 from "json5";
+import {
+  isAtLeastOpenclawVersion,
+  MEMORY_SEARCH_NAMESPACE_MIN_VERSION,
+} from "@digital-me/runtime-openclaw";
 
 /**
  * Install-time wiring that makes openclaw's `memory_search` auto-index the
@@ -62,21 +67,114 @@ export const KEY_OPTIONAL_EMBEDDING_PROVIDERS: ReadonlySet<string> = new Set([
   "lmstudio",
 ]);
 
-/** Pure merge: ensure `agents.defaults.memorySearch.extraPaths` contains every
+/**
+ * The two config layouts openclaw has used for the memory-search block.
+ *
+ *  - `legacy`     — `agents.defaults.memorySearch` (openclaw < 2026.7.1)
+ *  - `namespaced` — `memory.search`                (openclaw >= 2026.7.1)
+ *
+ * This is a HARD cutover. Both schemas are `.strict()` and openclaw's loader
+ * THROWS on an unknown key, so the wrong layout does not degrade to "corpus
+ * unindexed" — it stops the gateway from starting. Never write both.
+ */
+export type MemorySearchLayout = "legacy" | "namespaced";
+
+/** Which layout a config already uses, or undefined when it has neither. */
+export function detectMemorySearchLayout(
+  cfg: Record<string, unknown>,
+): MemorySearchLayout | undefined {
+  const legacy = (cfg.agents as Record<string, unknown> | undefined)?.defaults as
+    | Record<string, unknown>
+    | undefined;
+  if (legacy?.memorySearch !== undefined) return "legacy";
+  const memory = cfg.memory as Record<string, unknown> | undefined;
+  if (memory?.search !== undefined) return "namespaced";
+  return undefined;
+}
+
+/**
+ * Pick the layout to write. An existing block always wins — moving it is a
+ * migration, never a side effect of wiring paths. With no existing block the
+ * host version decides, and an unknown host defaults to `namespaced` (current
+ * openclaw); a fresh install on an old host is the rarer case and is still
+ * repairable, whereas silently writing the legacy key on a new host is not.
+ */
+export function resolveMemorySearchLayout(
+  cfg: Record<string, unknown>,
+  hostVersion: string | undefined,
+): MemorySearchLayout {
+  const existing = detectMemorySearchLayout(cfg);
+  if (existing) return existing;
+  const isNew = isAtLeastOpenclawVersion(hostVersion, MEMORY_SEARCH_NAMESPACE_MIN_VERSION);
+  return isNew === false ? "legacy" : "namespaced";
+}
+
+/** Get-or-create the memory-search object at `layout`'s location. */
+function memorySearchBlock(
+  cfg: Record<string, unknown>,
+  layout: MemorySearchLayout,
+): Record<string, unknown> {
+  if (layout === "legacy") {
+    const agents = (cfg.agents ??= {}) as Record<string, unknown>;
+    const defaults = (agents.defaults ??= {}) as Record<string, unknown>;
+    return (defaults.memorySearch ??= {}) as Record<string, unknown>;
+  }
+  const memory = (cfg.memory ??= {}) as Record<string, unknown>;
+  return (memory.search ??= {}) as Record<string, unknown>;
+}
+
+/**
+ * Move the memory-search block to `target`, preserving every sub-key. All six
+ * sub-keys digital-me writes or preserves (`enabled`, `extraPaths`,
+ * `provider`, `fallback`, `model`, `remote`) exist in both versions'
+ * `MemorySearchSchema`, so the move is lossless for our shape. Returns
+ * `migrated: false` when the config is already on `target` or has no block.
+ */
+export function migrateMemorySearchLayout(
+  cfg: Record<string, unknown>,
+  target: MemorySearchLayout,
+): { cfg: Record<string, unknown>; migrated: boolean; from?: MemorySearchLayout } {
+  const from = detectMemorySearchLayout(cfg);
+  if (!from || from === target) return { cfg, migrated: false };
+
+  let block: Record<string, unknown>;
+  if (from === "legacy") {
+    const defaults = (cfg.agents as Record<string, unknown>).defaults as Record<string, unknown>;
+    block = defaults.memorySearch as Record<string, unknown>;
+    delete defaults.memorySearch;
+  } else {
+    const memory = cfg.memory as Record<string, unknown>;
+    block = memory.search as Record<string, unknown>;
+    delete memory.search;
+    // An empty `memory: {}` is schema-valid, but leaving it is noise.
+    if (Object.keys(memory).length === 0) delete cfg.memory;
+  }
+
+  if (target === "legacy") {
+    const agents = (cfg.agents ??= {}) as Record<string, unknown>;
+    const defaults = (agents.defaults ??= {}) as Record<string, unknown>;
+    defaults.memorySearch = block;
+  } else {
+    const memory = (cfg.memory ??= {}) as Record<string, unknown>;
+    memory.search = block;
+  }
+  return { cfg, migrated: true, from };
+}
+
+/** Pure merge: ensure the memory-search block's `extraPaths` contains every
  *  path in `paths` (deduped, append-only). Returns the mutated config and the
  *  list of paths that were newly added (empty ⇒ already present). */
 export function mergeMemoryExtraPaths(
   cfg: Record<string, unknown>,
   paths: readonly string[],
+  layout: MemorySearchLayout = "legacy",
 ): { cfg: Record<string, unknown>; added: string[] } {
   const root = cfg && typeof cfg === "object" ? cfg : {};
-  const agents = (root.agents ??= {}) as Record<string, unknown>;
-  const defaults = (agents.defaults ??= {}) as Record<string, unknown>;
-  const ms = (defaults.memorySearch ??= {}) as Record<string, unknown>;
-  const existing: string[] = Array.isArray(ms.extraPaths)
-    ? (ms.extraPaths.filter((x) => typeof x === "string") as string[])
-    : [];
-  const seen = new Set(existing);
+  const ms = memorySearchBlock(root, layout);
+  // openclaw >= 2026.7.1 also accepts `{path, pattern}` entries here; ours are
+  // plain strings, and a foreign object entry must survive untouched.
+  const existing: unknown[] = Array.isArray(ms.extraPaths) ? [...ms.extraPaths] : [];
+  const seen = new Set(existing.filter((x): x is string => typeof x === "string"));
   const added: string[] = [];
   for (const p of paths) {
     if (!seen.has(p)) {
@@ -90,21 +188,56 @@ export function mergeMemoryExtraPaths(
 }
 
 /** Pure: when the config expresses NO embedding intent (no `provider`, no
- *  `fallback`, no `remote` block under memorySearch), seed
+ *  `fallback`, no `remote` block under memory search), seed
  *  `fallback: "local"` so a keyless fresh machine still builds an index —
  *  openclaw's default provider is `openai`, which needs an API key. Never
  *  touches an explicit choice (even `fallback: "none"`). Call after
- *  `mergeMemoryExtraPaths` (the memorySearch object is guaranteed then).
+ *  `mergeMemoryExtraPaths` (the block is guaranteed then).
  *  Returns true when it seeded. */
-export function seedKeylessEmbeddingFallback(cfg: Record<string, unknown>): boolean {
-  const agents = cfg.agents as Record<string, unknown>;
-  const defaults = agents.defaults as Record<string, unknown>;
-  const ms = defaults.memorySearch as Record<string, unknown>;
+export function seedKeylessEmbeddingFallback(
+  cfg: Record<string, unknown>,
+  layout: MemorySearchLayout = "legacy",
+): boolean {
+  const ms = memorySearchBlock(cfg, layout);
   if (ms.provider !== undefined || ms.fallback !== undefined || ms.remote !== undefined) {
     return false;
   }
   ms.fallback = "local";
   return true;
+}
+
+/**
+ * Pure: grant every plugin in `pluginIds` conversation-hook access.
+ *
+ * openclaw drops a "conversation" typed hook at registration when a
+ * NON-BUNDLED plugin has not opted in — a warn diagnostic and an early
+ * `return`, no error, no failed load, no missing tool. digital-me's plugins
+ * are always non-bundled (`Origin: global`), and the gated set grew to
+ * include `before_prompt_build` in 2026.8.1, which is the entire recall
+ * injection path. `agent_end` (the M1 application-ack) has been gated for
+ * longer still.
+ *
+ * The key is accepted by every openclaw version in our supported range, so
+ * this is granted unconditionally rather than behind a host-version check.
+ * Only ever writes `true`; an explicit `false` set by the operator is left
+ * alone, because that is a deliberate opt-out.
+ */
+export function mergeHookGrants(
+  cfg: Record<string, unknown>,
+  pluginIds: readonly string[],
+): { cfg: Record<string, unknown>; granted: string[] } {
+  const plugins = (cfg.plugins ??= {}) as Record<string, unknown>;
+  const entries = (plugins.entries ??= {}) as Record<string, unknown>;
+  const granted: string[] = [];
+  for (const id of pluginIds) {
+    const entry = (entries[id] ??= {}) as Record<string, unknown>;
+    const hooks = (entry.hooks ??= {}) as Record<string, unknown>;
+    if (hooks.allowConversationAccess === undefined) {
+      hooks.allowConversationAccess = true;
+      granted.push(id);
+    }
+  }
+  return { cfg, granted };
 }
 
 /** Injectable filesystem seam so the wiring is unit-testable without disk. */
@@ -122,11 +255,100 @@ const NODE_IO: MemoryPathIO = {
   mkdirp: (p) => mkdirSync(p, { recursive: true }),
 };
 
+/**
+ * Plugin ids that need conversation-hook access (see {@link mergeHookGrants}).
+ *
+ * ONLY digital-me-recall. It is the sole plugin that registers typed hooks at
+ * all — digital-me-brain registers tools via `api.registerTool` and no hooks,
+ * so granting it conversation access would hand out a capability it never
+ * exercises and make `digital-me doctor` fail on a permission nothing needs.
+ * Least privilege: extend this list only when a plugin actually registers a
+ * hook from openclaw's conversation set.
+ */
+export const CONVERSATION_HOOK_PLUGIN_IDS: readonly string[] = ["digital-me-recall"];
+
+/** Minimal shape of the spawn seam used to probe the CLI. */
+export type VersionSpawn = (
+  cmd: string,
+  args: readonly string[],
+  opts: { encoding: "utf-8"; timeout: number },
+) => { status: number | null; stdout?: string };
+
+/**
+ * Run `openclaw --version` and return raw stdout, or undefined.
+ *
+ * Never throws: an absent binary, a non-zero exit, or a timeout all resolve to
+ * undefined so the caller falls through to the next version signal rather than
+ * failing the install.
+ */
+export function probeOpenclawVersion(
+  spawn: VersionSpawn = spawnSync as unknown as VersionSpawn,
+): string | undefined {
+  try {
+    const res = spawn("openclaw", ["--version"], { encoding: "utf-8", timeout: 20_000 });
+    return res.status === 0 ? res.stdout : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Pull a `YYYY.M.PATCH` out of `openclaw --version` output ("OpenClaw 2026.8.1 (abc123)"). */
+export function parseOpenclawVersionOutput(out: string | undefined): string | undefined {
+  if (!out) return undefined;
+  const m = /\b(\d{4}\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)\b/.exec(out);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Best-effort read of the openclaw version this machine will actually run.
+ *
+ * Order matters, most-authoritative first:
+ *  1. The SOURCE checkout's package.json — that file IS the binary the
+ *     `openclaw` shim executes, so it is right even mid-update, when the
+ *     config's stamp still says the old version.
+ *  2. `openclaw --version` — covers npm-global installs with no checkout.
+ *  3. `meta.lastTouchedVersion` — the gateway's own stamp; a good signal for
+ *     an existing install, stale only if the binary moved without a run.
+ *
+ * Returns undefined when none resolve. Callers MUST treat that as "unknown"
+ * and must not let it silently choose a config layout — picking wrong makes
+ * openclaw reject the whole config and refuse to start.
+ */
+export function detectOpenclawHostVersion(
+  home: string,
+  cfg: Record<string, unknown>,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  io: Pick<MemoryPathIO, "exists" | "read"> = NODE_IO,
+  probe: () => string | undefined = probeOpenclawVersion,
+): string | undefined {
+  const repoDir = env.OPENCLAW_REPO ?? path.join(home, "openclaw");
+  const pkgPath = path.join(repoDir, "package.json");
+  try {
+    if (io.exists(pkgPath)) {
+      const v = (JSON.parse(io.read(pkgPath)) as { version?: unknown }).version;
+      if (typeof v === "string" && v.trim()) return v.trim();
+    }
+  } catch {
+    // Fall through to the next signal.
+  }
+  const probed = parseOpenclawVersionOutput(probe());
+  if (probed) return probed;
+  const meta = cfg.meta as Record<string, unknown> | undefined;
+  const stamped = meta?.lastTouchedVersion;
+  return typeof stamped === "string" && stamped.trim() ? stamped.trim() : undefined;
+}
+
 export interface EnsureMemoryResult {
   configPath: string;
   added: string[];
   ok: boolean;
   error?: string;
+  /** Which layout the memory-search block was written to. */
+  layout?: MemorySearchLayout;
+  /** Set when the block was moved between layouts to match the running host. */
+  migratedLayoutFrom?: MemorySearchLayout;
+  /** Plugin ids newly granted `hooks.allowConversationAccess`. */
+  hookGrants?: string[];
   /** true when `fallback: "local"` was seeded because the config had no
    *  embedding configuration at all (see seedKeylessEmbeddingFallback). */
   seededLocalFallback?: boolean;
@@ -145,6 +367,7 @@ export function ensureOpenclawMemoryPaths(
   wikiRoot: string | undefined,
   env: Readonly<Record<string, string | undefined>> = process.env,
   io: MemoryPathIO = NODE_IO,
+  probe: () => string | undefined = probeOpenclawVersion,
 ): EnsureMemoryResult {
   const configPath = resolveOpenclawConfigPath(home, env);
   const paths = digitalMeKnowledgePaths(home, wikiRoot, env);
@@ -175,9 +398,31 @@ export function ensureOpenclawMemoryPaths(
     if (parsed && typeof parsed === "object") cfg = parsed as Record<string, unknown>;
   }
 
-  const { cfg: merged, added } = mergeMemoryExtraPaths(cfg, paths);
-  const seeded = seedKeylessEmbeddingFallback(merged);
-  if (added.length === 0 && !seeded) return { configPath, added, ok: true };
+  // Which layout does the RUNNING host demand? A block already in the config
+  // normally wins, but when the host has crossed the 2026.7.1 cutover the
+  // block must move — leaving it costs more than an unindexed corpus, it
+  // makes openclaw reject the whole config and refuse to start.
+  const hostVersion = detectOpenclawHostVersion(home, cfg, env, io, probe);
+  const hostWantsNamespaced = isAtLeastOpenclawVersion(
+    hostVersion,
+    MEMORY_SEARCH_NAMESPACE_MIN_VERSION,
+  );
+  const layout: MemorySearchLayout =
+    hostWantsNamespaced === undefined
+      ? resolveMemorySearchLayout(cfg, hostVersion)
+      : hostWantsNamespaced
+        ? "namespaced"
+        : "legacy";
+  const { migrated, from } = migrateMemorySearchLayout(cfg, layout);
+
+  const { cfg: merged, added } = mergeMemoryExtraPaths(cfg, paths, layout);
+  const seeded = seedKeylessEmbeddingFallback(merged, layout);
+  const { granted } = mergeHookGrants(merged, CONVERSATION_HOOK_PLUGIN_IDS);
+  if (added.length === 0 && !seeded && !migrated && granted.length === 0) {
+    // Nothing to write. Still report the shape fields so callers can read
+    // `layout` / `hookGrants` uniformly instead of special-casing the no-op.
+    return { configPath, added, ok: true, layout, hookGrants: granted };
+  }
 
   io.mkdirp(path.dirname(configPath));
   io.write(configPath, JSON.stringify(merged, null, 2) + "\n");
@@ -185,6 +430,9 @@ export function ensureOpenclawMemoryPaths(
     configPath,
     added,
     ok: true,
+    layout,
+    migratedLayoutFrom: migrated ? from : undefined,
+    hookGrants: granted,
     seededLocalFallback: seeded,
     json5Rewritten: json5Only,
   };

--- a/packages/cli/src/openclaw-overlay.test.ts
+++ b/packages/cli/src/openclaw-overlay.test.ts
@@ -197,6 +197,21 @@ describe("materializeOpenclawOverlay (unit)", () => {
         external: ["openclaw/*", "node:*"],
       }),
     );
+    // REGRESSION GUARD. ESM output + bundled CJS deps makes esbuild emit
+    // `__require(x)` for anything it cannot inline, and that shim throws
+    // `Dynamic require of "x" is not supported` because ESM has no `require`.
+    // The gateway then refuses the ENTIRE plugin at load while
+    // `openclaw plugins inspect` still says "Status: loaded" — so every tool
+    // it registers vanishes with no visible error.
+    //
+    // Real incident (2026-08-31): yaml@2.9's CJS dist calls
+    // `require("process")` — a BARE specifier, so the "node:*" external above
+    // does not cover it — which took digital-me-brain fully offline: tasks,
+    // agent_identify, traces_record, m1_event_record and m1_score all
+    // disappeared, and with them the brain MCP for every client.
+    const opts = vi.mocked(build).mock.calls[0]![0] as { banner?: { js?: string } };
+    expect(opts.banner?.js).toContain("createRequire");
+    expect(opts.banner?.js).toContain("import.meta.url");
     const pkg = JSON.parse(
       fs.readFileSync(path.join(target, "bundle-me-plugin", "package.json"), "utf-8"),
     ) as { description?: string; install?: { minHostVersion?: string } };

--- a/packages/cli/src/openclaw-overlay.ts
+++ b/packages/cli/src/openclaw-overlay.ts
@@ -115,6 +115,29 @@ export async function materializeOpenclawOverlay(
           // listing explicitly is safer across esbuild versions):
           "node:*",
         ],
+        // ESM output + bundled CJS dependencies = esbuild emits `__require(x)`
+        // for every require() it cannot inline (anything external, which with
+        // platform:node includes the node built-ins). That shim THROWS
+        // `Dynamic require of "x" is not supported` unless a real `require`
+        // exists in scope — and ESM has none. The gateway then refuses the
+        // whole plugin at load time, so every tool it registers silently
+        // disappears while `openclaw plugins inspect` still reports
+        // "Status: loaded" (that is manifest state, not runtime state).
+        //
+        // This bit us for real: yaml@2.9's CJS dist calls `require("process")`
+        // (a BARE specifier — note it is not matched by the "node:*" external
+        // pattern above), which took digital-me-brain offline entirely: no
+        // tasks, agent_identify, traces_record, m1_event_record or m1_score,
+        // and therefore no brain MCP for any client.
+        //
+        // Defining `require` via createRequire makes the shim delegate to a
+        // real resolver instead of throwing.
+        banner: {
+          js: [
+            'import { createRequire as __dmCreateRequire } from "node:module";',
+            "const require = __dmCreateRequire(import.meta.url);",
+          ].join("\n"),
+        },
         // Source map is small + helps debug live errors:
         sourcemap: "inline",
         // Silence the dev-time warnings about node built-ins:

--- a/packages/cli/src/stable-registration.test.ts
+++ b/packages/cli/src/stable-registration.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isWorktreePath,
+  resolveStableNodePath,
+  resolveStableRegistrationPath,
+  stabilizeRegistration,
+} from "./stable-registration.js";
+
+/** Probe stub: only the listed paths "exist". */
+const only =
+  (...paths: string[]) =>
+  (p: string) =>
+    paths.includes(p);
+const none = () => false;
+const all = () => true;
+
+const MAIN = "/home/u/digital-me-os/packages/transport/brain-mcp-proxy/bin/brain-mcp-proxy.mjs";
+const WORKTREE =
+  "/home/u/digital-me-os/.claude/worktrees/my-branch-abc123/packages/transport/brain-mcp-proxy/bin/brain-mcp-proxy.mjs";
+
+describe("resolveStableRegistrationPath", () => {
+  it("rewrites a worktree path to the main checkout", () => {
+    expect(resolveStableRegistrationPath(WORKTREE, only(MAIN))).toBe(MAIN);
+  });
+
+  it("leaves a non-worktree path untouched", () => {
+    expect(resolveStableRegistrationPath(MAIN, all)).toBe(MAIN);
+  });
+
+  it("keeps the worktree path when the main checkout lacks the file", () => {
+    // A package that exists only on the unmerged branch. Redirecting would
+    // produce a path that 404s immediately — strictly worse than a path that
+    // works until the worktree is removed.
+    expect(resolveStableRegistrationPath(WORKTREE, none)).toBe(WORKTREE);
+  });
+
+  it("strips only the worktree segment, preserving the rest of the path", () => {
+    const p = "/repo/.claude/worktrees/wt/a/b/c.mjs";
+    expect(resolveStableRegistrationPath(p, only("/repo/a/b/c.mjs"))).toBe("/repo/a/b/c.mjs");
+  });
+
+  it("handles a path that ends at the worktree directory itself", () => {
+    const p = "/repo/.claude/worktrees/wt";
+    expect(resolveStableRegistrationPath(p, only("/repo"))).toBe("/repo");
+  });
+
+  it("does not match a directory merely named like the worktree path", () => {
+    // Anchoring on the separator keeps `my.claude/worktrees` from matching.
+    const p = "/repo/my.claude/worktrees/x/bin.mjs";
+    expect(resolveStableRegistrationPath(p, all)).toBe(p);
+  });
+
+  it("supports windows-style separators", () => {
+    const p = "C:\\repo\\.claude\\worktrees\\wt\\bin.mjs";
+    expect(resolveStableRegistrationPath(p, only("C:\\repo\\bin.mjs"))).toBe("C:\\repo\\bin.mjs");
+  });
+});
+
+describe("isWorktreePath", () => {
+  it("identifies worktree paths without rewriting them", () => {
+    expect(isWorktreePath(WORKTREE)).toBe(true);
+    expect(isWorktreePath(MAIN)).toBe(false);
+  });
+});
+
+describe("resolveStableNodePath", () => {
+  it("de-pins a Homebrew Cellar node to the generic symlink", () => {
+    expect(
+      resolveStableNodePath("/opt/homebrew/Cellar/node/25.4.0/bin/node", only("/opt/homebrew/bin/node")),
+    ).toBe("/opt/homebrew/bin/node");
+  });
+
+  it("handles versioned formulae like node@24", () => {
+    expect(
+      resolveStableNodePath("/opt/homebrew/Cellar/node@24/24.20.0/bin/node", only("/opt/homebrew/bin/node")),
+    ).toBe("/opt/homebrew/bin/node");
+  });
+
+  it("derives the prefix rather than hard-coding /opt/homebrew (Intel Macs)", () => {
+    expect(
+      resolveStableNodePath("/usr/local/Cellar/node/24.0.0/bin/node", only("/usr/local/bin/node")),
+    ).toBe("/usr/local/bin/node");
+  });
+
+  it("keeps the Cellar path when the generic symlink is absent", () => {
+    const pinned = "/opt/homebrew/Cellar/node/25.4.0/bin/node";
+    expect(resolveStableNodePath(pinned, none)).toBe(pinned);
+  });
+
+  it("leaves non-Homebrew interpreters alone", () => {
+    // nvm, volta, system node, or a bare command — not our shaped problem.
+    for (const p of ["/usr/bin/node", "/home/u/.nvm/versions/node/v24.0.0/bin/node", "node"]) {
+      expect(resolveStableNodePath(p, all)).toBe(p);
+    }
+  });
+});
+
+describe("stabilizeRegistration", () => {
+  it("applies both hardenings and explains each one", () => {
+    const r = stabilizeRegistration(
+      "/opt/homebrew/Cellar/node/25.4.0/bin/node",
+      WORKTREE,
+      only(MAIN, "/opt/homebrew/bin/node"),
+    );
+    expect(r.binPath).toBe(MAIN);
+    expect(r.nodePath).toBe("/opt/homebrew/bin/node");
+    expect(r.notes).toHaveLength(2);
+    expect(r.notes[0]).toMatch(/worktree/);
+    expect(r.notes[1]).toMatch(/version-pinned/);
+  });
+
+  it("is silent when nothing needs changing", () => {
+    const r = stabilizeRegistration("/opt/homebrew/bin/node", MAIN, all);
+    expect(r.notes).toEqual([]);
+    expect(r.binPath).toBe(MAIN);
+    expect(r.nodePath).toBe("/opt/homebrew/bin/node");
+  });
+
+  it("WARNS loudly when it must register a worktree path anyway", () => {
+    // The dangerous case: we cannot fix it, so the operator has to be told —
+    // this is exactly the silent breakage the module exists to prevent.
+    const r = stabilizeRegistration("/usr/bin/node", WORKTREE, none);
+    expect(r.binPath).toBe(WORKTREE);
+    expect(r.notes).toHaveLength(1);
+    expect(r.notes[0]).toMatch(/WARNING/);
+    expect(r.notes[0]).toMatch(/break when the worktree is removed/);
+  });
+
+  it("reports only the node rewrite when the bin path is already stable", () => {
+    const r = stabilizeRegistration(
+      "/opt/homebrew/Cellar/node/25.4.0/bin/node",
+      MAIN,
+      only(MAIN, "/opt/homebrew/bin/node"),
+    );
+    expect(r.notes).toHaveLength(1);
+    expect(r.notes[0]).toMatch(/version-pinned/);
+  });
+
+  it("defaults its probe to the real filesystem", () => {
+    // Exercises the default parameter: a path that certainly does not exist
+    // must come back untouched rather than throwing.
+    const p = "/nonexistent/.claude/worktrees/wt/x.mjs";
+    expect(stabilizeRegistration("/usr/bin/node", p).binPath).toBe(p);
+  });
+});

--- a/packages/cli/src/stable-registration.ts
+++ b/packages/cli/src/stable-registration.ts
@@ -1,0 +1,142 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Path hardening for values written into PERSISTENT, user-scope client config
+ * (`~/.claude.json`, `~/.codex/config.toml`, `~/.hermes/config.yaml`).
+ *
+ * Those files outlive the process that wrote them, so any path baked into them
+ * must still resolve months later. Two classes of path do not:
+ *
+ *  1. **Worktree paths.** `digital-me install` registers whatever checkout it
+ *     runs from. Run it inside `<repo>/.claude/worktrees/<name>/` and the
+ *     ephemeral worktree gets written into global config; when the worktree is
+ *     removed the entry 404s and the MCP server fails to connect on every
+ *     future session — with no error at install time and none at the point of
+ *     failure either, since a client just reports "Connection closed".
+ *
+ *  2. **Version-pinned interpreters.** `process.execPath` under Homebrew is
+ *     `/opt/homebrew/Cellar/node/<version>/bin/node`. That path dies on the
+ *     next `brew upgrade node` — or, as happened here, when installing a
+ *     second node formula moves a shared dependency out from under the old
+ *     one. The generic `/opt/homebrew/bin/node` symlink follows whichever
+ *     node is linked and keeps working.
+ *
+ * Observed 2026-09-01: all three clients were broken at once — hermes had been
+ * pointing at a worktree deleted months earlier AND pinned to a since-broken
+ * Cellar node, while claude-code and codex had just been re-pointed at a live
+ * worktree by an install run from inside it. See wiki:
+ * infrastructure/never-register-persistent-config-with-worktree-paths.
+ *
+ * Both helpers are pure given their injected probes, and both FAIL OPEN: if a
+ * path cannot be improved with confidence it is returned untouched. Writing a
+ * slightly-suboptimal path is recoverable; rewriting to a path that does not
+ * exist is not.
+ */
+
+/**
+ * Claude Code's worktree layout: `<repo>/.claude/worktrees/<name>/<rest>`.
+ * Anchored on the separator so it cannot match a directory merely *named*
+ * something like `my.claude/worktrees`.
+ */
+const WORKTREE_SEGMENT_RE = /[/\\]\.claude[/\\]worktrees[/\\][^/\\]+(?=[/\\]|$)/;
+
+/**
+ * Rewrite a worktree path to the equivalent path in the main checkout.
+ *
+ * `<repo>/.claude/worktrees/<name>/packages/x/bin/y.mjs`
+ *   → `<repo>/packages/x/bin/y.mjs`
+ *
+ * The rewrite is applied ONLY when the resulting file actually exists, so a
+ * worktree holding something the main checkout does not (a new package on an
+ * unmerged branch) is left alone rather than silently redirected to a path
+ * that would 404 immediately.
+ *
+ * Returns the input unchanged when it is not a worktree path.
+ */
+export function resolveStableRegistrationPath(
+  p: string,
+  exists: (candidate: string) => boolean = existsSync,
+): string {
+  const match = WORKTREE_SEGMENT_RE.exec(p);
+  if (!match) return p;
+  const candidate = p.slice(0, match.index) + p.slice(match.index + match[0].length);
+  return exists(candidate) ? candidate : p;
+}
+
+/** True when `p` sits inside a Claude Code worktree. Exported for messaging. */
+export function isWorktreePath(p: string): boolean {
+  return WORKTREE_SEGMENT_RE.test(p);
+}
+
+/**
+ * Homebrew's version-pinned node: `/opt/homebrew/Cellar/node@24/24.20.0/bin/node`
+ * or `/opt/homebrew/Cellar/node/25.4.0/bin/node`. Captures the prefix so the
+ * generic sibling can be derived rather than hard-coded (Intel Macs use
+ * `/usr/local`, and a custom `--prefix` is possible).
+ */
+const CELLAR_NODE_RE = /^(.*)[/\\]Cellar[/\\]node(?:@[\w.]+)?[/\\][^/\\]+[/\\]bin[/\\]node$/;
+
+/**
+ * Prefer a stable node symlink over a version-pinned Cellar path.
+ *
+ * `/opt/homebrew/Cellar/node/25.4.0/bin/node` → `/opt/homebrew/bin/node`
+ *
+ * Only rewrites when the generic path exists; a Cellar path is still better
+ * than a path that is not there. Non-Homebrew interpreters (nvm, volta, system
+ * node, a bare `node`) are returned untouched — this is a Homebrew-shaped
+ * problem and we do not guess at other layouts.
+ */
+export function resolveStableNodePath(
+  execPath: string,
+  exists: (candidate: string) => boolean = existsSync,
+): string {
+  const match = CELLAR_NODE_RE.exec(execPath);
+  if (!match) return execPath;
+  const generic = path.join(match[1]!, "bin", "node");
+  return exists(generic) ? generic : execPath;
+}
+
+/** Both hardenings, plus what changed — so the installer can say so out loud. */
+export interface StableRegistration {
+  readonly nodePath: string;
+  readonly binPath: string;
+  /** Human-readable notes for each rewrite applied (empty when none). */
+  readonly notes: readonly string[];
+}
+
+/**
+ * Harden an (interpreter, script) pair for persistent registration.
+ *
+ * Callers should print `notes`: a silent rewrite is nearly as confusing as the
+ * silent breakage it prevents, and the operator needs to know the global
+ * config does not point at the checkout they are standing in.
+ */
+export function stabilizeRegistration(
+  nodePath: string,
+  binPath: string,
+  exists: (candidate: string) => boolean = existsSync,
+): StableRegistration {
+  const stableNode = resolveStableNodePath(nodePath, exists);
+  const stableBin = resolveStableRegistrationPath(binPath, exists);
+  const notes: string[] = [];
+  if (stableBin !== binPath) {
+    notes.push(
+      `resolved worktree path to the main checkout (${stableBin}) — a worktree ` +
+        `path in global config breaks as soon as the worktree is removed`,
+    );
+  } else if (isWorktreePath(binPath)) {
+    notes.push(
+      `WARNING: registering a WORKTREE path (${binPath}) because the main ` +
+        `checkout has no matching file. This registration will break when the ` +
+        `worktree is removed — re-run from the main checkout once it is merged`,
+    );
+  }
+  if (stableNode !== nodePath) {
+    notes.push(
+      `using ${stableNode} instead of the version-pinned ${nodePath} — a Cellar ` +
+        `path dies on the next node upgrade`,
+    );
+  }
+  return { nodePath: stableNode, binPath: stableBin, notes };
+}

--- a/packages/runtimes/claude-code/hooks/dm_m1_emit.py
+++ b/packages/runtimes/claude-code/hooks/dm_m1_emit.py
@@ -151,8 +151,12 @@ def post_to_brain(
     # openclaw >= 2026.8.1 requires an explicit owner on a multi-agent host;
     # without agentId the gateway returns invalid_request and the event only
     # ever reaches the WAL (replayable via m1_backfill.py, but brain.db
-    # silently stops receiving live events).
-    agent_id = os.environ.get("DIGITAL_ME_OPENCLAW_AGENT_ID", "main")
+    # silently stops receiving live events). Canonical name is
+    # OPENCLAW_GATEWAY_AGENT_ID; DIGITAL_ME_OPENCLAW_AGENT_ID is aliased.
+    agent_id = os.environ.get(
+        "OPENCLAW_GATEWAY_AGENT_ID",
+        os.environ.get("DIGITAL_ME_OPENCLAW_AGENT_ID", "main"),
+    )
     body = json.dumps(
         {"tool": "m1_event_record", "agentId": agent_id, "args": args}
     ).encode("utf-8")

--- a/packages/runtimes/claude-code/hooks/dm_m1_emit.py
+++ b/packages/runtimes/claude-code/hooks/dm_m1_emit.py
@@ -148,7 +148,14 @@ def post_to_brain(
         args["entries"] = json.dumps(event["entries"])
     if isinstance(event.get("extra"), dict):
         args["extra"] = json.dumps(event["extra"])
-    body = json.dumps({"tool": "m1_event_record", "args": args}).encode("utf-8")
+    # openclaw >= 2026.8.1 requires an explicit owner on a multi-agent host;
+    # without agentId the gateway returns invalid_request and the event only
+    # ever reaches the WAL (replayable via m1_backfill.py, but brain.db
+    # silently stops receiving live events).
+    agent_id = os.environ.get("DIGITAL_ME_OPENCLAW_AGENT_ID", "main")
+    body = json.dumps(
+        {"tool": "m1_event_record", "agentId": agent_id, "args": args}
+    ).encode("utf-8")
     req = urllib.request.Request(
         gateway_url,
         data=body,

--- a/packages/runtimes/claude-code/hooks/dm_memory_search_inject.sh
+++ b/packages/runtimes/claude-code/hooks/dm_memory_search_inject.sh
@@ -57,8 +57,9 @@ QUERY="$(printf '%s' "$PROMPT" | head -c 400)"
 # \"main\" has no explicit owner. Pass agentId or use an agent-prefixed session
 # key." Without it every injection fails and the hook exits 0 silently, so
 # recall just stops with no error anywhere. Override per machine if the
-# default agent is not "main".
-AGENT_ID="${DIGITAL_ME_OPENCLAW_AGENT_ID:-main}"
+# default agent is not "main". Canonical name is OPENCLAW_GATEWAY_AGENT_ID;
+# DIGITAL_ME_OPENCLAW_AGENT_ID is aliased for backward compat.
+AGENT_ID="${OPENCLAW_GATEWAY_AGENT_ID:-${DIGITAL_ME_OPENCLAW_AGENT_ID:-main}}"
 REQ="$(jq -cn --arg q "$QUERY" --arg a "$AGENT_ID" '{tool:"memory_search", agentId:$a, args:{query:$q, limit:6, corpus:"all"}}' 2>/dev/null)"
 [ -z "$REQ" ] && exit 0
 

--- a/packages/runtimes/claude-code/hooks/dm_memory_search_inject.sh
+++ b/packages/runtimes/claude-code/hooks/dm_memory_search_inject.sh
@@ -52,10 +52,18 @@ QUERY="$(printf '%s' "$PROMPT" | head -c 400)"
 
 # Request a few more than we need (limit 6) so the score-gate + dedup still
 # leaves us with usable hits. Then we trim back to ≤ 3 surfaced hits.
-REQ="$(jq -cn --arg q "$QUERY" '{tool:"memory_search", args:{query:$q, limit:6, corpus:"all"}}' 2>/dev/null)"
+# openclaw >= 2026.8.1 REJECTS /tools/invoke on a multi-agent host unless the
+# caller names an owner: "Multiple agents are configured, but session key
+# \"main\" has no explicit owner. Pass agentId or use an agent-prefixed session
+# key." Without it every injection fails and the hook exits 0 silently, so
+# recall just stops with no error anywhere. Override per machine if the
+# default agent is not "main".
+AGENT_ID="${DIGITAL_ME_OPENCLAW_AGENT_ID:-main}"
+REQ="$(jq -cn --arg q "$QUERY" --arg a "$AGENT_ID" '{tool:"memory_search", agentId:$a, args:{query:$q, limit:6, corpus:"all"}}' 2>/dev/null)"
 [ -z "$REQ" ] && exit 0
 
-RESP="$(curl -sS -m 4 -X POST http://localhost:18789/tools/invoke \
+HOOK_TIMEOUT="${DIGITAL_ME_HOOK_TIMEOUT_SECS:-12}"
+RESP="$(curl -sS -m "$HOOK_TIMEOUT" -X POST http://localhost:18789/tools/invoke \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d "$REQ" 2>/dev/null)"

--- a/packages/runtimes/claude-code/src/installer.ts
+++ b/packages/runtimes/claude-code/src/installer.ts
@@ -83,6 +83,11 @@ export type ClaudeHooksManifest = {
  * `~/.claude/settings.json`. Uses `$HOME/.claude/hooks/<name>` paths so
  * the installed location is canonical regardless of where the runtime
  * package itself lives.
+ *
+ * Timeouts:
+ *   - memory_search inject: 12s to match the hook script's curl default
+ *     (DIGITAL_ME_HOOK_TIMEOUT_SECS:-12). A shorter manifest timeout kills
+ *     the hook before curl finishes, making slow searches look like empty injects.
  */
 export function buildClaudeHooksManifest(): ClaudeHooksManifest {
   const cmd = (name: HookName) => `$HOME/.claude/hooks/${name}`;
@@ -93,7 +98,7 @@ export function buildClaudeHooksManifest(): ClaudeHooksManifest {
           {
             type: "command",
             command: cmd("dm_memory_search_inject.sh"),
-            timeout: 8,
+            timeout: 12,
             statusMessage: "Digital Me: searching brain…",
           },
         ],

--- a/packages/runtimes/codex/hooks/dm_m1_emit.py
+++ b/packages/runtimes/codex/hooks/dm_m1_emit.py
@@ -159,8 +159,12 @@ def post_to_brain(
     # openclaw >= 2026.8.1 requires an explicit owner on a multi-agent host;
     # without agentId the gateway returns invalid_request and the event only
     # ever reaches the WAL (replayable via m1_backfill.py, but brain.db
-    # silently stops receiving live events).
-    agent_id = os.environ.get("DIGITAL_ME_OPENCLAW_AGENT_ID", "main")
+    # silently stops receiving live events). Canonical name is
+    # OPENCLAW_GATEWAY_AGENT_ID; DIGITAL_ME_OPENCLAW_AGENT_ID is aliased.
+    agent_id = os.environ.get(
+        "OPENCLAW_GATEWAY_AGENT_ID",
+        os.environ.get("DIGITAL_ME_OPENCLAW_AGENT_ID", "main"),
+    )
     body = json.dumps(
         {"tool": "m1_event_record", "agentId": agent_id, "args": args}
     ).encode("utf-8")

--- a/packages/runtimes/codex/hooks/dm_m1_emit.py
+++ b/packages/runtimes/codex/hooks/dm_m1_emit.py
@@ -156,7 +156,14 @@ def post_to_brain(
         args["entries"] = json.dumps(event["entries"])
     if isinstance(event.get("extra"), dict):
         args["extra"] = json.dumps(event["extra"])
-    body = json.dumps({"tool": "m1_event_record", "args": args}).encode("utf-8")
+    # openclaw >= 2026.8.1 requires an explicit owner on a multi-agent host;
+    # without agentId the gateway returns invalid_request and the event only
+    # ever reaches the WAL (replayable via m1_backfill.py, but brain.db
+    # silently stops receiving live events).
+    agent_id = os.environ.get("DIGITAL_ME_OPENCLAW_AGENT_ID", "main")
+    body = json.dumps(
+        {"tool": "m1_event_record", "agentId": agent_id, "args": args}
+    ).encode("utf-8")
     req = urllib.request.Request(
         gateway_url,
         data=body,

--- a/packages/runtimes/codex/hooks/dm_memory_search_inject.sh
+++ b/packages/runtimes/codex/hooks/dm_memory_search_inject.sh
@@ -52,10 +52,18 @@ fi
 # Trim prompt for the query (brain does semantic search; long verbatim prompts add noise)
 QUERY="$(printf '%s' "$PROMPT" | head -c 400)"
 
-REQ="$(jq -cn --arg q "$QUERY" '{tool:"memory_search", args:{query:$q, limit:6, corpus:"all"}}' 2>/dev/null)"
+# openclaw >= 2026.8.1 REJECTS /tools/invoke on a multi-agent host unless the
+# caller names an owner: "Multiple agents are configured, but session key
+# \"main\" has no explicit owner. Pass agentId or use an agent-prefixed session
+# key." Without it every injection fails and the hook exits 0 silently, so
+# recall just stops with no error anywhere. Override per machine if the
+# default agent is not "main".
+AGENT_ID="${DIGITAL_ME_OPENCLAW_AGENT_ID:-main}"
+REQ="$(jq -cn --arg q "$QUERY" --arg a "$AGENT_ID" '{tool:"memory_search", agentId:$a, args:{query:$q, limit:6, corpus:"all"}}' 2>/dev/null)"
 [ -z "$REQ" ] && exit 0
 
-RESP="$(curl -sS -m 4 -X POST http://localhost:18789/tools/invoke \
+HOOK_TIMEOUT="${DIGITAL_ME_HOOK_TIMEOUT_SECS:-12}"
+RESP="$(curl -sS -m "$HOOK_TIMEOUT" -X POST http://localhost:18789/tools/invoke \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d "$REQ" 2>/dev/null)"

--- a/packages/runtimes/codex/hooks/dm_memory_search_inject.sh
+++ b/packages/runtimes/codex/hooks/dm_memory_search_inject.sh
@@ -57,8 +57,9 @@ QUERY="$(printf '%s' "$PROMPT" | head -c 400)"
 # \"main\" has no explicit owner. Pass agentId or use an agent-prefixed session
 # key." Without it every injection fails and the hook exits 0 silently, so
 # recall just stops with no error anywhere. Override per machine if the
-# default agent is not "main".
-AGENT_ID="${DIGITAL_ME_OPENCLAW_AGENT_ID:-main}"
+# default agent is not "main". Canonical name is OPENCLAW_GATEWAY_AGENT_ID;
+# DIGITAL_ME_OPENCLAW_AGENT_ID is aliased for backward compat.
+AGENT_ID="${OPENCLAW_GATEWAY_AGENT_ID:-${DIGITAL_ME_OPENCLAW_AGENT_ID:-main}}"
 REQ="$(jq -cn --arg q "$QUERY" --arg a "$AGENT_ID" '{tool:"memory_search", agentId:$a, args:{query:$q, limit:6, corpus:"all"}}' 2>/dev/null)"
 [ -z "$REQ" ] && exit 0
 

--- a/packages/runtimes/codex/src/installer.test.ts
+++ b/packages/runtimes/codex/src/installer.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   CODEX_MD_TEMPLATE,
-  HOOK_NAMES,
   HOOKS_DIR,
+  HOOK_NAMES,
   MCP_TOML_TEMPLATE,
   PACKAGE_ROOT,
   SECTION_BEGIN,
@@ -10,9 +10,11 @@ import {
   TEMPLATES_DIR,
   buildCodexHooksManifest,
   buildCodexMcpConfig,
+  inlineKeysOf,
   mergeCodexHooksJson,
   mergeCodexMd,
   mergeMcpServer,
+  stripDuplicatedSubTables,
 } from "./installer.js";
 
 describe("buildCodexMcpConfig", () => {
@@ -349,5 +351,101 @@ args = []
     const twice = mergeMcpServer(once, FRAGMENT);
     // Content equivalent (whitespace normalization aside)
     expect(twice.trim()).toBe(once.trim());
+  });
+});
+
+describe("mergeMcpServer — duplicate sub-table regression (2026-09-01)", () => {
+  // Codex writes `env` as a SUB-TABLE; our fragment writes it inline. TOML
+  // forbids both, and the failure is whole-file: the parser aborts and every
+  // MCP server in config.toml disappears, not just ours. Re-installing the
+  // codex runtime did exactly this on a live machine.
+  const fragment = [
+    "[mcp_servers.openclaw-brain]",
+    'command = "/opt/homebrew/bin/node"',
+    'args = ["/main/brain-mcp-proxy.mjs"]',
+    'env = { OPENCLAW_HOME = "/h", OPENCLAW_AGENT_ID = "codex" }',
+    "",
+  ].join("\n");
+
+  const existing = [
+    "[mcp_servers.other]",
+    'command = "x"',
+    "",
+    "[mcp_servers.openclaw-brain]",
+    'command = "/opt/homebrew/Cellar/node/25.4.0/bin/node"',
+    'args = ["/worktree/brain-mcp-proxy.mjs"]',
+    "",
+    "[mcp_servers.openclaw-brain.env]",
+    'OPENCLAW_HOME = "/h"',
+    'OPENCLAW_AGENT_ID = "codex"',
+    "",
+    "[mcp_servers.openclaw-brain.tools.memory_search]",
+    'approval_mode = "approve"',
+    "",
+  ].join("\n");
+
+  it("removes the colliding env sub-table so the result is valid TOML", () => {
+    const out = mergeMcpServer(existing, fragment);
+    expect(out).not.toContain("[mcp_servers.openclaw-brain.env]");
+    expect(out).toContain('env = { OPENCLAW_HOME = "/h"');
+    // exactly one declaration of env for this server
+    expect(out.match(/openclaw-brain\.env\]/g)).toBeNull();
+  });
+
+  it("PRESERVES per-tool approval settings, which are not ours to delete", () => {
+    const out = mergeMcpServer(existing, fragment);
+    expect(out).toContain("[mcp_servers.openclaw-brain.tools.memory_search]");
+    expect(out).toContain('approval_mode = "approve"');
+  });
+
+  it("leaves unrelated servers intact", () => {
+    const out = mergeMcpServer(existing, fragment);
+    expect(out).toContain("[mcp_servers.other]");
+  });
+
+  it("still replaces the stale command/args", () => {
+    const out = mergeMcpServer(existing, fragment);
+    expect(out).toContain("/main/brain-mcp-proxy.mjs");
+    expect(out).not.toContain("/worktree/brain-mcp-proxy.mjs");
+    expect(out).not.toContain("Cellar/node/25.4.0");
+  });
+
+  it("is idempotent — merging twice does not reintroduce a duplicate", () => {
+    const once = mergeMcpServer(existing, fragment);
+    const twice = mergeMcpServer(once, fragment);
+    expect(twice.match(/openclaw-brain\.env\]/g)).toBeNull();
+    expect(twice).toBe(once);
+  });
+});
+
+describe("inlineKeysOf", () => {
+  it("collects only keys declared directly under the fragment header", () => {
+    expect(
+      inlineKeysOf('[mcp_servers.x]\ncommand = "n"\nenv = { A = "1" }\n\n[mcp_servers.x.tools.t]\nk = 1\n'),
+    ).toEqual(["command", "env"]);
+  });
+
+  it("ignores lines before any header", () => {
+    expect(inlineKeysOf('stray = 1\n[mcp_servers.x]\ncommand = "n"\n')).toEqual(["command"]);
+  });
+
+  it("returns nothing for a fragment with no keys", () => {
+    expect(inlineKeysOf("[mcp_servers.x]\n")).toEqual([]);
+  });
+});
+
+describe("stripDuplicatedSubTables", () => {
+  it("returns input untouched when there is nothing to strip", () => {
+    const lines = ["[a.b.env]", "k = 1"];
+    expect(stripDuplicatedSubTables(lines, "[a.b]", [])).toEqual(lines);
+  });
+
+  it("stops skipping at the next unrelated header", () => {
+    const out = stripDuplicatedSubTables(
+      ["[a.b.env]", "k = 1", "[a.b.tools.t]", "m = 2"],
+      "[a.b]",
+      ["env"],
+    );
+    expect(out).toEqual(["[a.b.tools.t]", "m = 2"]);
   });
 });

--- a/packages/runtimes/codex/src/installer.test.ts
+++ b/packages/runtimes/codex/src/installer.test.ts
@@ -449,3 +449,45 @@ describe("stripDuplicatedSubTables", () => {
     expect(out).toEqual(["[a.b.tools.t]", "m = 2"]);
   });
 });
+
+describe("mergeCodexMd — duplicate marker accumulation (2026-09-01)", () => {
+  // Twin of the hermes SOUL.md bug: the template embeds its own markers and
+  // the merge took the FIRST end marker, so the live CODEX.md reached
+  // 2 BEGIN / 9 END. Missed when hermes was fixed; caught in review.
+  const damaged = [
+    "# Codex",
+    "",
+    SECTION_BEGIN,
+    "old protocol text",
+    SECTION_BEGIN,
+    "duplicated inner block",
+    SECTION_END,
+    SECTION_END,
+    SECTION_END,
+    "",
+  ].join("\n");
+
+  it("collapses every stray marker into one clean managed section", () => {
+    const out = mergeCodexMd(damaged, "## Digital Me Protocol\nfresh");
+    expect(out.split(SECTION_BEGIN).length - 1).toBe(1);
+    expect(out.split(SECTION_END).length - 1).toBe(1);
+    expect(out).toContain("fresh");
+    expect(out).not.toContain("duplicated inner block");
+  });
+
+  it("does not nest when the incoming section already carries markers (the template does)", () => {
+    const templateLike = `${SECTION_BEGIN}\nbody\n${SECTION_END}`;
+    const out = mergeCodexMd("# Codex\n", templateLike);
+    expect(out.split(SECTION_BEGIN).length - 1).toBe(1);
+    expect(out.split(SECTION_END).length - 1).toBe(1);
+  });
+
+  it("preserves the operator's own content outside the section", () => {
+    expect(mergeCodexMd(damaged, "fresh").startsWith("# Codex")).toBe(true);
+  });
+
+  it("is idempotent on an already-clean file", () => {
+    const once = mergeCodexMd(damaged, "fresh");
+    expect(mergeCodexMd(once, "fresh")).toBe(once);
+  });
+});

--- a/packages/runtimes/codex/src/installer.ts
+++ b/packages/runtimes/codex/src/installer.ts
@@ -101,6 +101,51 @@ export function mergeCodexMd(
  * the simple key=value MCP-server stanzas we ship, and avoids pulling
  * in a TOML parser dependency.
  */
+
+/** Keys a fragment declares INLINE (`key = ...`) directly under its header. */
+export function inlineKeysOf(fragment: string): string[] {
+  const keys: string[] = [];
+  let seenHeader = false;
+  for (const raw of fragment.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("[") && line.endsWith("]")) {
+      if (seenHeader) break; // a nested/next table ends the inline region
+      seenHeader = true;
+      continue;
+    }
+    if (!seenHeader) continue;
+    const m = /^([A-Za-z0-9_-]+)\s*=/.exec(line);
+    if (m) keys.push(m[1]!);
+  }
+  return keys;
+}
+
+/**
+ * Remove `[<header-body>.<key>]` sub-tables for each key in `inlineKeys`,
+ * along with the lines they own (up to the next table header).
+ *
+ * `header` arrives as `[mcp_servers.<name>]`; the sub-table to strip is
+ * therefore `[mcp_servers.<name>.<key>]`.
+ */
+export function stripDuplicatedSubTables(
+  lines: readonly string[],
+  header: string,
+  inlineKeys: readonly string[],
+): string[] {
+  if (inlineKeys.length === 0) return [...lines];
+  const base = header.trim().slice(1, -1); // "mcp_servers.<name>"
+  const targets = new Set(inlineKeys.map((k) => `[${base}.${k}]`));
+  const out: string[] = [];
+  let skipping = false;
+  for (const line of lines) {
+    const t = line.trim();
+    const isHeader = t.startsWith("[") && t.endsWith("]");
+    if (isHeader) skipping = targets.has(t);
+    if (!skipping) out.push(line);
+  }
+  return out;
+}
+
 export function mergeMcpServer(
   existingToml: string,
   fragment: string,
@@ -124,7 +169,24 @@ export function mergeMcpServer(
     }
   }
   const before = lines.slice(0, headerIdx).join("\n");
-  const after = lines.slice(endIdx).join("\n");
+  // Drop any sub-table that re-declares a key our fragment sets INLINE.
+  //
+  // TOML forbids defining a key both ways, and it is a WHOLE-FILE error: the
+  // parser aborts and every other server in config.toml disappears with it.
+  // Codex writes `env` as a sub-table (`[mcp_servers.<name>.env]`) while this
+  // fragment writes it inline, and the block-replacement above stops at the
+  // next `[...]` header — which IS that sub-table — so it survived and
+  // collided. Observed 2026-09-01: re-installing the codex runtime made the
+  // entire config unparseable, taking all six MCP servers down, not just ours.
+  //
+  // Only sub-tables we would actually duplicate are removed; anything else
+  // under the same server (notably `[mcp_servers.<name>.tools.*]`, which holds
+  // per-tool approval settings the operator or codex owns) is preserved.
+  const after = stripDuplicatedSubTables(
+    lines.slice(endIdx),
+    header,
+    inlineKeysOf(fragment),
+  ).join("\n");
   const beforeSep = before.length > 0 && !before.endsWith("\n") ? "\n" : "";
   const afterSep = after.length > 0 ? "\n" : "";
   return `${before}${beforeSep}${fragment.trim()}\n${afterSep}${after}`;

--- a/packages/runtimes/codex/src/installer.ts
+++ b/packages/runtimes/codex/src/installer.ts
@@ -262,6 +262,11 @@ export const DEFAULT_CODEX_HOOKS_DIR = "$HOME/.codex/hooks";
  *                        dm_session_extract.sh         (skinny audit log)
  *                        dm_application_rate.sh        (M1 assistant_ack + session_end)
  *   - PreToolUse       → brain_route_inject.sh         (brain-MCP protocol injection)
+ *
+ * Timeouts:
+ *   - memory_search inject: 12s to match the hook script's curl default
+ *     (DIGITAL_ME_HOOK_TIMEOUT_SECS:-12). A shorter manifest timeout kills
+ *     the hook before curl finishes, making slow searches look like empty injects.
  */
 export function buildCodexHooksManifest(
   hooksDir: string = DEFAULT_CODEX_HOOKS_DIR,
@@ -274,7 +279,7 @@ export function buildCodexHooksManifest(
           {
             type: "command",
             command: cmd("dm_memory_search_inject.sh"),
-            timeout: 8,
+            timeout: 12,
             statusMessage: "Digital Me: searching brain…",
           },
         ],

--- a/packages/runtimes/codex/src/installer.ts
+++ b/packages/runtimes/codex/src/installer.ts
@@ -78,9 +78,25 @@ export function mergeCodexMd(
   existing: string,
   newManagedSection: string,
 ): string {
-  const wrapped = `${SECTION_BEGIN}\n${newManagedSection.trim()}\n${SECTION_END}`;
+  // Strip any markers the incoming section already carries before wrapping.
+  // The shipped CODEX.md template contains its own BEGIN/END pair (lines 11
+  // and 132), so wrapping it verbatim nests a section inside a section on
+  // EVERY install. Identical root cause to hermes' SOUL.md.
+  const bare = newManagedSection
+    .split("\n")
+    .filter((l) => l.trim() !== SECTION_BEGIN && l.trim() !== SECTION_END)
+    .join("\n")
+    .trim();
+  const wrapped = `${SECTION_BEGIN}\n${bare}\n${SECTION_END}`;
   const beginIdx = existing.indexOf(SECTION_BEGIN);
-  const endIdx = existing.indexOf(SECTION_END);
+  // LAST end marker, not the first: with `indexOf`, every marker after the
+  // first one landed in `after` and survived each merge, so damage
+  // accumulated instead of being replaced. The live CODEX.md had reached
+  // 2 BEGIN / 9 END markers this way (2026-09-01) — the hermes fix was
+  // applied and this twin was missed, caught in maintainer review.
+  // Spanning to the last marker makes a damaged file self-heal on the next
+  // install.
+  const endIdx = existing.lastIndexOf(SECTION_END);
   if (beginIdx >= 0 && endIdx > beginIdx) {
     // Replace the existing managed span (inclusive of both markers).
     const before = existing.slice(0, beginIdx);

--- a/packages/runtimes/hermes/plugins/digital-me-recall-hermes/__init__.py
+++ b/packages/runtimes/hermes/plugins/digital-me-recall-hermes/__init__.py
@@ -188,7 +188,17 @@ def _invoke_gateway(tool: str, args: Dict[str, Any], timeout: float = 4.0) -> Op
     token = _get_token()
     if not token:
         return None
-    req_body = json.dumps({"tool": tool, "args": args}).encode("utf-8")
+    # openclaw >= 2026.8.1 rejects /tools/invoke on a multi-agent host without
+    # an explicit owner ("Multiple agents are configured, but session key
+    # \"main\" has no explicit owner"). This is the OWNING openclaw agent and
+    # is distinct from args["agent_id"], which is hermes' own attribution
+    # label — passing the label here fails differently ("Unknown agent id").
+    # Without it every recall call is refused and this plugin silently
+    # injects nothing, exactly like the claude-code hook did.
+    gateway_agent = os.environ.get("OPENCLAW_GATEWAY_AGENT_ID", "main")
+    req_body = json.dumps(
+        {"tool": tool, "agentId": gateway_agent, "args": args}
+    ).encode("utf-8")
     req = urllib.request.Request(
         GATEWAY_URL,
         data=req_body,

--- a/packages/runtimes/hermes/scripts/m1_backfill.py
+++ b/packages/runtimes/hermes/scripts/m1_backfill.py
@@ -88,7 +88,12 @@ def invoke_brain(
     args: Dict[str, Any],
     timeout: float = 5.0,
 ) -> Optional[Dict[str, Any]]:
-    body = json.dumps({"tool": tool, "args": args}).encode("utf-8")
+    # openclaw >= 2026.8.1 rejects /tools/invoke on a multi-agent host without
+    # an explicit owner. Distinct from args["agent_id"], which is attribution.
+    _gw_agent = os.environ.get("OPENCLAW_GATEWAY_AGENT_ID", "main")
+    body = json.dumps(
+        {"tool": tool, "agentId": _gw_agent, "args": args}
+    ).encode("utf-8")
     req = urllib.request.Request(
         gateway_url,
         data=body,

--- a/packages/runtimes/hermes/src/installer.test.ts
+++ b/packages/runtimes/hermes/src/installer.test.ts
@@ -208,3 +208,45 @@ describe("digital-me-recall-hermes plugin shipping", () => {
     );
   });
 });
+
+describe("mergeSoulMd — duplicate marker accumulation (2026-09-01)", () => {
+  // A live SOUL.md reached 2 BEGIN + 9 END markers: taking the FIRST end
+  // marker left every later one in the untouched tail, so each install added
+  // to the damage instead of repairing it.
+  const damaged = [
+    "# Soul",
+    "",
+    SECTION_BEGIN,
+    "old protocol text",
+    SECTION_BEGIN,
+    "duplicated inner block",
+    SECTION_END,
+    SECTION_END,
+    SECTION_END,
+    "",
+  ].join("\n");
+
+  it("collapses every stray marker into one clean managed section", () => {
+    const out = mergeSoulMd(damaged, "## Digital Me Protocol\nfresh");
+    expect(out.split(SECTION_BEGIN).length - 1).toBe(1);
+    expect(out.split(SECTION_END).length - 1).toBe(1);
+    expect(out).toContain("fresh");
+    expect(out).not.toContain("duplicated inner block");
+  });
+
+  it("preserves the operator's own content outside the section", () => {
+    const out = mergeSoulMd(damaged, "fresh");
+    expect(out.startsWith("# Soul")).toBe(true);
+  });
+
+  it("is idempotent on an already-clean file", () => {
+    const once = mergeSoulMd(damaged, "fresh");
+    expect(mergeSoulMd(once, "fresh")).toBe(once);
+  });
+
+  it("still appends when no managed section exists", () => {
+    const out = mergeSoulMd("# Soul\n", "fresh");
+    expect(out).toContain(SECTION_BEGIN);
+    expect(out.split(SECTION_END).length - 1).toBe(1);
+  });
+});

--- a/packages/runtimes/hermes/src/installer.ts
+++ b/packages/runtimes/hermes/src/installer.ts
@@ -79,9 +79,29 @@ export function mergeSoulMd(
   existing: string,
   newManagedSection: string,
 ): string {
-  const wrapped = `${SECTION_BEGIN}\n${newManagedSection.trim()}\n${SECTION_END}`;
+  // Strip any markers the incoming section already carries before wrapping.
+  // The shipped template contains its own BEGIN/END pair, so wrapping it
+  // verbatim nested one section inside another on EVERY install — which is
+  // how a live SOUL.md accumulated 2 begin and 9 end markers.
+  const bare = newManagedSection
+    .split("\n")
+    .filter((l) => l.trim() !== SECTION_BEGIN && l.trim() !== SECTION_END)
+    .join("\n")
+    .trim();
+  const wrapped = `${SECTION_BEGIN}\n${bare}\n${SECTION_END}`;
   const beginIdx = existing.indexOf(SECTION_BEGIN);
-  const endIdx = existing.indexOf(SECTION_END);
+  // LAST end marker, not the first.
+  //
+  // With `indexOf` here, any marker after the first one fell into `after` and
+  // survived every subsequent merge — so duplicates accumulated instead of
+  // being replaced. A live SOUL.md reached TWO begin markers and NINE end
+  // markers this way (2026-09-01), which then tripped the malformed-section
+  // guard below and would have made the next install throw outright.
+  //
+  // Taking the last end marker makes the replacement span cover every stray
+  // marker in between, so a damaged file self-heals on the next install
+  // rather than degrading further.
+  const endIdx = existing.lastIndexOf(SECTION_END);
   if (
     (beginIdx >= 0 && endIdx < 0) ||
     (beginIdx < 0 && endIdx >= 0) ||

--- a/packages/runtimes/openclaw/src/compat.test.ts
+++ b/packages/runtimes/openclaw/src/compat.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  CONVERSATION_HOOK_PROMPT_BUILD_MIN_VERSION,
+  isAtLeastOpenclawVersion,
   MAX_TESTED_OPENCLAW_VERSION,
+  MEMORY_SEARCH_NAMESPACE_MIN_VERSION,
   OPENCLAW_MIN_HOST_VERSION,
   resolveHostOpenclawVersion,
   warnIfUntestedHost,
@@ -62,11 +65,11 @@ describe("compat", () => {
   });
 
   it("warns when the host is newer than the tested range", () => {
-    const { api, warnings } = makeApi("2026.7.0");
+    const { api, warnings } = makeApi("2026.9.1");
     warnIfUntestedHost(api, "digital-me-brain");
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("digital-me-brain");
-    expect(warnings[0]).toContain("2026.7.0");
+    expect(warnings[0]).toContain("2026.9.1");
   });
 
   it("does not warn when the host equals the tested ceiling", () => {
@@ -131,5 +134,40 @@ describe("compat", () => {
       },
     };
     expect(() => warnIfUntestedHost(api, "digital-me-brain")).not.toThrow();
+  });
+});
+
+describe("isAtLeastOpenclawVersion", () => {
+  it("compares on [year, month, patch], not string order", () => {
+    // "2026.10.1" < "2026.9.1" lexicographically but is NEWER by calendar.
+    expect(isAtLeastOpenclawVersion("2026.10.1", "2026.9.1")).toBe(true);
+    expect(isAtLeastOpenclawVersion("2026.6.11", "2026.7.1")).toBe(false);
+    expect(isAtLeastOpenclawVersion("2026.7.1", "2026.7.1")).toBe(true);
+    expect(isAtLeastOpenclawVersion("2026.8.1", "2026.7.1")).toBe(true);
+    // Patch ordering within a month is numeric, not lexical: 6.34 > 6.11.
+    expect(isAtLeastOpenclawVersion("2026.6.34", "2026.6.11")).toBe(true);
+  });
+
+  it("tolerates a prerelease suffix on the host version", () => {
+    expect(isAtLeastOpenclawVersion("2026.9.1-beta.1", "2026.8.1")).toBe(true);
+  });
+
+  it("returns undefined — never false — when a version is unparseable", () => {
+    // A caller must be able to distinguish "older" from "unknown": picking a
+    // config layout from a bad parse would make openclaw reject the config.
+    expect(isAtLeastOpenclawVersion(undefined, "2026.7.1")).toBeUndefined();
+    expect(isAtLeastOpenclawVersion("unknown", "2026.7.1")).toBeUndefined();
+    expect(isAtLeastOpenclawVersion("2026.7.1", "not-a-version")).toBeUndefined();
+  });
+});
+
+describe("openclaw cutover constants", () => {
+  it("pins the releases whose behaviour digital-me branches on", () => {
+    // Changing either of these changes which config layout we write and when
+    // we expect hooks to be gated — both are load-bearing, so pin them.
+    expect(MEMORY_SEARCH_NAMESPACE_MIN_VERSION).toBe("2026.7.1");
+    expect(CONVERSATION_HOOK_PROMPT_BUILD_MIN_VERSION).toBe("2026.8.1");
+    // The verified ceiling must not drift below a cutover we already handle.
+    expect(isAtLeastOpenclawVersion(MAX_TESTED_OPENCLAW_VERSION, MEMORY_SEARCH_NAMESPACE_MIN_VERSION)).toBe(true);
   });
 });

--- a/packages/runtimes/openclaw/src/compat.ts
+++ b/packages/runtimes/openclaw/src/compat.ts
@@ -32,7 +32,40 @@ export const MIN_OPENCLAW_VERSION = "2026.5.12";
 export const OPENCLAW_MIN_HOST_VERSION = `>=${MIN_OPENCLAW_VERSION}`;
 
 /** Highest openclaw stable release the plugins have been verified against. */
-export const MAX_TESTED_OPENCLAW_VERSION = "2026.6.10";
+export const MAX_TESTED_OPENCLAW_VERSION = "2026.8.1";
+
+/**
+ * First openclaw release that moved the memory-search config block from
+ * `agents.defaults.memorySearch` to the root `memory.search` namespace.
+ *
+ * This is a HARD cutover, not a soft rename — both schemas are `.strict()`,
+ * so the legacy key is rejected on a new host and the new key is rejected on
+ * an old one. openclaw's config loader THROWS on an unknown key
+ * (`config/io.load.ts` → `throwInvalidConfig`), which means a config carrying
+ * the wrong layout stops the gateway from starting at all. Callers that write
+ * this block must pick the layout that matches the running host.
+ *
+ * Verified: 2026.6.11 `zod-schema.agent-defaults.ts` mounts `memorySearch`
+ * and its root `MemorySchema` has no `search` key; 2026.8.1
+ * `zod-schema.root-support.ts` mounts `memory.search` and `agents.defaults`
+ * no longer accepts `memorySearch`.
+ */
+export const MEMORY_SEARCH_NAMESPACE_MIN_VERSION = "2026.7.1";
+
+/**
+ * First openclaw release that gates `before_prompt_build` behind the
+ * conversation-access plugin policy.
+ *
+ * `agent_end` has been gated since well before 2026.6.11, but 2026.8.1 added
+ * `before_prompt_build` and `agent_turn_prepare` to `CONVERSATION_HOOK_NAMES`
+ * (`plugins/hook-types.ts`). A non-bundled plugin — which every digital-me
+ * plugin is (`Origin: global`) — must set
+ * `plugins.entries.<id>.hooks.allowConversationAccess: true` or the hook is
+ * silently dropped at registration: a warn diagnostic and an early `return`,
+ * no error and no failed load. Setting the flag is valid on both sides of the
+ * cutover, so it is safe to grant unconditionally.
+ */
+export const CONVERSATION_HOOK_PROMPT_BUILD_MIN_VERSION = "2026.8.1";
 
 /** Parse a "YYYY.M.PATCH[-prerelease][+build]" version into [year, month, patch]. */
 function parseVersionTriple(version: string): [number, number, number] | null {
@@ -49,6 +82,23 @@ function isStrictlyNewer(
   if (a[0] !== b[0]) return a[0] > b[0];
   if (a[1] !== b[1]) return a[1] > b[1];
   return a[2] > b[2];
+}
+
+/**
+ * True when `version` is at least `minimum` on [year, month, patch].
+ * Returns undefined when either version cannot be parsed — callers must treat
+ * that as "unknown", never as false, so an unreadable host version never
+ * silently selects the wrong config layout.
+ */
+export function isAtLeastOpenclawVersion(
+  version: string | undefined,
+  minimum: string,
+): boolean | undefined {
+  if (!version) return undefined;
+  const a = parseVersionTriple(version);
+  const b = parseVersionTriple(minimum);
+  if (!a || !b) return undefined;
+  return !isStrictlyNewer(b, a);
 }
 
 /**

--- a/packages/runtimes/openclaw/src/index.ts
+++ b/packages/runtimes/openclaw/src/index.ts
@@ -20,6 +20,22 @@ export {
 } from "./plugin-entry.js";
 export type { OpenClawAgentTool } from "./plugin-entry.js";
 
+export {
+  BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS,
+  BRAIN_MEMORY_SEARCH_MAX_RESULTS,
+  BRAIN_MEMORY_SEARCH_TOOL_NAME,
+  BrainMemorySearchToolSchema,
+  buildBrainMemorySearchTool,
+  normalizeMemoryHit,
+  resolveMaxResults,
+} from "./memory-search-tool.js";
+export type {
+  BrainMemorySearchHit,
+  BrainMemorySearchToolParams,
+  MemorySearchFn,
+  RawMemoryHit,
+} from "./memory-search-tool.js";
+
 export { TRANSCRIPT_SOURCE } from "./manifest.js";
 
 export {

--- a/packages/runtimes/openclaw/src/index.ts
+++ b/packages/runtimes/openclaw/src/index.ts
@@ -86,7 +86,10 @@ export type {
 } from "./installer.js";
 
 export {
+  CONVERSATION_HOOK_PROMPT_BUILD_MIN_VERSION,
+  isAtLeastOpenclawVersion,
   MAX_TESTED_OPENCLAW_VERSION,
+  MEMORY_SEARCH_NAMESPACE_MIN_VERSION,
   MIN_OPENCLAW_VERSION,
   OPENCLAW_MIN_HOST_VERSION,
   resolveHostOpenclawVersion,

--- a/packages/runtimes/openclaw/src/installer.test.ts
+++ b/packages/runtimes/openclaw/src/installer.test.ts
@@ -47,12 +47,13 @@ describe("installer paths — brain plugin", () => {
     expect(targets).toEqual(["index.mjs", "openclaw.plugin.json"]);
   });
 
-  it("the brain manifest declares all 7 brain tool contracts (incl. M1 universal protocol)", () => {
+  it("the brain manifest declares all 8 brain tool contracts (incl. M1 universal protocol + brain_memory_search)", () => {
     const manifest = JSON.parse(
       fs.readFileSync(BRAIN_MANIFEST_TEMPLATE, "utf8"),
     ) as { contracts: { tools: string[] } };
     expect(manifest.contracts.tools.sort()).toEqual([
       "agent_identify",
+      "brain_memory_search",
       "learning_capture",
       "m1_event_record",
       "m1_score",

--- a/packages/runtimes/openclaw/src/installer.test.ts
+++ b/packages/runtimes/openclaw/src/installer.test.ts
@@ -156,8 +156,20 @@ describe("installer paths — recall plugin", () => {
     // before_message_write is SYNCHRONOUS — the handler must not be async
     // (the host drops Promise returns).
     expect(entry).toContain('api.on("before_message_write", (event, ctx) =>');
-    // The registration-log marker advertises both emitters.
-    expect(entry).toContain("assistant_ack=agent_end+before_message_write");
+    // The registration-log marker is DERIVED, not hardcoded. A literal
+    // `assistant_ack=agent_end+before_message_write` would keep advertising
+    // agent_end even when openclaw refused to register it — which is exactly
+    // how a blocked conversation hook stayed invisible to `digital-me deploy`'s
+    // fingerprint check. The marker must be computed from the hooks the host
+    // will actually honour.
+    expect(entry).not.toContain("assistant_ack=agent_end+before_message_write");
+    expect(entry).toContain("const ackSources = [");
+    expect(entry).toContain("assistant_ack=${ackSources.join");
+    // ...and the boot self-check that feeds it must be present, so a missing
+    // grant is loud in the gateway log instead of silent.
+    expect(entry).toContain("conversationAccessGranted");
+    expect(entry).toContain("conversation_hooks=");
+    expect(entry).toContain("CONVERSATION HOOKS NOT GRANTED");
   });
 
   it("Hook D's INSERT uses the actual traces table schema (id, agent_id, kind, payload, t)", () => {

--- a/packages/runtimes/openclaw/src/memory-search-tool.test.ts
+++ b/packages/runtimes/openclaw/src/memory-search-tool.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS,
+  BRAIN_MEMORY_SEARCH_MAX_RESULTS,
+  BRAIN_MEMORY_SEARCH_TOOL_NAME,
+  BrainMemorySearchToolSchema,
+  buildBrainMemorySearchTool,
+  normalizeMemoryHit,
+  resolveMaxResults,
+} from "./memory-search-tool.js";
+
+function parse(result: { content: readonly { text: string }[] }): Record<string, unknown> {
+  return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+describe("normalizeMemoryHit", () => {
+  it("keeps path/title/score/snippet/source and drops unknown-typed fields", () => {
+    expect(
+      normalizeMemoryHit({ path: "a.md", title: "A", score: 0.9, snippet: "s", source: "memory", body: "b" }),
+    ).toEqual({ path: "a.md", title: "A", score: 0.9, snippet: "s", source: "memory" });
+    expect(normalizeMemoryHit({ path: "a.md", title: 3, score: "x", source: 1 })).toEqual({ path: "a.md" });
+  });
+
+  it("falls back to a bounded body excerpt when there is no snippet", () => {
+    const hit = normalizeMemoryHit({ path: "a.md", snippet: "", body: "x".repeat(1000) });
+    expect(hit?.snippet).toHaveLength(400);
+  });
+
+  it("rejects hits without a usable path", () => {
+    expect(normalizeMemoryHit({ path: "" })).toBeNull();
+    expect(normalizeMemoryHit({ title: "no path" })).toBeNull();
+  });
+
+  it("ignores a non-finite score", () => {
+    expect(normalizeMemoryHit({ path: "a.md", score: Number.NaN })).toEqual({ path: "a.md" });
+  });
+});
+
+describe("resolveMaxResults", () => {
+  it("defaults, floors, and clamps", () => {
+    expect(resolveMaxResults(undefined)).toBe(BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS);
+    expect(resolveMaxResults("7")).toBe(BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS);
+    expect(resolveMaxResults(Number.POSITIVE_INFINITY)).toBe(BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS);
+    expect(resolveMaxResults(0)).toBe(1);
+    expect(resolveMaxResults(3.9)).toBe(3);
+    expect(resolveMaxResults(999)).toBe(BRAIN_MEMORY_SEARCH_MAX_RESULTS);
+  });
+});
+
+describe("buildBrainMemorySearchTool", () => {
+  it("is openclaw-shaped and named brain_memory_search with the typebox schema", () => {
+    const tool = buildBrainMemorySearchTool({ search: vi.fn(), defaultAgentId: "main" });
+    expect(tool.name).toBe(BRAIN_MEMORY_SEARCH_TOOL_NAME);
+    expect(tool.parameters).toBe(BrainMemorySearchToolSchema);
+    expect(tool.description).toMatch(/warm/);
+  });
+
+  it("searches the default agent, normalizes hits, and reports count", async () => {
+    const search = vi.fn().mockResolvedValue([
+      { path: "MEMORY.md", title: "M", score: 0.8, snippet: "s" },
+      { title: "no path" },
+    ]);
+    const tool = buildBrainMemorySearchTool({ search, defaultAgentId: "main" });
+    const result = await tool.execute("id", { query: "  COO " });
+    expect(search).toHaveBeenCalledWith({ agentId: "main", query: "COO", maxResults: 6 });
+    const payload = parse(result);
+    expect(result.isError).toBeUndefined();
+    expect(payload).toMatchObject({ agent: "main", query: "COO", count: 1, path: "gateway-warm-manager" });
+    expect(payload.results).toEqual([{ path: "MEMORY.md", title: "M", score: 0.8, snippet: "s" }]);
+    expect(typeof payload.durationMs).toBe("number");
+    expect(result.details).toEqual(payload);
+  });
+
+  it("honours agent and maxResults, and truncates over-long result sets", async () => {
+    const search = vi.fn().mockResolvedValue([{ path: "a" }, { path: "b" }, { path: "c" }]);
+    const tool = buildBrainMemorySearchTool({ search, defaultAgentId: "main" });
+    const result = await tool.execute("id", { query: "x", agent: " coo ", maxResults: 2 });
+    expect(search).toHaveBeenCalledWith({ agentId: "coo", query: "x", maxResults: 2 });
+    expect(parse(result).count).toBe(2);
+  });
+
+  it("treats a null/undefined search result as zero hits", async () => {
+    const tool = buildBrainMemorySearchTool({ search: vi.fn().mockResolvedValue(null), defaultAgentId: "main" });
+    const result = await tool.execute("id", { query: "x" });
+    expect(parse(result)).toMatchObject({ count: 0, results: [] });
+  });
+
+  it("rejects a missing/empty query and non-object params without searching", async () => {
+    const search = vi.fn();
+    const tool = buildBrainMemorySearchTool({ search, defaultAgentId: "main" });
+    for (const params of [{ query: "   " }, {}, null, "str", [1]]) {
+      const result = await tool.execute("id", params);
+      expect(result.isError).toBe(true);
+      expect(parse(result)).toEqual({ error: "query required", agent: "main" });
+    }
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a search failure as an isError result (Error and non-Error throws)", async () => {
+    const tool1 = buildBrainMemorySearchTool({
+      search: vi.fn().mockRejectedValue(new Error("memory search unavailable for agent \"coo\"")),
+      defaultAgentId: "main",
+    });
+    const r1 = await tool1.execute("id", { query: "x", agent: "coo" });
+    expect(r1.isError).toBe(true);
+    expect(parse(r1)).toMatchObject({ error: 'memory search unavailable for agent "coo"', agent: "coo", query: "x" });
+
+    const tool2 = buildBrainMemorySearchTool({ search: vi.fn().mockRejectedValue("boom"), defaultAgentId: "main" });
+    const r2 = await tool2.execute("id", { query: "x" });
+    expect(parse(r2).error).toBe("boom");
+  });
+});

--- a/packages/runtimes/openclaw/src/memory-search-tool.ts
+++ b/packages/runtimes/openclaw/src/memory-search-tool.ts
@@ -1,0 +1,171 @@
+/**
+ * `brain_memory_search` — an IN-GATEWAY memory search tool registered by the
+ * digital-me-brain openclaw plugin.
+ *
+ * Why this exists (2026-09-01, openclaw 2026.8.1):
+ *   - openclaw gives one-shot CLI runs (the cli-backend heartbeat, `openclaw
+ *     agent` exec) a TRANSIENT memory manager per `memory_search` call
+ *     (memory-core tools.ts: `oneShotCliRun → purpose "cli"`). On a large
+ *     store that is a cold open plus a KNN subprocess inside the hardcoded
+ *     15 s deadline — 0/19 heartbeat calls succeeded on a 1.7 GB index — and
+ *     each attempt also kicks off a full reindex that races the gateway's own
+ *     indexer, aborts, and strands a 1.3 GB temp database.
+ *   - An external MCP server (the brain proxy) cannot be the workaround in
+ *     those runs: openclaw treats it as "native tool use" and a headless run
+ *     cannot answer the approval prompt.
+ *   - Tools registered by an openclaw plugin are served through the bundle
+ *     server without that gate, and `getActiveMemorySearchManager` from the
+ *     plugin SDK resolves the gateway's long-lived (warm) manager — the same
+ *     path `/tools/invoke` uses, ~1–3 s for the same query.
+ *
+ * The search itself is injected (`MemorySearchFn`) so this module stays free
+ * of openclaw imports and fully unit-testable; the plugin template wires it
+ * to the SDK.
+ */
+
+import { Type, type Static } from "typebox";
+import type { MCPToolResult } from "@digital-me/brain-orchestrator";
+import type { OpenClawAgentTool } from "./plugin-entry.js";
+
+export const BRAIN_MEMORY_SEARCH_TOOL_NAME = "brain_memory_search";
+
+/** Hard cap on results; keeps a liveness probe from pulling whole corpora. */
+export const BRAIN_MEMORY_SEARCH_MAX_RESULTS = 20;
+export const BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS = 6;
+/** Snippet fallback length when a hit carries only a body. */
+const SNIPPET_CHARS = 400;
+
+export const BrainMemorySearchToolSchema = Type.Object(
+  {
+    query: Type.String({ description: "Search query (natural language)." }),
+    agent: Type.Optional(
+      Type.String({
+        description:
+          "openclaw agent whose memory index to search (e.g. 'coo'). Defaults to the host's primary agent.",
+      }),
+    ),
+    maxResults: Type.Optional(
+      Type.Number({
+        description: `Max results (default ${BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS}, max ${BRAIN_MEMORY_SEARCH_MAX_RESULTS}).`,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+export type BrainMemorySearchToolParams = Static<typeof BrainMemorySearchToolSchema>;
+
+/** A hit as returned by openclaw's MemorySearchManager.search (loosely typed:
+ *  the SDK's result type is not exported to plugins). */
+export type RawMemoryHit = {
+  readonly path?: unknown;
+  readonly title?: unknown;
+  readonly score?: unknown;
+  readonly snippet?: unknown;
+  readonly body?: unknown;
+  readonly source?: unknown;
+};
+
+export type MemorySearchFn = (params: {
+  readonly agentId: string;
+  readonly query: string;
+  readonly maxResults: number;
+}) => Promise<readonly RawMemoryHit[] | null | undefined>;
+
+export type BrainMemorySearchHit = {
+  readonly path: string;
+  readonly title?: string;
+  readonly score?: number;
+  readonly snippet?: string;
+  readonly source?: string;
+};
+
+/** Normalize one raw hit; drops entries with no usable path. */
+export function normalizeMemoryHit(raw: RawMemoryHit): BrainMemorySearchHit | null {
+  if (typeof raw.path !== "string" || raw.path === "") return null;
+  const snippetSource =
+    typeof raw.snippet === "string" && raw.snippet !== ""
+      ? raw.snippet
+      : typeof raw.body === "string"
+        ? raw.body.slice(0, SNIPPET_CHARS)
+        : undefined;
+  return {
+    path: raw.path,
+    ...(typeof raw.title === "string" ? { title: raw.title } : {}),
+    ...(typeof raw.score === "number" && Number.isFinite(raw.score) ? { score: raw.score } : {}),
+    ...(snippetSource !== undefined ? { snippet: snippetSource } : {}),
+    ...(typeof raw.source === "string" ? { source: raw.source } : {}),
+  };
+}
+
+/** Clamp a caller-supplied result count into [1, MAX]; non-numbers → default. */
+export function resolveMaxResults(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return BRAIN_MEMORY_SEARCH_DEFAULT_RESULTS;
+  }
+  return Math.min(BRAIN_MEMORY_SEARCH_MAX_RESULTS, Math.max(1, Math.floor(value)));
+}
+
+function textResult(payload: Record<string, unknown>, isError: boolean): MCPToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    details: payload,
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+/**
+ * Build the openclaw-shaped `brain_memory_search` tool. `defaultAgentId` is
+ * the owner used when the caller passes no `agent`.
+ */
+export function buildBrainMemorySearchTool(deps: {
+  readonly search: MemorySearchFn;
+  readonly defaultAgentId: string;
+}): OpenClawAgentTool {
+  return {
+    name: BRAIN_MEMORY_SEARCH_TOOL_NAME,
+    description:
+      "Search an openclaw agent's memory index on the gateway's long-lived (warm) manager. " +
+      "Use this instead of memory_search from one-shot CLI sessions such as heartbeats: there " +
+      "memory_search cold-opens the whole index per call and cannot meet its 15s deadline. " +
+      "Pass agent to pick the index (e.g. 'coo'); returns {agent, query, count, results[{path,title,score,snippet}]}.",
+    parameters: BrainMemorySearchToolSchema,
+    execute: async (_toolCallId, params) => {
+      const record =
+        params && typeof params === "object" && !Array.isArray(params)
+          ? (params as Record<string, unknown>)
+          : {};
+      const query = typeof record.query === "string" ? record.query.trim() : "";
+      const agentRaw = typeof record.agent === "string" ? record.agent.trim() : "";
+      const agentId = agentRaw !== "" ? agentRaw : deps.defaultAgentId;
+      if (query === "") {
+        return textResult({ error: "query required", agent: agentId }, true);
+      }
+      const maxResults = resolveMaxResults(record.maxResults);
+      const startedAt = Date.now();
+      try {
+        const raw = (await deps.search({ agentId, query, maxResults })) ?? [];
+        const results = raw
+          .map((hit) => normalizeMemoryHit(hit))
+          .filter((hit): hit is BrainMemorySearchHit => hit !== null)
+          .slice(0, maxResults);
+        return textResult(
+          {
+            agent: agentId,
+            query,
+            count: results.length,
+            results,
+            durationMs: Date.now() - startedAt,
+            path: "gateway-warm-manager",
+          },
+          false,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return textResult(
+          { error: message, agent: agentId, query, durationMs: Date.now() - startedAt },
+          true,
+        );
+      }
+    },
+  };
+}

--- a/packages/runtimes/openclaw/templates/brain/index.mjs
+++ b/packages/runtimes/openclaw/templates/brain/index.mjs
@@ -33,8 +33,11 @@ import path from "node:path";
 // cli alias (see infra wiki: run-local-cli-as-brain-exec-worker-via-cli-exec-aliases).
 import * as YAML from "yaml";
 
-// openclaw plugin SDK (the only openclaw-side import).
+// openclaw plugin SDK (the only openclaw-side imports).
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+// Resolves the gateway's long-lived memory manager for an agent — the warm
+// search path. See brain_memory_search below for why this tool exists.
+import { getActiveMemorySearchManager } from "openclaw/plugin-sdk/memory-host-search";
 
 // brain-orchestrator: stores, migrations, scheduler.
 import {
@@ -63,6 +66,7 @@ import {
 
 // runtime-openclaw: Dispatcher + alias resolver + tool builder + compat check.
 import {
+  buildBrainMemorySearchTool,
   buildOpenClawBrainTools,
   createOpenClawAliasResolver,
   createOpenClawDispatcher,
@@ -214,7 +218,34 @@ export default definePluginEntry({
     for (const tool of tools) {
       api.registerTool(tool);
     }
-    api.logger.info(`digital-me-brain: registered ${tools.length} tools`);
+
+    // 5b. brain_memory_search — memory search on the gateway's WARM manager.
+    //     One-shot CLI runs (the cli-backend heartbeat) get a transient manager
+    //     for openclaw's own memory_search: a cold open of the whole store per
+    //     call that cannot meet the hardcoded 15 s deadline on a large index
+    //     (0/19 COO heartbeats on 2026-09-01), and each attempt strands a
+    //     temp reindex database. Plugin tools are served through the bundle
+    //     server without the native-tool approval gate that blocks external
+    //     MCP servers in those runs, so this is the only warm path they have.
+    const memorySearchDefaultAgent =
+      typeof api.pluginConfig?.memorySearchDefaultAgent === "string" &&
+      api.pluginConfig.memorySearchDefaultAgent.trim() !== ""
+        ? api.pluginConfig.memorySearchDefaultAgent.trim()
+        : "main";
+    const memorySearchTool = buildBrainMemorySearchTool({
+      defaultAgentId: memorySearchDefaultAgent,
+      search: async ({ agentId, query, maxResults }) => {
+        const memory = await getActiveMemorySearchManager({ cfg: api.config, agentId });
+        if (!memory.manager) {
+          throw new Error(memory.error ?? `memory search unavailable for agent "${agentId}"`);
+        }
+        return await memory.manager.search(query, { maxResults });
+      },
+    });
+    api.registerTool(memorySearchTool);
+    api.logger.info(
+      `digital-me-brain: registered ${tools.length + 1} tools (incl. brain_memory_search, default agent ${memorySearchDefaultAgent})`,
+    );
 
     // 6. The scheduler's `instantiateWorkflow` callback: given a
     //    (workflowId, vars), create the goal + tasks via brain-orchestrator's

--- a/packages/runtimes/openclaw/templates/brain/openclaw.plugin.json
+++ b/packages/runtimes/openclaw/templates/brain/openclaw.plugin.json
@@ -13,7 +13,8 @@
       "traces_record",
       "traces_query",
       "m1_event_record",
-      "m1_score"
+      "m1_score",
+      "brain_memory_search"
     ]
   },
   "configSchema": {

--- a/packages/runtimes/openclaw/templates/recall/index.mjs
+++ b/packages/runtimes/openclaw/templates/recall/index.mjs
@@ -49,6 +49,46 @@ import {
   warnIfUntestedHost,
 } from "@digital-me/runtime-openclaw";
 
+// ─── Conversation-hook access self-check ────────────────────────────────
+//
+// openclaw drops a "conversation" typed hook at registration when a
+// NON-BUNDLED plugin has not opted in via
+// `plugins.entries.<id>.hooks.allowConversationAccess: true`. It emits a warn
+// diagnostic and returns — the plugin still loads, still registers its tools,
+// and still looks healthy. Only the hooks are gone.
+//
+// `api.on()` cannot report this: the drop happens inside the host and returns
+// void either way. So instead of claiming what registered, read the policy we
+// were given and say plainly which of OUR hooks the host will refuse.
+//
+// The gated set grew over time; this is the 2026.8.1 set, which is a superset
+// of every earlier one, so a hook listed here that is NOT gated on an older
+// host only costs an over-cautious warning — never a false green.
+const CONVERSATION_GATED_HOOKS = new Set([
+  "before_model_resolve",
+  "agent_turn_prepare",
+  "before_prompt_build",
+  "before_agent_reply",
+  "llm_input",
+  "llm_output",
+  "before_agent_finalize",
+  "agent_end",
+  "before_agent_run",
+]);
+
+/** Hooks this plugin registers that the host may refuse without the grant. */
+const OUR_CONVERSATION_HOOKS = ["before_prompt_build", "agent_end"];
+
+/** True when the running config grants this plugin conversation-hook access. */
+function conversationAccessGranted(api, pluginId) {
+  try {
+    const entry = api?.config?.plugins?.entries?.[pluginId];
+    return entry?.hooks?.allowConversationAccess === true;
+  } catch {
+    return false;
+  }
+}
+
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require("node:sqlite");
 
@@ -1060,13 +1100,36 @@ export default definePluginEntry({
       }
     });
 
+    // Report what the host will actually honour, not what we asked for. A
+    // blocked conversation hook is otherwise indistinguishable from a healthy
+    // plugin, so this is the one place the failure becomes visible at boot.
+    const convGranted = conversationAccessGranted(api, "digital-me-recall");
+    const blockedHooks = convGranted
+      ? []
+      : OUR_CONVERSATION_HOOKS.filter((h) => CONVERSATION_GATED_HOOKS.has(h));
+    if (blockedHooks.length > 0) {
+      api.logger.warn(
+        `digital-me-recall: CONVERSATION HOOKS NOT GRANTED — ${blockedHooks.join(", ")} ` +
+          `may be dropped by the host. Set ` +
+          `plugins.entries.digital-me-recall.hooks.allowConversationAccess=true in the ` +
+          `openclaw config and restart the gateway, or run ` +
+          `'digital-me install --runtime openclaw'. Symptom: wiki recall and the ` +
+          `M1 application-ack silently stop with no error.`,
+      );
+    }
+    // `assistant_ack` names the hooks that feed the ack, minus any the host
+    // will refuse — so the deploy-time fingerprint reflects reality.
+    const ackSources = ["agent_end", "before_message_write"].filter(
+      (h) => !blockedHooks.includes(h),
+    );
     api.logger.info(
       `digital-me-recall: registered hooks (` +
         `boot=on, recall=${recallMaxResults > 0 ? "on" : "off"}, ` +
         `route=${enableRouteHashmap ? "on" : "off"}, ` +
         `observability=${enableObservability && brainDb ? "on" : "off"}, ` +
         `m1_emitter=${brainDb ? "on" : "wal-only"}, ` +
-        `assistant_ack=agent_end+before_message_write, ` +
+        `conversation_hooks=${convGranted ? "granted" : "BLOCKED"}, ` +
+        `assistant_ack=${ackSources.join("+") || "none"}, ` +
         `app_rate=on, periodic_flush_ms=${m1FlushIntervalMs}, ` +
         `m1_wal_seeded_sessions=${m1Seeded})`,
     );

--- a/packages/services/dream-cycle/src/dream_cycle/brain_client.py
+++ b/packages/services/dream-cycle/src/dream_cycle/brain_client.py
@@ -148,7 +148,12 @@ class BrainClient:
         self.timeout_s = timeout_s
 
     def _invoke(self, tool: str, args: dict[str, Any]) -> dict[str, Any]:
-        body = json.dumps({"tool": tool, "args": args}).encode("utf-8")
+        # openclaw >= 2026.8.1 rejects /tools/invoke on a multi-agent host without
+        # an explicit owner. Distinct from args["agent_id"], which is attribution.
+        _gw_agent = os.environ.get("OPENCLAW_GATEWAY_AGENT_ID", "main")
+        body = json.dumps(
+            {"tool": tool, "agentId": _gw_agent, "args": args}
+        ).encode("utf-8")
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.gateway.token}",

--- a/packages/services/dream-cycle/tests/test_brain_client.py
+++ b/packages/services/dream-cycle/tests/test_brain_client.py
@@ -133,6 +133,10 @@ def test_run_workflow_sends_expected_request_shape() -> None:
     assert captured["headers"]["Content-Type"] == "application/json"
     assert captured["body"] == {
         "tool": "tasks",
+        # openclaw >= 2026.8.1 refuses /tools/invoke on a multi-agent host with
+        # no explicit owner. Distinct from any args-level agent_id, which is
+        # attribution rather than ownership.
+        "agentId": "main",
         "args": {
             "action": "run_workflow",
             "templateId": "wf_dream_cycle_v2",
@@ -193,7 +197,7 @@ def test_schedule_tick_posts_correct_action() -> None:
         captured=captured,
     )
     client.schedule_tick()
-    assert captured["body"] == {"tool": "tasks", "args": {"action": "schedule_tick"}}
+    assert captured["body"] == {"tool": "tasks", "agentId": "main", "args": {"action": "schedule_tick"}}
 
 
 def test_task_status_sends_taskId() -> None:

--- a/packages/transport/brain-mcp-proxy/src/config.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/config.test.ts
@@ -3,9 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  DEFAULT_GATEWAY_AGENT_ID,
+  GatewayConfigError,
   loadGatewayConfig,
   resolveDefaultAgentId,
-  GatewayConfigError,
+  resolveGatewayAgentId,
 } from "./config.js";
 
 let tmpDir: string;
@@ -243,5 +245,33 @@ describe("resolveDefaultAgentId", () => {
         argv: ["--other-flag=value", "--agent-id=picked"],
       }),
     ).toBe("picked");
+  });
+});
+
+describe("resolveGatewayAgentId", () => {
+  it("defaults to openclaw's conventional first agent", () => {
+    expect(resolveGatewayAgentId({})).toBe("main");
+    expect(resolveGatewayAgentId({})).toBe(DEFAULT_GATEWAY_AGENT_ID);
+  });
+
+  it("honours an explicit override for hosts whose primary agent isn't 'main'", () => {
+    expect(resolveGatewayAgentId({ OPENCLAW_GATEWAY_AGENT_ID: "coo" })).toBe("coo");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(resolveGatewayAgentId({ OPENCLAW_GATEWAY_AGENT_ID: "  coo \n" })).toBe("coo");
+  });
+
+  it("falls back when the override is blank", () => {
+    expect(resolveGatewayAgentId({ OPENCLAW_GATEWAY_AGENT_ID: "   " })).toBe("main");
+    expect(resolveGatewayAgentId({ OPENCLAW_GATEWAY_AGENT_ID: "" })).toBe("main");
+  });
+
+  it("is INDEPENDENT of OPENCLAW_AGENT_ID — they mean different things", () => {
+    // OPENCLAW_AGENT_ID is the calling client's attribution label ("hermes").
+    // Sending it as the gateway owner produced `Unknown agent id "hermes"`,
+    // because no openclaw agent by that name exists. The owner must be a real
+    // entry in agents.entries; the label must not leak into it.
+    expect(resolveGatewayAgentId({ OPENCLAW_AGENT_ID: "hermes" })).toBe("main");
   });
 });

--- a/packages/transport/brain-mcp-proxy/src/config.ts
+++ b/packages/transport/brain-mcp-proxy/src/config.ts
@@ -136,6 +136,39 @@ export function loadGatewayConfig(input: {
   };
 }
 
+/**
+ * Default openclaw agent that OWNS gateway invocations.
+ *
+ * openclaw's conventional first agent. Used only when nothing overrides it.
+ */
+export const DEFAULT_GATEWAY_AGENT_ID = "main";
+
+/**
+ * Resolve the owning openclaw agent for `/tools/invoke`.
+ *
+ * DISTINCT FROM {@link resolveDefaultAgentId}, and conflating the two is a
+ * live bug we shipped:
+ *
+ *  - `resolveDefaultAgentId` (`$OPENCLAW_AGENT_ID`) is an ATTRIBUTION label —
+ *    which client is calling ("hermes", "codex", "claude-code"). It lands in
+ *    `args.agent_id` and is what the brain tools record.
+ *  - This one is the openclaw AGENT that owns the call. It must name a real
+ *    entry in `agents.entries`, because openclaw >= 2026.8.1 rejects an
+ *    invocation on a multi-agent host with no owner — and rejects an owner it
+ *    does not recognise just as hard (`Unknown agent id "hermes"`).
+ *
+ * Override with `$OPENCLAW_GATEWAY_AGENT_ID` on a host whose primary agent is
+ * not "main".
+ */
+export function resolveGatewayAgentId(env: NodeJS.ProcessEnv): string {
+  const raw = env.OPENCLAW_GATEWAY_AGENT_ID;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (trimmed !== "") return trimmed;
+  }
+  return DEFAULT_GATEWAY_AGENT_ID;
+}
+
 export function resolveDefaultAgentId(input: {
   env: NodeJS.ProcessEnv;
   argv: readonly string[];

--- a/packages/transport/brain-mcp-proxy/src/gateway.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/gateway.test.ts
@@ -249,3 +249,65 @@ describe("invokeGatewayTool — timeout firing in real time", () => {
     expect(receivedSignal?.aborted).toBe(true);
   });
 });
+
+describe("invokeGatewayTool — agentId in the invoke envelope", () => {
+  const gateway = { url: "http://127.0.0.1:18789/tools/invoke", token: "t" };
+  const okResponse = () =>
+    Promise.resolve({
+      json: () => Promise.resolve({ ok: true, result: { content: [] } }),
+    } as unknown as Response);
+
+  it("sends agentId at the TOP level, alongside (not inside) args", async () => {
+    // openclaw >= 2026.8.1 rejects a multi-agent invocation with no owner:
+    // 'Multiple agents are configured, but session key "main" has no explicit
+    // owner.' The owner belongs on the envelope; args.agent_id is separate
+    // attribution metadata the brain tools read.
+    let body: Record<string, unknown> = {};
+    await invokeGatewayTool({
+      toolName: "memory_search",
+      args: { query: "q", agent_id: "hermes" },
+      gateway,
+      fetchFn: ((_u: string, init: { body: string }) => {
+        body = JSON.parse(init.body) as Record<string, unknown>;
+        return okResponse();
+      }) as never,
+      timeoutMs: 1000,
+      agentId: "main",
+    });
+    expect(body.agentId).toBe("main");
+    expect(body.tool).toBe("memory_search");
+    // attribution is preserved and NOT overwritten by the owner
+    expect((body.args as Record<string, unknown>).agent_id).toBe("hermes");
+  });
+
+  it("omits agentId entirely when none is given (single-agent hosts need no owner)", async () => {
+    let body: Record<string, unknown> = {};
+    await invokeGatewayTool({
+      toolName: "tasks",
+      args: {},
+      gateway,
+      fetchFn: ((_u: string, init: { body: string }) => {
+        body = JSON.parse(init.body) as Record<string, unknown>;
+        return okResponse();
+      }) as never,
+      timeoutMs: 1000,
+    });
+    expect("agentId" in body).toBe(false);
+  });
+
+  it("omits agentId when it is blank rather than sending an empty owner", async () => {
+    let body: Record<string, unknown> = {};
+    await invokeGatewayTool({
+      toolName: "tasks",
+      args: {},
+      gateway,
+      fetchFn: ((_u: string, init: { body: string }) => {
+        body = JSON.parse(init.body) as Record<string, unknown>;
+        return okResponse();
+      }) as never,
+      timeoutMs: 1000,
+      agentId: "",
+    });
+    expect("agentId" in body).toBe(false);
+  });
+});

--- a/packages/transport/brain-mcp-proxy/src/gateway.ts
+++ b/packages/transport/brain-mcp-proxy/src/gateway.ts
@@ -61,8 +61,23 @@ export async function invokeGatewayTool(input: {
   gateway: GatewayEndpoint;
   fetchFn: FetchFn;
   timeoutMs: number;
+  /**
+   * Owning agent for this call. openclaw >= 2026.8.1 REFUSES /tools/invoke on
+   * a multi-agent host without one:
+   *
+   *   Multiple agents are configured, but session key "main" has no explicit
+   *   owner. Pass agentId or use an agent-prefixed session key.
+   *
+   * Note this is distinct from `args.agent_id`, which is attribution metadata
+   * the brain tools read; the gateway needs the owner at the TOP level of the
+   * envelope. Sending only the former made every brain tool fail for every
+   * MCP client at once (2026-09-01).
+   *
+   * Optional so a single-agent host, which needs no owner, is unaffected.
+   */
+  agentId?: string;
 }): Promise<CallToolResult> {
-  const { toolName, args, gateway, fetchFn, timeoutMs } = input;
+  const { toolName, args, gateway, fetchFn, timeoutMs, agentId } = input;
 
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -75,7 +90,11 @@ export async function invokeGatewayTool(input: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${gateway.token}`,
       },
-      body: JSON.stringify({ tool: toolName, args }),
+      body: JSON.stringify({
+        tool: toolName,
+        ...(agentId !== undefined && agentId !== "" ? { agentId } : {}),
+        args,
+      }),
       signal: ctrl.signal,
     });
     data = (await resp.json()) as GatewayResponse;

--- a/packages/transport/brain-mcp-proxy/src/handler.test.ts
+++ b/packages/transport/brain-mcp-proxy/src/handler.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   attributionLabel,
   buildToolArgs,
+  splitOwnerAgent,
+  OWNER_AGENT_ARG,
   createCallToolHandler,
   DEFAULT_MAX_RESULT_BYTES,
   extractHitCount,
@@ -88,7 +90,78 @@ describe("attributionLabel", () => {
   });
 });
 
+describe("splitOwnerAgent", () => {
+  it("returns the args untouched when no owner override is present", () => {
+    const args = { query: "x", agent_id: "hermes" };
+    const out = splitOwnerAgent(args);
+    expect(out.ownerAgentId).toBeUndefined();
+    expect(out.forwardedArgs).toBe(args);
+  });
+
+  it("extracts a non-empty owner and strips it from the forwarded args", () => {
+    const out = splitOwnerAgent({ query: "x", [OWNER_AGENT_ARG]: " coo " });
+    expect(out.ownerAgentId).toBe("coo");
+    expect(out.forwardedArgs).toEqual({ query: "x" });
+  });
+
+  it("ignores an empty or non-string owner but still strips the key", () => {
+    expect(splitOwnerAgent({ query: "x", agent: "" })).toEqual({
+      forwardedArgs: { query: "x" },
+      ownerAgentId: undefined,
+    });
+    expect(splitOwnerAgent({ query: "x", agent: 42 })).toEqual({
+      forwardedArgs: { query: "x" },
+      ownerAgentId: undefined,
+    });
+  });
+
+  it("does not mutate the input", () => {
+    const args = { query: "x", agent: "coo" };
+    splitOwnerAgent(args);
+    expect(args).toEqual({ query: "x", agent: "coo" });
+  });
+});
+
 describe("createCallToolHandler", () => {
+  it("forwards a per-call owning agent to the invoker and strips it from the args", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const log = vi.fn();
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "claude-code",
+      log,
+    });
+    await handler({
+      name: "memory_search",
+      arguments: { query: "heartbeat liveness", agent: "coo" },
+    });
+    expect(invoke.mock.calls[0]![0]).toEqual({
+      toolName: "memory_search",
+      args: { query: "heartbeat liveness", agent_id: "claude-code" },
+      agentId: "claude-code",
+      ownerAgentId: "coo",
+    });
+    // Attribution stays the caller; the owner is only annotated.
+    expect(log.mock.calls[0]![0]).toBe(
+      "[brain] memory_search called by claude-code (owner coo)",
+    );
+  });
+
+  it("omits ownerAgentId entirely when the caller sets no owner", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const handler = createCallToolHandler({
+      invokeFn: invoke,
+      defaultAgentId: "claude-code",
+      log: vi.fn(),
+    });
+    await handler({ name: "memory_search", arguments: { query: "x" } });
+    expect(invoke.mock.calls[0]![0]).not.toHaveProperty("ownerAgentId");
+  });
+
   it("invokes the gateway with toolName and prepared args, returns its result", async () => {
     const invoke = vi.fn().mockResolvedValue({
       content: [{ type: "text", text: "ok" }],

--- a/packages/transport/brain-mcp-proxy/src/handler.ts
+++ b/packages/transport/brain-mcp-proxy/src/handler.ts
@@ -177,6 +177,8 @@ export function oversizeResult(input: {
 export type GatewayInvoker = (input: {
   toolName: string;
   args: Record<string, unknown>;
+  /** Owning agent, required by openclaw >= 2026.8.1 on a multi-agent host. */
+  agentId?: string;
 }) => Promise<CallToolResult>;
 
 export type CallToolRequest = {
@@ -329,7 +331,7 @@ export function createCallToolHandler(deps: {
     };
 
     try {
-      const result = await invokeFn({ toolName: req.name, args });
+      const result = await invokeFn({ toolName: req.name, args, agentId });
       // Augment memory_search responses with the top hit's body. Inliner
       // is fault-tolerant — on any internal error it returns the input
       // result unchanged. Wrap defensively anyway.

--- a/packages/transport/brain-mcp-proxy/src/handler.ts
+++ b/packages/transport/brain-mcp-proxy/src/handler.ts
@@ -179,7 +179,47 @@ export type GatewayInvoker = (input: {
   args: Record<string, unknown>;
   /** Owning agent, required by openclaw >= 2026.8.1 on a multi-agent host. */
   agentId?: string;
+  /**
+   * Per-call owning-agent override taken from the `agent` tool argument.
+   * When set, the transport must send THIS as the gateway's top-level
+   * agentId instead of its process-wide default, so a caller can search
+   * another configured agent's memory index (e.g. the COO's own store from
+   * a one-shot CLI session). See splitOwnerAgent.
+   */
+  ownerAgentId?: string;
 }) => Promise<CallToolResult>;
+
+/**
+ * Name of the optional tool argument that selects which openclaw agent OWNS
+ * the call (i.e. whose memory index is searched). Distinct from `agent_id`,
+ * which is the caller's attribution label and is forwarded as-is.
+ *
+ * Why this exists (2026-09-01): openclaw's own `memory_search`, when reached
+ * from a one-shot CLI session (the cli-backend heartbeat path), builds a
+ * transient memory manager per call — a cold open of the whole store plus a
+ * KNN subprocess — and on a large store that cannot meet its hardcoded 15s
+ * deadline (0/19 heartbeat calls succeeded on a 1.7 GB index). This proxy's
+ * `/tools/invoke` path runs on the gateway's warm manager (~1.5s), but was
+ * pinned to one owning agent; `agent` lets the caller pick the index.
+ */
+export const OWNER_AGENT_ARG = "agent";
+
+/**
+ * Split the owning-agent override out of the tool args. The `agent` key is
+ * always removed from the forwarded args (openclaw's tools do not take it);
+ * only a non-empty string selects an owner — anything else is ignored.
+ */
+export function splitOwnerAgent(args: Record<string, unknown>): {
+  forwardedArgs: Record<string, unknown>;
+  ownerAgentId: string | undefined;
+} {
+  if (!Object.hasOwn(args, OWNER_AGENT_ARG)) {
+    return { forwardedArgs: args, ownerAgentId: undefined };
+  }
+  const { [OWNER_AGENT_ARG]: raw, ...forwardedArgs } = args;
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  return { forwardedArgs, ownerAgentId: trimmed === "" ? undefined : trimmed };
+}
 
 export type CallToolRequest = {
   name: string;
@@ -306,7 +346,11 @@ export function createCallToolHandler(deps: {
   return async (req) => {
     const args = buildToolArgs(req.arguments, defaultAgentId);
     const agentId = attributionLabel(args);
-    log(`[brain] ${req.name} called by ${agentId}`);
+    const { forwardedArgs, ownerAgentId } = splitOwnerAgent(args);
+    log(
+      `[brain] ${req.name} called by ${agentId}` +
+        (ownerAgentId !== undefined ? ` (owner ${ownerAgentId})` : ""),
+    );
     const startedAt = Date.now();
     const recordTrace = (result: CallToolResult, isError: boolean): void => {
       if (!traceWriter) return;
@@ -331,7 +375,12 @@ export function createCallToolHandler(deps: {
     };
 
     try {
-      const result = await invokeFn({ toolName: req.name, args, agentId });
+      const result = await invokeFn({
+        toolName: req.name,
+        args: forwardedArgs,
+        agentId,
+        ...(ownerAgentId !== undefined ? { ownerAgentId } : {}),
+      });
       // Augment memory_search responses with the top hit's body. Inliner
       // is fault-tolerant — on any internal error it returns the input
       // result unchanged. Wrap defensively anyway.

--- a/packages/transport/brain-mcp-proxy/src/http-server.ts
+++ b/packages/transport/brain-mcp-proxy/src/http-server.ts
@@ -22,6 +22,7 @@ import {
 } from "./app-rate-writer.js";
 import { loadGatewayConfig } from "./config.js";
 import { invokeGatewayTool } from "./gateway.js";
+import { resolveGatewayAgentId } from "./config.js";
 import { createCallToolHandler, resolveMaxResultBytes } from "./handler.js";
 import { createRequestListener, MCP_PATH } from "./http-app.js";
 import { isLoopbackHost, loadHttpConfig } from "./http-config.js";
@@ -74,6 +75,7 @@ export async function mainHttp(): Promise<void> {
     warn: emitStderr,
   });
 
+  const gatewayAgentId = resolveGatewayAgentId(process.env);
   const listener = createRequestListener({
     token: httpConfig.token,
     maxBodyBytes: httpConfig.maxBodyBytes,
@@ -85,6 +87,8 @@ export async function mainHttp(): Promise<void> {
           invokeGatewayTool({
             toolName: input.toolName,
             args: input.args,
+            // Owning openclaw agent, not the caller's attribution label.
+            agentId: gatewayAgentId,
             gateway: { url: gateway.url, token: gateway.token },
             fetchFn: globalThis.fetch,
             timeoutMs: GATEWAY_TIMEOUT_MS,

--- a/packages/transport/brain-mcp-proxy/src/http-server.ts
+++ b/packages/transport/brain-mcp-proxy/src/http-server.ts
@@ -88,7 +88,8 @@ export async function mainHttp(): Promise<void> {
             toolName: input.toolName,
             args: input.args,
             // Owning openclaw agent, not the caller's attribution label.
-            agentId: gatewayAgentId,
+            // A per-call `agent` argument wins over the process default.
+            agentId: input.ownerAgentId ?? gatewayAgentId,
             gateway: { url: gateway.url, token: gateway.token },
             fetchFn: globalThis.fetch,
             timeoutMs: GATEWAY_TIMEOUT_MS,

--- a/packages/transport/brain-mcp-proxy/src/index.ts
+++ b/packages/transport/brain-mcp-proxy/src/index.ts
@@ -23,7 +23,12 @@ export const PACKAGE_ROOT = path.resolve(
  */
 export const BIN_PATH = path.join(PACKAGE_ROOT, "bin", "brain-mcp-proxy.mjs");
 
-export { loadGatewayConfig, resolveDefaultAgentId } from "./config.js";
+export {
+  DEFAULT_GATEWAY_AGENT_ID,
+  loadGatewayConfig,
+  resolveDefaultAgentId,
+  resolveGatewayAgentId,
+} from "./config.js";
 export type { GatewayConfig } from "./config.js";
 export { GatewayConfigError } from "./config.js";
 export { invokeGatewayTool } from "./gateway.js";

--- a/packages/transport/brain-mcp-proxy/src/server.ts
+++ b/packages/transport/brain-mcp-proxy/src/server.ts
@@ -119,8 +119,10 @@ export async function main(): Promise<void> {
         args: input.args,
         // The OWNER of the invocation — a real openclaw agent. Not
         // input.agentId, which is the calling client's attribution label
-        // ("hermes"/"codex") and is rejected as `Unknown agent id`.
-        agentId: gatewayAgentId,
+        // ("hermes"/"codex") and is rejected as `Unknown agent id`. A
+        // per-call `agent` argument (input.ownerAgentId) wins over the
+        // process-wide default so a caller can search another agent's index.
+        agentId: input.ownerAgentId ?? gatewayAgentId,
         gateway: { url: gateway.url, token: gateway.token },
         fetchFn: globalThis.fetch,
         timeoutMs: GATEWAY_TIMEOUT_MS,

--- a/packages/transport/brain-mcp-proxy/src/server.ts
+++ b/packages/transport/brain-mcp-proxy/src/server.ts
@@ -16,6 +16,7 @@ import {
 import { loadConfig } from "@digital-me/contracts";
 import { loadGatewayConfig, resolveDefaultAgentId } from "./config.js";
 import { invokeGatewayTool } from "./gateway.js";
+import { resolveGatewayAgentId } from "./config.js";
 import { createCallToolHandler, resolveMaxResultBytes } from "./handler.js";
 import { startParentPidWatcher } from "./lifecycle.js";
 import { TOOLS } from "./tools.js";
@@ -110,11 +111,16 @@ export async function main(): Promise<void> {
   });
   appRateShutdownHook = () => appRateWriter.shutdown();
 
+  const gatewayAgentId = resolveGatewayAgentId(process.env);
   const handle = createCallToolHandler({
     invokeFn: (input) =>
       invokeGatewayTool({
         toolName: input.toolName,
         args: input.args,
+        // The OWNER of the invocation — a real openclaw agent. Not
+        // input.agentId, which is the calling client's attribution label
+        // ("hermes"/"codex") and is rejected as `Unknown agent id`.
+        agentId: gatewayAgentId,
         gateway: { url: gateway.url, token: gateway.token },
         fetchFn: globalThis.fetch,
         timeoutMs: GATEWAY_TIMEOUT_MS,

--- a/packages/transport/brain-mcp-proxy/src/tools.ts
+++ b/packages/transport/brain-mcp-proxy/src/tools.ts
@@ -309,6 +309,11 @@ export const TOOLS = [
       properties: {
         query: { type: "string", description: "Search query" },
         ...AGENT_ID_PROP,
+        agent: {
+          type: "string",
+          description:
+            "openclaw agent whose memory index to use (e.g. 'coo'). Defaults to the host's primary agent. Prefer this tool over openclaw's own memory_search from a one-shot CLI session: there openclaw cold-opens the index per call and a large store cannot meet its 15s deadline, while this proxy searches on the gateway's warm manager.",
+        },
         limit: { type: "number", description: "Max results (default 5)" },
         corpus: {
           type: "string",
@@ -331,6 +336,11 @@ export const TOOLS = [
           type: "string",
           description:
             "Memory file path to retrieve (e.g. 'MEMORY.md' or 'memory/some-note.md'), relative to the corpus root.",
+        },
+        agent: {
+          type: "string",
+          description:
+            "openclaw agent whose memory index to use (e.g. 'coo'). Defaults to the host's primary agent. Prefer this tool over openclaw's own memory_search from a one-shot CLI session: there openclaw cold-opens the index per call and a large store cannot meet its 15s deadline, while this proxy searches on the gateway's warm manager.",
         },
         corpus: {
           type: "string",

--- a/scripts/verify_gateway_callers.sh
+++ b/scripts/verify_gateway_callers.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Invariant: EVERY caller of openclaw's /tools/invoke sends an owning agent.
+#
+# WHY THIS EXISTS
+# openclaw >= 2026.8.1 rejects an invocation on a multi-agent host that carries
+# no explicit owner:
+#
+#   Multiple agents are configured, but session key "main" has no explicit
+#   owner. Pass agentId or use an agent-prefixed session key.
+#
+# One upstream change, but SIX independent call sites in this repo across
+# three languages — TypeScript, Python and Bash. Each was found separately, by
+# a person noticing a downstream symptom, over about sixteen hours:
+#
+#   claude-code inject hook   recall silently stopped
+#   codex inject hook         same, unnoticed
+#   brain MCP proxy           every brain tool failed for every MCP client
+#   hermes recall plugin      hermes never injected at all
+#   m1_backfill.py            found only by enumerating, not by symptom
+#   dream_cycle/brain_client  same — the nightly pipeline
+#
+# The last two had no reported symptom. They were found by asking "how many
+# callers are there?" instead of "what broke?" — which is the whole point of
+# this check. A grep finds them once; this makes it an invariant.
+#
+# The deeper fix is fewer call sites (see PROPOSAL in the repo docs); until
+# they are consolidated, this guards the seam.
+#
+# Exit 0 = every caller conforms. Exit 1 = at least one does not.
+# Read-only. Safe to run anywhere, including CI with no gateway present.
+
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+fail=0
+note() { printf '  %s\n' "$1"; }
+
+# Files that POST to the gateway's tool endpoint, excluding tests and builds.
+# Read via process substitution, NOT a pipe: the last stage of a pipeline runs
+# in a subshell, so an array built there is discarded and this check would
+# silently pass with zero callers — the exact failure mode it exists to catch.
+# macOS ships bash 3.2, which has no `mapfile`.
+CALLERS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && CALLERS+=("$line")
+done < <(
+  grep -rl "tools/invoke" \
+    --include="*.ts" --include="*.py" --include="*.sh" --include="*.mjs" \
+    packages/ scripts/ 2>/dev/null \
+    | grep -vE "(^|/)(dist|node_modules)/" \
+    | grep -vE "\.test\.(ts|py)$|_test\.py$|/test_[^/]*\.py$" \
+    | grep -v "verify_gateway_callers.sh" \
+    | sort
+)
+
+if (( ${#CALLERS[@]} == 0 )); then
+  # This repo always has callers. Zero means the search itself broke — which
+  # is precisely how this script failed on first run (an array built in a
+  # pipeline subshell). A check that cannot find its subject must fail, not
+  # report success.
+  echo "FAIL gateway-callers: found NO callers — the search is broken, not the repo."
+  exit 1
+fi
+
+for f in "${CALLERS[@]}"; do
+  # A file that only names the URL (a constants module) is not a caller.
+  if ! grep -qE '"tool"|tool:|\{tool' "$f" 2>/dev/null; then
+    note "skip    $f (references the endpoint but builds no request)"
+    continue
+  fi
+  if grep -q "agentId" "$f" 2>/dev/null; then
+    note "ok      $f"
+  else
+    note "FAIL    $f builds a /tools/invoke request with no agentId"
+    fail=1
+  fi
+done
+
+if (( fail != 0 )); then
+  echo ""
+  echo "FAIL gateway-callers: a caller omits the owning agent."
+  echo "  On a multi-agent host every one of its calls is refused, and callers"
+  echo "  that fail open (the inject hooks) will do so SILENTLY."
+  echo "  Send agentId, defaulting to \$OPENCLAW_GATEWAY_AGENT_ID or \"main\"."
+  exit 1
+fi
+echo "OK gateway-callers: all ${#CALLERS[@]} caller(s) send an owning agent."
+exit 0

--- a/scripts/verify_m1_application.py
+++ b/scripts/verify_m1_application.py
@@ -59,6 +59,13 @@ def _accumulate(events, since_ms, surfaced_turns, acked_turns):
             acked_turns[runtime].add(key)
 
 
+def _last_seen(events, out):
+    """Track the newest event timestamp per runtime."""
+    for runtime, _etype, _ack, _sid, _tid, t in events:
+        if isinstance(t, (int, float)) and t > out.get(runtime, 0):
+            out[runtime] = t
+
+
 def _read_brain(brain_db: Path, since_ms: int):
     if not brain_db.exists():
         return []
@@ -112,6 +119,18 @@ def main(argv=None) -> int:
     ap.add_argument("--home", type=Path, default=Path.home())
     ap.add_argument("--brain-db", type=Path, default=None)
     ap.add_argument(
+        "--stale-hours",
+        type=int,
+        default=0,
+        help=(
+            "REGRESSION mode. Fail when a runtime that WAS surfacing knowledge "
+            "during the --days baseline has surfaced nothing in the last N "
+            "hours. This is the check that catches an unknown cause: it asks "
+            "whether the outcome still happens, not whether any particular "
+            "component reports healthy. 0 disables."
+        ),
+    )
+    ap.add_argument(
         "--require-all",
         action="store_true",
         help="Fail unless EVERY known runtime is healthy (surfaced>0 and acked>0).",
@@ -152,11 +171,68 @@ def main(argv=None) -> int:
             status = "ok"
         print(f"{rt:<14}{s:>10}{a:>8}{rate_str:>9}   {status}")
 
-    print()
-    if unhealthy:
-        print(f"UNHEALTHY: {', '.join(unhealthy)}")
+    # ── regression pass: was working, now silent ────────────────────────
+    #
+    # The window check above cannot see a same-day break: a runtime that
+    # surfaced for six days and died today still shows surfaced>0, acked>0
+    # and reports "ok". That is exactly how recall stayed broken for ~18h
+    # across claude-code, codex and hermes on 2026-09-01 while every
+    # component-level check stayed green.
+    #
+    # A runtime with baseline activity and ZERO recent activity is either
+    # broken or genuinely unused; a runtime that was busy all week does not
+    # go quiet on its own. Distinguishing "idle" from "broken" is why this
+    # compares each runtime against ITS OWN history rather than a fixed
+    # expectation.
+    stalled = []
+    if args.stale_hours > 0:
+        recent_ms = int(
+            (datetime.now(timezone.utc)
+             - timedelta(hours=args.stale_hours)).timestamp() * 1000
+        )
+        r_surf, r_ack = defaultdict(set), defaultdict(set)
+        last = {}
+        for reader in (_read_brain(brain_db, since_ms), _read_wals(home, since_ms)):
+            _accumulate(reader, recent_ms, r_surf, r_ack)
+            _last_seen(reader, last)
+
+        print(f"Regression check — surfaced in the last {args.stale_hours}h?\n")
+        print(f"{'runtime':<14}{'baseline':>10}{'recent':>8}   last seen")
+        print("-" * 62)
+        for rt in runtimes:
+            base = len(surfaced_turns.get(rt, set()))
+            rec = len(r_surf.get(rt, set()))
+            ts = last.get(rt)
+            when = (
+                datetime.fromtimestamp(ts / 1000, timezone.utc)
+                .astimezone().strftime("%Y-%m-%d %H:%M")
+                if ts else "never"
+            )
+            if base > 0 and rec == 0:
+                stalled.append(rt)
+                mark = "  ← STALLED"
+            else:
+                mark = ""
+            print(f"{rt:<14}{base:>10}{rec:>8}   {when}{mark}")
+        print()
+
+    if unhealthy or stalled:
+        if unhealthy:
+            print(f"UNHEALTHY: {', '.join(unhealthy)}")
+        if stalled:
+            print(
+                f"STALLED: {', '.join(stalled)} — surfaced during the last "
+                f"{args.days}d but nothing in {args.stale_hours}h."
+            )
+            print(
+                "  Either the runtime is genuinely unused, or its recall path "
+                "is broken. Check the injection path end to end; a component "
+                "reporting healthy does not mean the path works."
+            )
         return 1
     print("All runtimes that surfaced knowledge also recorded application. ✓")
+    if args.stale_hours > 0:
+        print(f"No runtime went silent within {args.stale_hours}h. ✓")
     return 0
 
 

--- a/scripts/verify_openclaw_hooks.sh
+++ b/scripts/verify_openclaw_hooks.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Post-update gate: assert the openclaw gateway did NOT drop any of
+# digital-me-recall's typed hooks.
+#
+# THE FAILURE THIS CATCHES
+# openclaw refuses a "conversation" typed hook from a NON-BUNDLED plugin
+# unless the operator has set
+# `plugins.entries.<id>.hooks.allowConversationAccess: true`. The refusal is a
+# warn diagnostic plus an early `return` inside the host's hook registrar
+# (plugins/registry-registrars-tools-hooks.ts) — the plugin still loads, still
+# registers its tools, still reports `Status: loaded`, and the gateway
+# connectivity probe still passes. Only the hooks are gone.
+#
+# openclaw 2026.8.1 added `before_prompt_build` to that gated set
+# (plugins/hook-types.ts CONVERSATION_HOOK_NAMES), which is the entire wiki
+# recall-injection path; `agent_end` (the M1 application-ack) has been gated
+# for longer. Every digital-me plugin is non-bundled (`Origin: global`).
+#
+# NOTHING ELSE IN THE UPDATE GATE SEES THIS. The updater's overlay smoke is
+# `node --check` (syntax only — it cannot load the bundle because `openclaw/*`
+# is externalized), the gateway probe passes, and the digest pipeline is
+# unaffected. Hence this check.
+#
+# Two independent signals, either of which fails the gate:
+#   1. CONFIG   — the grant is missing for a plugin that registers such hooks.
+#   2. RUNTIME  — the gateway log carries a host block diagnostic, or the
+#                 plugin's own boot self-check reported conversation_hooks=BLOCKED.
+#
+# Exit 0 = no hooks blocked. Exit 1 = at least one signal fired.
+# Read-only: no writes, no network, no LLM.
+
+set -uo pipefail
+
+OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
+CONFIG="${DIGITAL_ME_OPENCLAW_CONFIG:-$OPENCLAW_HOME/openclaw.json}"
+GATEWAY_LOG="${OPENCLAW_GATEWAY_LOG:-$OPENCLAW_HOME/logs/gateway.log}"
+# Plugins that actually register conversation hooks. digital-me-brain
+# registers tools only, so it needs no grant (least privilege).
+PLUGINS=("digital-me-recall")
+
+fail=0
+note() { printf '  %s\n' "$1"; }
+
+# ── 1. Config: is the grant present? ────────────────────────────────────
+if [[ ! -f "$CONFIG" ]]; then
+  echo "SKIP openclaw-hooks: no config at $CONFIG (openclaw not installed here)"
+  exit 0
+fi
+
+for id in "${PLUGINS[@]}"; do
+  granted=$(python3 - "$CONFIG" "$id" <<'PY'
+import json, sys
+try:
+    # openclaw parses its config as JSON5; strict=False tolerates the control
+    # characters a hand-edited file can carry. A parse failure is reported as
+    # "unknown" rather than "ungranted" so this gate never fails on syntax.
+    cfg = json.loads(open(sys.argv[1]).read(), strict=False)
+except Exception:
+    print("unknown")
+    raise SystemExit
+entry = (cfg.get("plugins") or {}).get("entries", {}).get(sys.argv[2]) or {}
+print("yes" if (entry.get("hooks") or {}).get("allowConversationAccess") is True else "no")
+PY
+)
+  case "$granted" in
+    yes) note "ok      $id: allowConversationAccess=true" ;;
+    unknown) note "warn    $id: config unparseable, grant not verified" ;;
+    *)
+      note "FAIL    $id: plugins.entries.$id.hooks.allowConversationAccess is not true"
+      note "        openclaw will silently drop its before_prompt_build / agent_end hooks."
+      fail=1
+      ;;
+  esac
+done
+
+# ── 2. Runtime: did the host or the plugin report a block? ──────────────
+# Only the tail matters — earlier boots may predate the fix.
+if [[ -f "$GATEWAY_LOG" ]]; then
+  tail_txt=$(tail -c 2000000 "$GATEWAY_LOG" 2>/dev/null)
+
+  if grep -q "blocked because non-bundled plugins must set" <<<"$tail_txt"; then
+    note "FAIL    gateway log carries a host hook-block diagnostic:"
+    grep -o "typed hook \"[a-z_]*\" blocked because non-bundled[^\"]*" <<<"$tail_txt" \
+      | tail -3 | sed 's/^/          /'
+    fail=1
+  fi
+
+  # The plugin's own boot self-check (see templates/recall/index.mjs). Use the
+  # LAST registration line only: an older blocked boot must not fail a fixed one.
+  last_reg=$(grep "digital-me-recall: registered hooks" <<<"$tail_txt" | tail -1)
+  if [[ -n "$last_reg" ]]; then
+    if grep -q "conversation_hooks=BLOCKED" <<<"$last_reg"; then
+      note "FAIL    recall self-check reported conversation_hooks=BLOCKED at boot"
+      fail=1
+    elif grep -q "conversation_hooks=granted" <<<"$last_reg"; then
+      note "ok      recall self-check reported conversation_hooks=granted"
+    fi
+  fi
+else
+  note "warn    no gateway log at $GATEWAY_LOG — runtime signal not checked"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "FAIL openclaw-hooks: at least one conversation hook is (or will be) dropped."
+  exit 1
+fi
+echo "OK openclaw-hooks: no dropped conversation hooks detected."
+exit 0

--- a/scripts/verify_openclaw_hooks.sh
+++ b/scripts/verify_openclaw_hooks.sh
@@ -45,12 +45,16 @@ resolve_gateway_log() {
     printf '%s\n' "$OPENCLAW_GATEWAY_LOG"
     return
   fi
+  # The debug file log (/tmp/openclaw/openclaw-<date>.log, what `openclaw logs`
+  # tails) carries every plugin/hook diagnostic the stdout log carries and more;
+  # it is a candidate so a host whose stdout log is frozen is still observable.
   local newest="" cand
   for cand in \
+    "$(ls -t /tmp/openclaw/openclaw-*.log 2>/dev/null | head -1)" \
     "$HOME/Library/Logs/openclaw/gateway.log" \
     "$OPENCLAW_HOME/logs/gateway.log" \
     "${XDG_STATE_HOME:-$HOME/.local/state}/openclaw/gateway.log"; do
-    [[ -f "$cand" ]] || continue
+    [[ -n "$cand" && -f "$cand" ]] || continue
     if [[ -z "$newest" || "$cand" -nt "$newest" ]]; then newest="$cand"; fi
   done
   printf '%s\n' "$newest"

--- a/scripts/verify_openclaw_hooks.sh
+++ b/scripts/verify_openclaw_hooks.sh
@@ -34,7 +34,28 @@ set -uo pipefail
 
 OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
 CONFIG="${DIGITAL_ME_OPENCLAW_CONFIG:-$OPENCLAW_HOME/openclaw.json}"
-GATEWAY_LOG="${OPENCLAW_GATEWAY_LOG:-$OPENCLAW_HOME/logs/gateway.log}"
+
+# Resolve the log the RUNNING gateway writes to — not the first path that
+# happens to exist. `$OPENCLAW_HOME/logs/gateway.log` is a real file on this
+# machine but has been frozen since the service moved its StandardOutPath to
+# ~/Library/Logs; reading it would make this gate silently blind, which is the
+# exact failure class the gate exists to catch. Pick the NEWEST candidate.
+resolve_gateway_log() {
+  if [[ -n "${OPENCLAW_GATEWAY_LOG:-}" ]]; then
+    printf '%s\n' "$OPENCLAW_GATEWAY_LOG"
+    return
+  fi
+  local newest="" cand
+  for cand in \
+    "$HOME/Library/Logs/openclaw/gateway.log" \
+    "$OPENCLAW_HOME/logs/gateway.log" \
+    "${XDG_STATE_HOME:-$HOME/.local/state}/openclaw/gateway.log"; do
+    [[ -f "$cand" ]] || continue
+    if [[ -z "$newest" || "$cand" -nt "$newest" ]]; then newest="$cand"; fi
+  done
+  printf '%s\n' "$newest"
+}
+GATEWAY_LOG="$(resolve_gateway_log)"
 # Plugins that actually register conversation hooks. digital-me-brain
 # registers tools only, so it needs no grant (least privilege).
 PLUGINS=("digital-me-recall")
@@ -76,7 +97,8 @@ done
 
 # ── 2. Runtime: did the host or the plugin report a block? ──────────────
 # Only the tail matters — earlier boots may predate the fix.
-if [[ -f "$GATEWAY_LOG" ]]; then
+if [[ -n "$GATEWAY_LOG" && -f "$GATEWAY_LOG" ]]; then
+  note "log     $GATEWAY_LOG"
   tail_txt=$(tail -c 2000000 "$GATEWAY_LOG" 2>/dev/null)
 
   if grep -q "blocked because non-bundled plugins must set" <<<"$tail_txt"; then

--- a/scripts/verify_openclaw_hooks.sh
+++ b/scripts/verify_openclaw_hooks.sh
@@ -75,22 +75,33 @@ fi
 
 for id in "${PLUGINS[@]}"; do
   granted=$(python3 - "$CONFIG" "$id" <<'PY'
-import json, sys
+import sys
+# openclaw parses its config as JSON5 (comments, trailing commas, unquoted keys).
+# Use pyjson5 if available; fall back to a lenient JSON parser that strips
+# comments/trailing-commas manually (the same dialect the installer uses).
 try:
-    # openclaw parses its config as JSON5; strict=False tolerates the control
-    # characters a hand-edited file can carry. A parse failure is reported as
-    # "unknown" rather than "ungranted" so this gate never fails on syntax.
-    cfg = json.loads(open(sys.argv[1]).read(), strict=False)
-except Exception:
-    print("unknown")
-    raise SystemExit
+    import pyjson5
+    cfg = pyjson5.load(open(sys.argv[1]))
+except ImportError:
+    import json, re
+    raw = open(sys.argv[1]).read()
+    # Strip // and /* */ comments (minimal; sufficient for openclaw.json)
+    raw = re.sub(r'//.*?$', '', raw, flags=re.MULTILINE)
+    raw = re.sub(r'/\*.*?\*/', '', raw, flags=re.DOTALL)
+    # Strip trailing commas before } or ]
+    raw = re.sub(r',(\s*[}\]])', r'\1', raw)
+    cfg = json.loads(raw)
+except Exception as e:
+    print(f"FAIL: config parse error: {e}", file=sys.stderr)
+    raise SystemExit(1)
+
 entry = (cfg.get("plugins") or {}).get("entries", {}).get(sys.argv[2]) or {}
-print("yes" if (entry.get("hooks") or {}).get("allowConversationAccess") is True else "no")
+granted = (entry.get("hooks") or {}).get("allowConversationAccess") is True
+print("yes" if granted else "no")
 PY
 )
   case "$granted" in
     yes) note "ok      $id: allowConversationAccess=true" ;;
-    unknown) note "warn    $id: config unparseable, grant not verified" ;;
     *)
       note "FAIL    $id: plugins.entries.$id.hooks.allowConversationAccess is not true"
       note "        openclaw will silently drop its before_prompt_build / agent_end hooks."
@@ -105,13 +116,6 @@ if [[ -n "$GATEWAY_LOG" && -f "$GATEWAY_LOG" ]]; then
   note "log     $GATEWAY_LOG"
   tail_txt=$(tail -c 2000000 "$GATEWAY_LOG" 2>/dev/null)
 
-  if grep -q "blocked because non-bundled plugins must set" <<<"$tail_txt"; then
-    note "FAIL    gateway log carries a host hook-block diagnostic:"
-    grep -o "typed hook \"[a-z_]*\" blocked because non-bundled[^\"]*" <<<"$tail_txt" \
-      | tail -3 | sed 's/^/          /'
-    fail=1
-  fi
-
   # The plugin's own boot self-check (see templates/recall/index.mjs). Use the
   # LAST registration line only: an older blocked boot must not fail a fixed one.
   last_reg=$(grep "digital-me-recall: registered hooks" <<<"$tail_txt" | tail -1)
@@ -122,6 +126,23 @@ if [[ -n "$GATEWAY_LOG" && -f "$GATEWAY_LOG" ]]; then
     elif grep -q "conversation_hooks=granted" <<<"$last_reg"; then
       note "ok      recall self-check reported conversation_hooks=granted"
     fi
+  fi
+
+  # Host-side hook-block diagnostic. Scope to the last boot (everything after the
+  # last registration line) so an old `agent_end` gate warn doesn't false-red the
+  # update sweep after the grant is written.
+  if [[ -n "$last_reg" ]]; then
+    # Extract everything from the last registration onward
+    last_boot_txt=$(grep -A 99999 "digital-me-recall: registered hooks" <<<"$tail_txt" | tail -n +1)
+  else
+    # No registration found — check the whole tail (first boot or pre-recall install)
+    last_boot_txt="$tail_txt"
+  fi
+  if grep -q "blocked because non-bundled plugins must set" <<<"$last_boot_txt"; then
+    note "FAIL    gateway log carries a host hook-block diagnostic in the last boot:"
+    grep -o "typed hook \"[a-z_]*\" blocked because non-bundled[^\"]*" <<<"$last_boot_txt" \
+      | tail -3 | sed 's/^/          /'
+    fail=1
   fi
 else
   note "warn    no gateway log at $GATEWAY_LOG — runtime signal not checked"

--- a/scripts/verify_openclaw_hooks.sh
+++ b/scripts/verify_openclaw_hooks.sh
@@ -74,23 +74,37 @@ if [[ ! -f "$CONFIG" ]]; then
 fi
 
 for id in "${PLUGINS[@]}"; do
-  granted=$(python3 - "$CONFIG" "$id" <<'PY'
+  # openclaw parses its config as JSON5 (comments, trailing commas, unquoted keys).
+  # Try Node + json5 package first (avoids URL-eating regex), then pyjson5.
+  granted=""
+  if command -v node >/dev/null 2>&1; then
+    granted=$(node - "$CONFIG" "$id" 2>/dev/null <<'JS'
+const fs = require('fs');
+try {
+  const JSON5 = require('json5');
+  const cfg = JSON5.parse(fs.readFileSync(process.argv[2], 'utf8'));
+  const entry = (cfg.plugins?.entries || {})[process.argv[3]] || {};
+  const allow = (entry.hooks || {}).allowConversationAccess === true;
+  console.log(allow ? 'yes' : 'no');
+} catch (e) {
+  console.error('FAIL: JSON5 parse error:', e.message);
+  process.exit(1);
+}
+JS
+) || granted=""
+  fi
+  
+  if [[ -z "$granted" ]]; then
+    granted=$(python3 - "$CONFIG" "$id" <<'PY'
 import sys
-# openclaw parses its config as JSON5 (comments, trailing commas, unquoted keys).
-# Use pyjson5 if available; fall back to a lenient JSON parser that strips
-# comments/trailing-commas manually (the same dialect the installer uses).
 try:
     import pyjson5
     cfg = pyjson5.load(open(sys.argv[1]))
 except ImportError:
-    import json, re
-    raw = open(sys.argv[1]).read()
-    # Strip // and /* */ comments (minimal; sufficient for openclaw.json)
-    raw = re.sub(r'//.*?$', '', raw, flags=re.MULTILINE)
-    raw = re.sub(r'/\*.*?\*/', '', raw, flags=re.DOTALL)
-    # Strip trailing commas before } or ]
-    raw = re.sub(r',(\s*[}\]])', r'\1', raw)
-    cfg = json.loads(raw)
+    print("FAIL: openclaw.json is JSON5 (comments/trailing-commas/unquoted-keys).", file=sys.stderr)
+    print("      Install pyjson5:  pip install pyjson5", file=sys.stderr)
+    print("      (or ensure 'node' + json5 package are on PATH)", file=sys.stderr)
+    raise SystemExit(1)
 except Exception as e:
     print(f"FAIL: config parse error: {e}", file=sys.stderr)
     raise SystemExit(1)
@@ -100,6 +114,8 @@ granted = (entry.get("hooks") or {}).get("allowConversationAccess") is True
 print("yes" if granted else "no")
 PY
 )
+  fi
+  
   case "$granted" in
     yes) note "ok      $id: allowConversationAccess=true" ;;
     *)
@@ -132,13 +148,22 @@ if [[ -n "$GATEWAY_LOG" && -f "$GATEWAY_LOG" ]]; then
   # last registration line) so an old `agent_end` gate warn doesn't false-red the
   # update sweep after the grant is written.
   if [[ -n "$last_reg" ]]; then
-    # Extract everything from the last registration onward
-    last_boot_txt=$(grep -A 99999 "digital-me-recall: registered hooks" <<<"$tail_txt" | tail -n +1)
+    # Extract everything AFTER the LAST registration line (not the first).
+    # awk: print=1 once we see the last occurrence of the registration marker.
+    last_boot_txt=$(awk -v marker="digital-me-recall: registered hooks" '
+      {line[NR]=$0}
+      $0 ~ marker {last_match=NR}
+      END {
+        if (last_match) {
+          for (i=last_match; i<=NR; i++) print line[i]
+        }
+      }
+    ' <<<"$tail_txt")
   else
     # No registration found — check the whole tail (first boot or pre-recall install)
     last_boot_txt="$tail_txt"
   fi
-  if grep -q "blocked because non-bundled plugins must set" <<<"$last_boot_txt"; then
+  if [[ -n "$last_boot_txt" ]] && grep -q "blocked because non-bundled plugins must set" <<<"$last_boot_txt"; then
     note "FAIL    gateway log carries a host hook-block diagnostic in the last boot:"
     grep -o "typed hook \"[a-z_]*\" blocked because non-bundled[^\"]*" <<<"$last_boot_txt" \
       | tail -3 | sed 's/^/          /'

--- a/scripts/verify_openclaw_memory_index.sh
+++ b/scripts/verify_openclaw_memory_index.sh
@@ -84,10 +84,17 @@ fi
 # StandardErrorPath to /dev/null (daemon/launchd-service-files.ts), so the
 # error stream is only visible when the operator has redirected it. Pick the
 # newest candidate and say which one was read.
+#
+# 2026-09-01: the stdout log has NO memory-subsystem lines at all. openclaw's
+# debug FILE log — /tmp/openclaw/openclaw-<YYYY-MM-DD>.log, what `openclaw
+# logs` tails over RPC — is where "Memory index changed while full reindex was
+# building" actually lands (24 aborts on the day this was found; the stdout
+# log showed zero). It is the first candidate for that reason.
 resolve_log() {
   local newest="" cand
   for cand in \
     "${OPENCLAW_GATEWAY_LOG:-}" \
+    "$(ls -t /tmp/openclaw/openclaw-*.log 2>/dev/null | head -1)" \
     "$HOME/Library/Logs/openclaw/gateway.err.log" \
     "$HOME/Library/Logs/openclaw/gateway.log" \
     "$OPENCLAW_HOME/logs/gateway.log"; do

--- a/scripts/verify_openclaw_memory_index.sh
+++ b/scripts/verify_openclaw_memory_index.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Health gate: catch openclaw memory-index reindex failures and the disk they leak.
+#
+# THE FAILURE THIS CATCHES
+# openclaw's memory engine (`memory-core-host-engine-storage`) builds a full
+# reindex into a temporary sibling database named
+# `<agent>.sqlite.memory-reindex-<uuid>`. When the live index revision moves
+# while that build is running it aborts with:
+#
+#   [memory] sync failed (search): Memory index changed while full reindex was
+#   building (expected revision N, found N+1); retry the full reindex.
+#
+# and — the actual damage — it does NOT remove the temp database. Each aborted
+# attempt strands a copy the size of the agent's whole index. Observed on
+# 2026-08-31: four orphans on `coo` (4.8 GiB) plus one on `main` (369 MB) from
+# a single afternoon, while `openclaw memory status` still reported
+# `Dirty: no` and every search kept working.
+#
+# That combination is why nothing else notices: the index is healthy, search
+# succeeds, the gateway probe passes, and the only symptom is disk quietly
+# disappearing plus RSS spikes during each doomed rebuild.
+#
+# This is an UPSTREAM defect — digital-me cannot fix it (see
+# docs/UPSTREAM-ADAPTATION-CONSTRAINT.md: we consume openclaw, we don't change
+# it). Per that document's prescribed pattern the downstream job is
+# detect-and-degrade-and-notify, which is what this script is.
+#
+# Exit 0 = clean. Exit 1 = orphaned reindex databases over threshold, or a
+# livelock signature in the gateway log.
+#
+# Read-only: no writes, no network, no LLM. Safe to run at any time.
+
+set -uo pipefail
+
+OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
+AGENTS_DIR="$OPENCLAW_HOME/agents"
+# One stranded temp DB can be a genuinely in-flight rebuild; two or more is a
+# leak. Override for a machine with a different tolerance.
+MAX_ORPHANS="${OPENCLAW_MAX_REINDEX_ORPHANS:-1}"
+
+fail=0
+note() { printf '  %s\n' "$1"; }
+
+if [[ ! -d "$AGENTS_DIR" ]]; then
+  echo "SKIP openclaw-memory-index: no $AGENTS_DIR (openclaw not installed here)"
+  exit 0
+fi
+
+# ── 1. Orphaned reindex databases ───────────────────────────────────────
+# Match openclaw's own naming (src/infra/backup-volatile-filter.ts treats
+# these as transient artifacts). Count only the base file, not -wal/-shm.
+# Portable collection: macOS ships bash 3.2, which has no `mapfile`.
+orphans=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && orphans+=("$line")
+done < <(
+  find "$AGENTS_DIR" -maxdepth 3 -name '*.sqlite.memory-reindex-*' 2>/dev/null \
+    | grep -vE -- '-(wal|shm|journal)$' | sort
+)
+
+if (( ${#orphans[@]} > MAX_ORPHANS )); then
+  total=$(du -ch "${orphans[@]}" 2>/dev/null | tail -1 | awk '{print $1}')
+  note "FAIL    ${#orphans[@]} orphaned reindex database(s) (~${total:-?}), threshold ${MAX_ORPHANS}"
+  for o in "${orphans[@]}"; do
+    agent=$(sed -E 's|.*/agents/([^/]+)/.*|\1|' <<<"$o")
+    sz=$(du -h "$o" 2>/dev/null | awk '{print $1}')
+    note "          ${agent}: ${sz}  $(basename "$o")"
+  done
+  note "        Each is a full reindex that aborted without cleaning up."
+  note "        Upstream: openclaw memory-core-host-engine-storage."
+  note "        Safe to delete when no reindex is running (verify the files are"
+  note "        not growing first), but they WILL come back until upstream fixes it."
+  fail=1
+elif (( ${#orphans[@]} > 0 )); then
+  note "warn    ${#orphans[@]} reindex database present (within threshold ${MAX_ORPHANS}; may be in flight)"
+else
+  note "ok      no orphaned reindex databases"
+fi
+
+# ── 2. Livelock signature in the gateway log ────────────────────────────
+# Same log-resolution problem as verify_openclaw_hooks.sh: the service's
+# StandardOutPath moved to ~/Library/Logs, and openclaw hardcodes
+# StandardErrorPath to /dev/null (daemon/launchd-service-files.ts), so the
+# error stream is only visible when the operator has redirected it. Pick the
+# newest candidate and say which one was read.
+resolve_log() {
+  local newest="" cand
+  for cand in \
+    "${OPENCLAW_GATEWAY_LOG:-}" \
+    "$HOME/Library/Logs/openclaw/gateway.err.log" \
+    "$HOME/Library/Logs/openclaw/gateway.log" \
+    "$OPENCLAW_HOME/logs/gateway.log"; do
+    [[ -n "$cand" && -f "$cand" ]] || continue
+    if [[ -z "$newest" || "$cand" -nt "$newest" ]]; then newest="$cand"; fi
+  done
+  printf '%s\n' "$newest"
+}
+LOG="$(resolve_log)"
+
+if [[ -n "$LOG" ]]; then
+  note "log     $LOG"
+  hits=$(tail -c 4000000 "$LOG" 2>/dev/null \
+    | grep -c "Memory index changed while full reindex" || true)
+  if (( hits > 0 )); then
+    note "FAIL    ${hits} full-reindex abort(s) in the log tail — the rebuild is not converging:"
+    tail -c 4000000 "$LOG" 2>/dev/null \
+      | grep -o "expected revision [0-9]*, found [0-9]*" | tail -3 \
+      | sed 's/^/          /'
+    fail=1
+  else
+    note "ok      no full-reindex aborts in the log tail"
+  fi
+else
+  note "warn    no gateway log found — livelock signal not checked"
+fi
+
+if (( fail != 0 )); then
+  echo "FAIL openclaw-memory-index: reindex is leaking or not converging."
+  exit 1
+fi
+echo "OK openclaw-memory-index: no reindex leak or livelock detected."
+exit 0

--- a/scripts/watch_openclaw_upstream.sh
+++ b/scripts/watch_openclaw_upstream.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Upstream openclaw watch — for a host deliberately soaking a release before
+# committing to it.
+#
+# Reports three things and nothing else:
+#   1. Installed version vs the npm dist-tags (is a newer stable out?)
+#   2. Whether a newer stable touches the subsystems that broke us
+#   3. The state of the upstream issues we are blocked on / tracking
+#
+# Read-only: no installs, no config writes, no gateway restarts. It tells you
+# when to look; it never acts. That distinction matters — an auto-updater is
+# exactly what you do NOT want on a host you are soaking.
+#
+# Usage:  bash scripts/watch_openclaw_upstream.sh
+# Exit:   0 always (this is a report, not a gate) unless --strict is passed,
+#         which exits 1 when a newer stable exists.
+
+set -uo pipefail
+STRICT=0
+[[ "${1:-}" == "--strict" ]] && STRICT=1
+
+say() { printf '%s\n' "$1"; }
+hr() { printf '%s\n' "────────────────────────────────────────────────────────"; }
+
+# ── 1. versions ─────────────────────────────────────────────────────────
+INSTALLED="$(openclaw --version 2>/dev/null | awk '{print $2}')"
+TAGS_JSON="$(npm view openclaw dist-tags --json 2>/dev/null)"
+LATEST="$(printf '%s' "$TAGS_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("latest",""))' 2>/dev/null)"
+EXTENDED="$(printf '%s' "$TAGS_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("extended-stable",""))' 2>/dev/null)"
+
+hr; say "openclaw upstream watch — $(date '+%Y-%m-%d %H:%M')"; hr
+say "  installed        : ${INSTALLED:-unknown}"
+say "  latest (npm)     : ${LATEST:-unknown}"
+say "  extended-stable  : ${EXTENDED:-unknown}"
+
+NEWER=0
+if [[ -n "$INSTALLED" && -n "$LATEST" && "$INSTALLED" != "$LATEST" ]]; then
+  NEWER=1
+  say ""
+  say "  ► NEWER STABLE AVAILABLE: $INSTALLED → $LATEST"
+fi
+
+# ── 2. does the new release touch what broke us? ────────────────────────
+# Only meaningful with a local checkout holding both tags.
+REPO="${OPENCLAW_REPO:-$HOME/openclaw}"
+if (( NEWER )) && [[ -d "$REPO/.git" ]]; then
+  git -C "$REPO" fetch origin --tags --quiet 2>/dev/null || true
+  if git -C "$REPO" rev-parse "v$LATEST" >/dev/null 2>&1; then
+    say ""
+    say "  memory-core changes in v$INSTALLED..v$LATEST:"
+    git -C "$REPO" log --oneline "v$INSTALLED..v$LATEST" -- extensions/memory-core/ 2>/dev/null \
+      | head -15 | sed 's/^/      /'
+    say ""
+    say "  plugin-loader / hook changes:"
+    git -C "$REPO" log --oneline "v$INSTALLED..v$LATEST" -- src/plugins/ 2>/dev/null \
+      | head -10 | sed 's/^/      /'
+  fi
+fi
+
+# ── 3. tracked upstream issues ──────────────────────────────────────────
+# Everything digital-me is currently working around. When one of these closes
+# WITH a fix in a shipped stable, the corresponding local workaround may be
+# retired — check before assuming.
+ISSUES=(
+  "128140:memory_search tool always times out (15s) — coo is over the line"
+  "121043:zero-hit query rebuilds the whole index — drove the reindex storms"
+  "134337:dirty maintenance repeatedly full-reindexes under concurrent writes"
+  "134332:maintenance reindex fails after a concurrent incremental write"
+  "132708:embeddings need configurable throttle + honor Retry-After + batch"
+  "135086:observability gaps — conflated status=unavailable"
+  "134830:aborted reindex strands its temp DB (ours; closed NOT_PLANNED)"
+)
+if command -v gh >/dev/null 2>&1; then
+  say ""; hr; say "  tracked upstream issues"; hr
+  for entry in "${ISSUES[@]}"; do
+    n="${entry%%:*}"; desc="${entry#*:}"
+    state="$(gh issue view "$n" --repo openclaw/openclaw --json state,stateReason \
+      --jq '.state + (if .stateReason then " ("+.stateReason+")" else "" end)' 2>/dev/null)"
+    printf '  #%-7s %-22s %s\n' "$n" "${state:-unknown}" "$desc"
+  done
+else
+  say ""; say "  (gh not on PATH — skipping upstream issue status)"
+fi
+
+say ""
+if (( NEWER )); then
+  say "  Next step is a JUDGEMENT call, not an upgrade: read the changes above,"
+  say "  check whether any tracked issue closed, then decide. The upgrade path is"
+  say "  documented in wiki: infrastructure/openclaw-2026-8-1-cutover-blockers."
+else
+  say "  No newer stable. Nothing to do."
+fi
+hr
+
+(( STRICT && NEWER )) && exit 1
+exit 0


### PR DESCRIPTION
Prepares the digital-me overlay for openclaw **2026.8.1** (npm `latest`). Grounded on a diff of the 2026.6.11 and 2026.8.1 sources, not on release notes.

There is no "OpenClaw 2.0" — upstream is calendar-versioned (npm carries only `0` and `2026` major prefixes). The real jump is `2026.6.11 → 2026.8.1`.

## Three blockers

### 1. Conversation-hook gate (silent)
openclaw drops a "conversation" typed hook at registration when a **non-bundled** plugin has not set `hooks.allowConversationAccess: true` — a warn diagnostic and an early `return` (`plugins/registry-registrars-tools-hooks.ts:380`). The plugin still loads, still registers tools, still reports `Status: loaded`. Only the hooks are gone.

2026.8.1 adds `before_prompt_build` to `CONVERSATION_HOOK_NAMES` (`plugins/hook-types.ts:229`) — that is the entire wiki-recall path. Every digital-me plugin is non-bundled (`openclaw plugins inspect` → `Origin: global`).

**This is already biting today.** `agent_end` has been in the gated set since before 2026.6.11, so the M1 application-ack emitter is dark right now:

```
runtime=openclaw  knowledge_surfaced  505  last 2026-08-31 22:30   <- before_prompt_build, working
runtime=openclaw  assistant_ack       134  last 2026-08-24 22:30   <- agent_end, gated
```

The installer now writes the grant. **Only `digital-me-recall`** — `digital-me-brain` registers tools and zero hooks, so granting it would hand out a capability it never exercises (least privilege).

### 2. Memory-search namespace cutover (fatal)
2026.7.1 moved the block from `agents.defaults.memorySearch` to root `memory.search`. Both schemas are `.strict()` and the config loader **throws** on an unknown key (`config/io.load.ts:127` → `throwInvalidConfig`).

So this is not "corpus silently unindexed" — **the gateway will not start**. And since 6.11's root `MemorySchema` is `{backend, citations, qmd}` with no `search`, while 8.1's `agents.defaults` has no `memorySearch`, **no single config is valid on both versions**. The migration must happen inside the binary-swap window.

The installer now detects the running host — source checkout `package.json` → `openclaw --version` → the config's own `meta.lastTouchedVersion` — writes the layout that host accepts, and migrates an existing block **in either direction** (forward on update, back on rollback). `doctor` reads whichever layout is present and names that key in its repair hint.

All six sub-keys we write or preserve (`enabled`, `extraPaths`, `provider`, `fallback`, `model`, `remote`) exist in both versions' `MemorySearchSchema`, so the move is lossless.

### 3. Nothing could have caught either one
- The updater's overlay smoke is `node --check` — **syntax only**. It cannot load the bundle because `openclaw/*` is externalized, so an SDK export removal would also pass it.
- The post-update sweep covered exactly one pipeline (`digest-smoke`).
- No CI job references openclaw at all, despite `docs/UPSTREAM-ADAPTATION-CONSTRAINT.md` prescribing exactly that canary.
- `deploy.ts`'s `parseRecallAckMode` greps for `assistant_ack=…`, but that value was a **hardcoded string literal** — it fingerprinted the build, not the registration.

Adds `scripts/verify_openclaw_hooks.sh` to the update profile. It fails on a missing grant, on a host block diagnostic in the gateway log, or on the plugin's own boot self-check reporting `conversation_hooks=BLOCKED`. Verified red on the current unfixed live config, before any fix was applied.

The recall registration line is now **derived** from the hooks the host will honour, and a missing grant logs a loud warning at boot — so deploy's existing fingerprint parser becomes a real canary for free.

## Also
`MAX_TESTED_OPENCLAW_VERSION` 2026.6.10 → 2026.8.1. It was *below* the installed 2026.6.11, so the "untested host" warning fired on every boot and had stopped being a signal.

## Not in this PR
Node 24 (openclaw ≥2026.7.1 requires `>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0`; the host runs 25.4.0, which satisfies none — `entry.ts:140` `assertSupportedRuntime()` hard-exits) and the live update itself. Both are host operations, tracked separately.

## Test plan
- `pnpm run ci` green — sanitize, build, typecheck, lint, knip, **100% coverage workspace-wide**
- New coverage: layout detect/resolve/migrate in both directions, grant merge (incl. never overriding a deliberate `false`), host-version detection precedence, calendar-version comparison (`2026.10.1 > 2026.9.1` is not string order), and the hook-grant doctor check
- Memory tests made **hermetic** — they previously read the host's real `openclaw --version` to pick a layout, so they would have behaved differently in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)